### PR TITLE
DEV-550: Added `designTemperature` and `designRating` to `Conductor`

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,20 +1,27 @@
 # Zepben EWB SDK changelog
+
 ## [0.21.0] - UNRELEASED
+
 ### Breaking Changes
+
 * None.
 
 ### New Features
+
 * None.
 
 ### Enhancements
-* None.
+
+* Added `designTemperature` and `designRating` to `Conductor` to capture limitations in the conductor based on the
+  network design and physical surrounds of the conductor.
 
 ### Fixes
+
 * Use latest version of ewb-conn for fix to issuer key in auth configuration endpoint
 
 ### Notes
-* None.
 
+* None.
 
 ## [0.20.0] - 2024-05-14
 

--- a/pom.xml
+++ b/pom.xml
@@ -74,7 +74,7 @@
         <dependency>
             <groupId>com.zepben.protobuf</groupId>
             <artifactId>evolve-grpc</artifactId>
-            <version>0.28.0</version>
+            <version>0.29.0-SNAPSHOT2</version>
         </dependency>
 
         <dependency>

--- a/src/main/kotlin/com/zepben/evolve/cim/iec61970/base/wires/Conductor.kt
+++ b/src/main/kotlin/com/zepben/evolve/cim/iec61970/base/wires/Conductor.kt
@@ -18,6 +18,9 @@ import com.zepben.evolve.cim.iec61970.base.core.ConductingEquipment
  * between points in the power system.
  *
  * @property length Segment length for calculating line section capabilities.
+ * @property designTemperature ZBEX: The temperature for the network design of this conductor.
+ * @property designRating ZBEX: The current rating in Amperes at the specified design temperature that can be used without the conductor breaching physical network
+ *   design limits.
  */
 abstract class Conductor(mRID: String = "") : ConductingEquipment(mRID) {
 
@@ -26,6 +29,9 @@ abstract class Conductor(mRID: String = "") : ConductingEquipment(mRID) {
             require((value == null) || (value >= 0) || value.isNaN()) { "Conductor length cannot be negative." }
             field = value
         }
+
+    var designTemperature: Int? = null
+    var designRating: Double? = null
 
     /**
      * Override the [AssetInfo] as [WireInfo].

--- a/src/main/kotlin/com/zepben/evolve/database/sqlite/cim/network/NetworkCIMReader.kt
+++ b/src/main/kotlin/com/zepben/evolve/database/sqlite/cim/network/NetworkCIMReader.kt
@@ -35,7 +35,6 @@ import com.zepben.evolve.cim.iec61970.infiec61970.protection.PowerDirectionKind
 import com.zepben.evolve.cim.iec61970.infiec61970.protection.ProtectionKind
 import com.zepben.evolve.cim.iec61970.infiec61970.wires.generation.production.EvChargingUnit
 import com.zepben.evolve.database.sqlite.cim.CimReader
-import com.zepben.evolve.database.sqlite.extensions.*
 import com.zepben.evolve.database.sqlite.cim.tables.associations.*
 import com.zepben.evolve.database.sqlite.cim.tables.iec61968.assetinfo.*
 import com.zepben.evolve.database.sqlite.cim.tables.iec61968.assets.*
@@ -63,6 +62,7 @@ import com.zepben.evolve.database.sqlite.cim.tables.iec61970.infiec61970.feeder.
 import com.zepben.evolve.database.sqlite.cim.tables.iec61970.infiec61970.feeder.TableLoops
 import com.zepben.evolve.database.sqlite.cim.tables.iec61970.infiec61970.feeder.TableLvFeeders
 import com.zepben.evolve.database.sqlite.cim.tables.iec61970.infiec61970.wires.generation.production.TableEvChargingUnits
+import com.zepben.evolve.database.sqlite.extensions.*
 import com.zepben.evolve.services.common.Resolvers
 import com.zepben.evolve.services.common.extensions.*
 import com.zepben.evolve.services.network.NetworkService
@@ -1550,6 +1550,8 @@ class NetworkCimReader(
     private fun loadConductor(conductor: Conductor, table: TableConductors, resultSet: ResultSet): Boolean {
         conductor.apply {
             length = resultSet.getNullableDouble(table.LENGTH.queryIndex)
+            designTemperature = resultSet.getNullableInt(table.DESIGN_TEMPERATURE.queryIndex)
+            designRating = resultSet.getNullableDouble(table.DESIGN_RATING.queryIndex)
             assetInfo = service.ensureGet(
                 resultSet.getNullableString(table.WIRE_INFO_MRID.queryIndex),
                 typeNameAndMRID()

--- a/src/main/kotlin/com/zepben/evolve/database/sqlite/cim/network/NetworkCIMWriter.kt
+++ b/src/main/kotlin/com/zepben/evolve/database/sqlite/cim/network/NetworkCIMWriter.kt
@@ -37,7 +37,6 @@ import com.zepben.evolve.cim.iec61970.infiec61970.feeder.Loop
 import com.zepben.evolve.cim.iec61970.infiec61970.feeder.LvFeeder
 import com.zepben.evolve.cim.iec61970.infiec61970.wires.generation.production.EvChargingUnit
 import com.zepben.evolve.database.sqlite.cim.CimWriter
-import com.zepben.evolve.database.sqlite.extensions.*
 import com.zepben.evolve.database.sqlite.cim.tables.associations.*
 import com.zepben.evolve.database.sqlite.cim.tables.iec61968.assetinfo.*
 import com.zepben.evolve.database.sqlite.cim.tables.iec61968.assets.*
@@ -65,6 +64,7 @@ import com.zepben.evolve.database.sqlite.cim.tables.iec61970.infiec61970.feeder.
 import com.zepben.evolve.database.sqlite.cim.tables.iec61970.infiec61970.feeder.TableLoops
 import com.zepben.evolve.database.sqlite.cim.tables.iec61970.infiec61970.feeder.TableLvFeeders
 import com.zepben.evolve.database.sqlite.cim.tables.iec61970.infiec61970.wires.generation.production.TableEvChargingUnits
+import com.zepben.evolve.database.sqlite.extensions.*
 import com.zepben.evolve.services.network.NetworkService
 import java.sql.PreparedStatement
 import java.sql.SQLException
@@ -1419,6 +1419,8 @@ class NetworkCimWriter(
     @Throws(SQLException::class)
     private fun saveConductor(table: TableConductors, insert: PreparedStatement, conductor: Conductor, description: String): Boolean {
         insert.setNullableDouble(table.LENGTH.queryIndex, conductor.length)
+        insert.setNullableInt(table.DESIGN_TEMPERATURE.queryIndex, conductor.designTemperature)
+        insert.setNullableDouble(table.DESIGN_RATING.queryIndex, conductor.designRating)
         insert.setNullableString(table.WIRE_INFO_MRID.queryIndex, conductor.assetInfo?.mRID)
 
         return saveConductingEquipment(table, insert, conductor, description)

--- a/src/main/kotlin/com/zepben/evolve/database/sqlite/cim/tables/TableCIMVersion.kt
+++ b/src/main/kotlin/com/zepben/evolve/database/sqlite/cim/tables/TableCIMVersion.kt
@@ -13,4 +13,4 @@ import com.zepben.evolve.database.sqlite.common.TableVersion
 /**
  * The `version` table in the CIM databases. Increment this when doing a schema update.
  */
-val tableCimVersion: TableVersion = TableVersion(52)
+val tableCimVersion: TableVersion = TableVersion(53)

--- a/src/main/kotlin/com/zepben/evolve/database/sqlite/cim/tables/iec61970/base/wires/TableConductors.kt
+++ b/src/main/kotlin/com/zepben/evolve/database/sqlite/cim/tables/iec61970/base/wires/TableConductors.kt
@@ -12,10 +12,20 @@ import com.zepben.evolve.database.sqlite.cim.tables.Column
 import com.zepben.evolve.database.sqlite.cim.tables.Column.Nullable.NULL
 import com.zepben.evolve.database.sqlite.cim.tables.iec61970.base.core.TableConductingEquipment
 
+/**
+ * A class representing the conductor columns required for the database table.
+ *
+ * @property LENGTH A column storing the conductor length.
+ * @property DESIGN_TEMPERATURE A column storing the conductor design temperature.
+ * @property DESIGN_RATING A column storing the conductor design rating.
+ * @property WIRE_INFO_MRID A column storing a link to the wire info for the conductor.
+ */
 @Suppress("PropertyName")
 abstract class TableConductors : TableConductingEquipment() {
 
     val LENGTH: Column = Column(++columnIndex, "length", "NUMBER", NULL)
+    val DESIGN_TEMPERATURE: Column = Column(++columnIndex, "design_temperature", "INTEGER", NULL)
+    val DESIGN_RATING: Column = Column(++columnIndex, "design_rating", "NUMBER", NULL)
     val WIRE_INFO_MRID: Column = Column(++columnIndex, "wire_info_mrid", "TEXT", NULL)
 
 }

--- a/src/main/kotlin/com/zepben/evolve/database/sqlite/cim/upgrade/UpgradeRunner.kt
+++ b/src/main/kotlin/com/zepben/evolve/database/sqlite/cim/upgrade/UpgradeRunner.kt
@@ -10,9 +10,9 @@ package com.zepben.evolve.database.sqlite.cim.upgrade
 
 import com.zepben.evolve.database.paths.DatabaseType
 import com.zepben.evolve.database.sqlite.cim.tables.tableCimVersion
-import com.zepben.evolve.database.sqlite.extensions.configureBatch
-import com.zepben.evolve.database.sqlite.common.TableVersion
 import com.zepben.evolve.database.sqlite.cim.upgrade.changesets.*
+import com.zepben.evolve.database.sqlite.common.TableVersion
+import com.zepben.evolve.database.sqlite.extensions.configureBatch
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import java.io.IOException
@@ -37,7 +37,8 @@ class UpgradeRunner @JvmOverloads constructor(
     internal val postSplitChangeSets: List<ChangeSet> = listOf(
         changeSet50(),
         changeSet51(),
-        changeSet52()
+        changeSet52(),
+        changeSet53()
     ),
     private val tableVersion: TableVersion = tableCimVersion
 ) {

--- a/src/main/kotlin/com/zepben/evolve/database/sqlite/cim/upgrade/changesets/ChangeSet53.kt
+++ b/src/main/kotlin/com/zepben/evolve/database/sqlite/cim/upgrade/changesets/ChangeSet53.kt
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2024 Zeppelin Bend Pty Ltd
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+package com.zepben.evolve.database.sqlite.cim.upgrade.changesets
+
+import com.zepben.evolve.database.paths.DatabaseType
+import com.zepben.evolve.database.sqlite.cim.upgrade.Change
+import com.zepben.evolve.database.sqlite.cim.upgrade.ChangeSet
+
+internal fun changeSet53() = ChangeSet(
+    53,
+    listOf(
+        // Network Changes
+
+        `Add design rating columns for conductors`
+    )
+)
+
+// ###################
+// # Network Changes #
+// ###################
+
+@Suppress("ObjectPropertyName")
+private val `Add design rating columns for conductors` = Change(
+    listOf(
+        "ALTER TABLE ac_line_segments ADD COLUMN design_temperature INTEGER NULL;",
+        "ALTER TABLE ac_line_segments ADD COLUMN design_rating NUMBER NULL;",
+    ),
+    targetDatabases = setOf(DatabaseType.NETWORK_MODEL)
+)

--- a/src/main/kotlin/com/zepben/evolve/services/network/NetworkServiceComparator.kt
+++ b/src/main/kotlin/com/zepben/evolve/services/network/NetworkServiceComparator.kt
@@ -663,7 +663,7 @@ class NetworkServiceComparator @JvmOverloads constructor(
         apply {
             compareConductingEquipment()
 
-            compareValues(Conductor::length)
+            compareValues(Conductor::length, Conductor::designTemperature, Conductor::designRating)
         }
 
     private fun ObjectDifference<out Connector>.compareConnector(): ObjectDifference<out Connector> =

--- a/src/main/kotlin/com/zepben/evolve/services/network/translator/NetworkCimToProto.kt
+++ b/src/main/kotlin/com/zepben/evolve/services/network/translator/NetworkCimToProto.kt
@@ -846,6 +846,8 @@ fun toPb(cim: BusbarSection, pb: PBBusbarSection.Builder): PBBusbarSection.Build
 fun toPb(cim: Conductor, pb: PBConductor.Builder): PBConductor.Builder =
     pb.apply {
         length = cim.length ?: UNKNOWN_DOUBLE
+        designTemperature = cim.designTemperature ?: UNKNOWN_INT
+        designRating = cim.designRating ?: UNKNOWN_DOUBLE
         toPb(cim, ceBuilder)
     }
 

--- a/src/main/kotlin/com/zepben/evolve/services/network/translator/NetworkProtoToCim.kt
+++ b/src/main/kotlin/com/zepben/evolve/services/network/translator/NetworkProtoToCim.kt
@@ -891,6 +891,8 @@ fun toCim(pb: PBBusbarSection, networkService: NetworkService): BusbarSection =
 fun toCim(pb: PBConductor, cim: Conductor, networkService: NetworkService): Conductor =
     cim.apply {
         length = pb.length.takeUnless { it == UNKNOWN_DOUBLE }
+        designTemperature = pb.designTemperature.takeUnless { it == UNKNOWN_INT }
+        designRating = pb.designRating.takeUnless { it == UNKNOWN_DOUBLE }
         networkService.resolveOrDeferReference(Resolvers.assetInfo(this), pb.assetInfoMRID())
         toCim(pb.ce, this, networkService)
     }

--- a/src/test/kotlin/com/zepben/evolve/cim/iec61970/base/wires/ConductorTest.kt
+++ b/src/test/kotlin/com/zepben/evolve/cim/iec61970/base/wires/ConductorTest.kt
@@ -37,12 +37,18 @@ internal class ConductorTest {
 
         assertThat(conductor.assetInfo, nullValue())
         assertThat(conductor.length, nullValue())
+        assertThat(conductor.designTemperature, nullValue())
+        assertThat(conductor.designRating, nullValue())
 
         conductor.assetInfo = wireInfo
         conductor.length = 12.3
+        conductor.designTemperature = 45
+        conductor.designRating = 67.8
 
         assertThat(conductor.assetInfo, equalTo(wireInfo))
         assertThat(conductor.length, equalTo(12.3))
+        assertThat(conductor.designTemperature, equalTo(45))
+        assertThat(conductor.designRating, equalTo(67.8))
     }
 
     @Test

--- a/src/test/kotlin/com/zepben/evolve/database/ResultSetExtensions.kt
+++ b/src/test/kotlin/com/zepben/evolve/database/ResultSetExtensions.kt
@@ -29,5 +29,8 @@ internal fun ResultSet.getNullableDouble(columnName: String): Double? {
         dbl
 }
 
+internal fun ResultSet.getNullableInt(columnName: String): Int? =
+    getInt(columnName).takeUnless { wasNull() }
+
 internal fun ResultSet.getInstant(columnName: String): Instant? =
     getString(columnName).takeUnless { wasNull() }?.let { Instant.parse(it) }

--- a/src/test/kotlin/com/zepben/evolve/database/sqlite/cim/upgrade/ChangeSetTest.kt
+++ b/src/test/kotlin/com/zepben/evolve/database/sqlite/cim/upgrade/ChangeSetTest.kt
@@ -15,12 +15,15 @@ import com.zepben.evolve.database.sqlite.cim.upgrade.changesets.combined.*
 import com.zepben.evolve.database.sqlite.cim.upgrade.changesets.customer.ChangeSet50CustomerValidator
 import com.zepben.evolve.database.sqlite.cim.upgrade.changesets.customer.ChangeSet51CustomerValidator
 import com.zepben.evolve.database.sqlite.cim.upgrade.changesets.customer.ChangeSet52CustomerValidator
+import com.zepben.evolve.database.sqlite.cim.upgrade.changesets.customer.ChangeSet53CustomerValidator
 import com.zepben.evolve.database.sqlite.cim.upgrade.changesets.diagram.ChangeSet50DiagramValidator
 import com.zepben.evolve.database.sqlite.cim.upgrade.changesets.diagram.ChangeSet51DiagramValidator
 import com.zepben.evolve.database.sqlite.cim.upgrade.changesets.diagram.ChangeSet52DiagramValidator
+import com.zepben.evolve.database.sqlite.cim.upgrade.changesets.diagram.ChangeSet53DiagramValidator
 import com.zepben.evolve.database.sqlite.cim.upgrade.changesets.network.ChangeSet50NetworkValidator
 import com.zepben.evolve.database.sqlite.cim.upgrade.changesets.network.ChangeSet51NetworkValidator
 import com.zepben.evolve.database.sqlite.cim.upgrade.changesets.network.ChangeSet52NetworkValidator
+import com.zepben.evolve.database.sqlite.cim.upgrade.changesets.network.ChangeSet53NetworkValidator
 import com.zepben.testutils.junit.SystemLogExtension
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.RegisterExtension
@@ -51,19 +54,22 @@ internal class ChangeSetTest {
     private val customerChangeSetValidators = mapOf(
         50 to ChangeSet50CustomerValidator,
         51 to ChangeSet51CustomerValidator,
-        52 to ChangeSet52CustomerValidator
+        52 to ChangeSet52CustomerValidator,
+        53 to ChangeSet53CustomerValidator
     )
 
     private val diagramChangeSetValidators = mapOf(
         50 to ChangeSet50DiagramValidator,
         51 to ChangeSet51DiagramValidator,
-        52 to ChangeSet52DiagramValidator
+        52 to ChangeSet52DiagramValidator,
+        53 to ChangeSet53DiagramValidator,
     )
 
     private val networkChangeSetValidators = mapOf(
         50 to ChangeSet50NetworkValidator,
         51 to ChangeSet51NetworkValidator,
-        52 to ChangeSet52NetworkValidator
+        52 to ChangeSet52NetworkValidator,
+        53 to ChangeSet53NetworkValidator
     )
 
     @Test

--- a/src/test/kotlin/com/zepben/evolve/database/sqlite/cim/upgrade/changesets/customer/ChangeSet53CustomerValidator.kt
+++ b/src/test/kotlin/com/zepben/evolve/database/sqlite/cim/upgrade/changesets/customer/ChangeSet53CustomerValidator.kt
@@ -1,0 +1,13 @@
+/*
+ * Copyright 2024 Zeppelin Bend Pty Ltd
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+package com.zepben.evolve.database.sqlite.cim.upgrade.changesets.customer
+
+import com.zepben.evolve.database.sqlite.cim.upgrade.changesets.NoChanges
+
+object ChangeSet53CustomerValidator : NoChanges()

--- a/src/test/kotlin/com/zepben/evolve/database/sqlite/cim/upgrade/changesets/diagram/ChangeSet53DiagramValidator.kt
+++ b/src/test/kotlin/com/zepben/evolve/database/sqlite/cim/upgrade/changesets/diagram/ChangeSet53DiagramValidator.kt
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2024 Zeppelin Bend Pty Ltd
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+package com.zepben.evolve.database.sqlite.cim.upgrade.changesets.diagram
+
+import com.zepben.evolve.database.sqlite.cim.upgrade.changesets.ChangeSetValidator
+import org.hamcrest.MatcherAssert.assertThat
+import org.hamcrest.Matchers.equalTo
+import java.sql.Statement
+
+object ChangeSet53DiagramValidator : ChangeSetValidator {
+
+    override fun setUpStatements(): List<String> = listOf(
+        "INSERT INTO diagram_object_points (diagram_object_mrid, sequence_number, x_position, y_position) VALUES ('id1', '2', '3.3', '4.4')"
+    )
+
+    override fun populateStatements(): List<String> = listOf(
+        "INSERT INTO diagram_object_points (diagram_object_mrid, sequence_number, x_position, y_position) VALUES ('id2', 3, 4.4, 5.5)"
+    )
+
+    override fun validate(statement: Statement) {
+        // Make sure the indexes were recreated.
+        ensureIndexes(statement, "diagram_object_points_diagram_object_mrid_sequence_number", "diagram_object_points_diagram_object_mrid")
+
+        // Make sure the data was copied.
+        validateRows(statement, "SELECT * FROM diagram_object_points",
+            { rs ->
+                assertThat(rs.getString("diagram_object_mrid"), equalTo("id1"))
+                assertThat(rs.getInt("sequence_number"), equalTo(2))
+                assertThat(rs.getDouble("x_position"), equalTo(3.3))
+                assertThat(rs.getDouble("y_position"), equalTo(4.4))
+            },
+            { rs ->
+                assertThat(rs.getString("diagram_object_mrid"), equalTo("id2"))
+                assertThat(rs.getInt("sequence_number"), equalTo(3))
+                assertThat(rs.getDouble("x_position"), equalTo(4.4))
+                assertThat(rs.getDouble("y_position"), equalTo(5.5))
+            }
+        )
+    }
+
+    override fun tearDownStatements(): List<String> =
+        listOf(
+            "DELETE FROM diagram_object_points"
+        )
+
+}

--- a/src/test/kotlin/com/zepben/evolve/database/sqlite/cim/upgrade/changesets/network/ChangeSet53NetworkValidator.kt
+++ b/src/test/kotlin/com/zepben/evolve/database/sqlite/cim/upgrade/changesets/network/ChangeSet53NetworkValidator.kt
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2024 Zeppelin Bend Pty Ltd
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+package com.zepben.evolve.database.sqlite.cim.upgrade.changesets.network
+
+import com.zepben.evolve.database.getNullableDouble
+import com.zepben.evolve.database.getNullableInt
+import com.zepben.evolve.database.sqlite.cim.upgrade.changesets.ChangeSetValidator
+import org.hamcrest.MatcherAssert.assertThat
+import org.hamcrest.Matchers.equalTo
+import org.hamcrest.Matchers.nullValue
+import java.sql.Statement
+
+object ChangeSet53NetworkValidator : ChangeSetValidator {
+
+    //
+    // NOTE: In the validators we are only checking the columns that were actually changed.
+    //
+
+    override fun setUpStatements(): List<String> = listOf(
+        """
+           INSERT INTO ac_line_segments (mrid, name, description, num_diagram_objects, location_mrid, num_controls, normally_in_service, in_service, 
+           base_voltage_mrid, length, wire_info_mrid, per_length_sequence_impedance_mrid, commissioned_date) 
+           VALUES ('id1', 'name', 'desc', 0, 'l_id',  0, true, true, 'bv1', 10.0, 'wi1', 'plsi1', '2020-01-01')
+        """.trimIndent(),
+    )
+
+    override fun populateStatements(): List<String> = listOf(
+        """
+           INSERT INTO ac_line_segments (mrid, name, description, num_diagram_objects, location_mrid, num_controls, normally_in_service, in_service, 
+           base_voltage_mrid, length, design_temperature, design_rating, wire_info_mrid, per_length_sequence_impedance_mrid, commissioned_date) 
+           VALUES ('id2', 'name', 'desc', 0, 'l_id',  0, true, true, 'bv1', 10.0, 1, 2.2, 'wi1', 'plsi1', '2020-01-01')
+        """.trimIndent(),
+    )
+
+    override fun validate(statement: Statement) {
+        validateRows(statement, "SELECT * FROM ac_line_segments",
+            { rs ->
+                assertThat(rs.getString("mrid"), equalTo("id1"))
+                assertThat(rs.getString("name"), equalTo("name"))
+                assertThat(rs.getString("description"), equalTo("desc"))
+                assertThat(rs.getInt("num_diagram_objects"), equalTo(0))
+                assertThat(rs.getString("location_mrid"), equalTo("l_id"))
+                assertThat(rs.getInt("num_controls"), equalTo(0))
+                assertThat(rs.getBoolean("normally_in_service"), equalTo(true))
+                assertThat(rs.getBoolean("in_service"), equalTo(true))
+                assertThat(rs.getString("base_voltage_mrid"), equalTo("bv1"))
+                assertThat(rs.getDouble("length"), equalTo(10.0))
+                assertThat(rs.getNullableInt("design_temperature"), nullValue())
+                assertThat(rs.getNullableDouble("design_rating"), nullValue())
+                assertThat(rs.getString("wire_info_mrid"), equalTo("wi1"))
+                assertThat(rs.getString("per_length_sequence_impedance_mrid"), equalTo("plsi1"))
+                assertThat(rs.getString("commissioned_date"), equalTo("2020-01-01"))
+            },
+            { rs ->
+                assertThat(rs.getString("mrid"), equalTo("id2"))
+                assertThat(rs.getString("name"), equalTo("name"))
+                assertThat(rs.getString("description"), equalTo("desc"))
+                assertThat(rs.getInt("num_diagram_objects"), equalTo(0))
+                assertThat(rs.getString("location_mrid"), equalTo("l_id"))
+                assertThat(rs.getInt("num_controls"), equalTo(0))
+                assertThat(rs.getBoolean("normally_in_service"), equalTo(true))
+                assertThat(rs.getBoolean("in_service"), equalTo(true))
+                assertThat(rs.getString("base_voltage_mrid"), equalTo("bv1"))
+                assertThat(rs.getDouble("length"), equalTo(10.0))
+                assertThat(rs.getNullableInt("design_temperature"), equalTo(1))
+                assertThat(rs.getNullableDouble("design_rating"), equalTo(2.2))
+                assertThat(rs.getString("wire_info_mrid"), equalTo("wi1"))
+                assertThat(rs.getString("per_length_sequence_impedance_mrid"), equalTo("plsi1"))
+                assertThat(rs.getString("commissioned_date"), equalTo("2020-01-01"))
+            }
+        )
+    }
+
+    override fun tearDownStatements(): List<String> =
+        listOf(
+            "DELETE FROM ac_line_segments;",
+        )
+
+}

--- a/src/test/kotlin/com/zepben/evolve/services/network/NetworkServiceComparatorTest.kt
+++ b/src/test/kotlin/com/zepben/evolve/services/network/NetworkServiceComparatorTest.kt
@@ -848,6 +848,8 @@ internal class NetworkServiceComparatorTest : BaseServiceComparatorTest() {
         compareConductingEquipment(createConductor)
 
         comparatorValidator.validateProperty(Conductor::length, createConductor, { 1.0 }, { 2.0 })
+        comparatorValidator.validateProperty(Conductor::designTemperature, createConductor, { 1 }, { 2 })
+        comparatorValidator.validateProperty(Conductor::designRating, createConductor, { 1.0 }, { 2.0 })
         comparatorValidator.validateProperty(Conductor::assetInfo, createConductor, { CableInfo("c1") }, { CableInfo("c2") })
     }
 

--- a/src/test/kotlin/com/zepben/evolve/services/network/testdata/FillFields.kt
+++ b/src/test/kotlin/com/zepben/evolve/services/network/testdata/FillFields.kt
@@ -959,6 +959,8 @@ fun Conductor.fillFields(service: NetworkService, includeRuntime: Boolean = true
     (this as ConductingEquipment).fillFields(service, includeRuntime)
 
     length = 1.1
+    designTemperature = 2
+    designRating = 3.3
     assetInfo = CableInfo().also { service.add(it) }
 
     return this


### PR DESCRIPTION
# Description

Added `designTemperature` and `designRating` to `Conductor` to support span level ratings based on how each conductor has been constructed for Essential Energy.

# Associated tasks

- https://github.com/zepben/ewb-grpc/pull/98

# Checklist

If any of these are not applicable, strikethrough the line `~like this~`. **Do not delete it!**. Let the reviewer decide if you should have done it.

### Code
- [x] I have performed a self review of my own code (including checking issues raised when creating the PR).
- [x] I have added/updated unit tests for these changes, and if not I have explained why they are not necessary.
- [x] I have commented my code in any hard-to-understand or hacky areas.
- [x] I have handled all new warnings generated by the compiler or IDE.
- [x] I have rebased onto the target branch (usually main).
      
### Documentation
- [x] I have updated the changelog.
~- [ ] I have updated any documentation required for these changes.~

# Breaking Changes
- [x] I have considered if this is a breaking change and will communicate it with other team members if so.

Only breaking change is the expected database schema upgrade