### PR TITLE
DEV-852: Create file named with job ID when saving metrics database

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -10,7 +10,7 @@
 ### Enhancements
 * Added feature list in documentation.
 * Changed `NetworkContainerMetrics` to a delegate type to assist in writing metrics creators:
-  * `NetworkContainerMetrics::plus(key: String, amount: Number = 1.0)`: Increases a metric by a certain value. If the metric doesn't exist yet, it is
+  * `NetworkContainerMetrics::plus(key: String, amount: Number)`: Increases a metric by a certain value. If the metric doesn't exist yet, it is
     automatically created and set to zero before being increased. A negative value may be used for `amount` to decrease the metric.
   * `NetworkContainerMetrics::inc(key: String)`: Equivalent to `NetworkContainerMetrics.plus(key, 1.0)`
   * `NetworkContainerMetrics::set(key: String, value: Int)`: Allows setting a metric using an integer rather than a double-precision float:

--- a/changelog.md
+++ b/changelog.md
@@ -4,7 +4,8 @@
 * None.
 
 ### New Features
-* None.
+* A file named after the ID of an ingestion job is now created when running `MetricsDatabaseWriter.save()`. For this feature to take effect, a `modelPath` must
+  be provided when constructing the `MetricsDatabaseWriter`.
 
 ### Enhancements
 * Added feature list in documentation.

--- a/changelog.md
+++ b/changelog.md
@@ -9,10 +9,11 @@
 
 ### Enhancements
 * Added feature list in documentation.
-* Added extension functions for `NetworkContainerMetrics` to assist in writing metrics creators:
-  * `NetworkContainerMetrics::increase(key: String, delta: Number = 1.0)`: Increases a metric by a certain value. If the metric doesn't exist yet, it is
-    automatically created and set to zero before being increased. A negative value may be used for `delta` to decrease the metric.
-  * `NetworkContainerMetrics.set(key: String, n: Int)`: Allows setting a metric using an integer rather than a double-precision float:
+* Changed `NetworkContainerMetrics` to a delegate type to assist in writing metrics creators:
+  * `NetworkContainerMetrics::plus(key: String, amount: Number = 1.0)`: Increases a metric by a certain value. If the metric doesn't exist yet, it is
+    automatically created and set to zero before being increased. A negative value may be used for `amount` to decrease the metric.
+  * `NetworkContainerMetrics::inc(key: String)`: Equivalent to `NetworkContainerMetrics.plus(key, 1.0)`
+  * `NetworkContainerMetrics::set(key: String, value: Int)`: Allows setting a metric using an integer rather than a double-precision float:
     ```
     metrics[TotalNetworkContainer]["metric-name"] = 3
     ```

--- a/changelog.md
+++ b/changelog.md
@@ -9,6 +9,13 @@
 
 ### Enhancements
 * Added feature list in documentation.
+* Added extension functions for `NetworkContainerMetrics` to assist in writing metrics creators:
+  * `NetworkContainerMetrics::increase(key: String, delta: Number = 1.0)`: Increases a metric by a certain value. If the metric doesn't exist yet, it is
+    automatically created and set to zero before being increased. A negative value may be used for `delta` to decrease the metric.
+  * `NetworkContainerMetrics.set(key: String, n: Int)`: Allows setting a metric using an integer rather than a double-precision float:
+    ```
+    metrics[TotalNetworkContainer]["metric-name"] = 3
+    ```
 
 ### Fixes
 * None.

--- a/docs/docs/metrics.mdx
+++ b/docs/docs/metrics.mdx
@@ -81,7 +81,12 @@ public class IngestionJobExample {
         ingestionJob.getNetworkMetrics().get(networkContainer(feeder)).put("total cable length", 12.345);
         ingestionJob.getNetworkMetrics().get(networkContainer(feeder, true)).put("total cable length", 123.45);
 
-        if (new MetricsDatabaseWriter("metrics.sqlite", ingestionJob).save()) {
+        MetricsDatabaseWriter metricsDatabaseWriter = new MetricsDatabaseWriter(
+            "metrics.sqlite", // Database file to create/update
+            ingestionJob, // Ingestion job to write
+            Path.of("path/to/model") // Optional: Folder containing files for the model exported by the ingestion job. The network, customer, and diagram databases should be located here.
+        );
+        if (metricsDatabaseWriter.save()) {
             System.out.println("Ingestion job saved successfully");
         } else {
             System.out.println("Ingestion job could not be saved successfully");
@@ -124,7 +129,12 @@ val ingestionJob = IngestionJob(UUID.randomUUID()).apply {
 }
 
 fun main() {
-    if (MetricsDatabaseWriter("metrics.sqlite", ingestionJob).save()) {
+    val metricsDatabaseWriter = MetricsDatabaseWriter(
+        "metrics.sqlite", // Database file to create/update
+        ingestionJob, // Ingestion job to write
+        Path.of("path/to/model") // Optional: Folder containing files for the model exported by the ingestion job. The network, customer, and diagram databases should be located here.
+    )
+    if (metricsDatabaseWriter.save()) {
         println("Ingestion job saved successfully")
     } else {
         println("Ingestion job could not be saved successfully")
@@ -136,4 +146,5 @@ fun main() {
 </Tabs>
 
 Each job in a metrics database should have a unique UUID. If you attempt to save a job to an existing database, it will be added to it rather than replacing the
-entire database.
+entire database. Additionally, calling `save()` will create a file named using the UUID of the job at the path of the model, if one is provided upon
+constructing the `MetricsDatabaseWriter`.

--- a/src/main/kotlin/com/zepben/evolve/database/paths/EwbDataFilePaths.kt
+++ b/src/main/kotlin/com/zepben/evolve/database/paths/EwbDataFilePaths.kt
@@ -90,8 +90,6 @@ class EwbDataFilePaths @JvmOverloads constructor(
      */
     fun energyReading(date: LocalDate): Path = date.toDatedPath(DatabaseType.ENERGY_READING.fileDescriptor)
 
-    fun jobDescriptor(date: LocalDate, jobId: UUID): Path = date.toDatedPath(jobId.toString())
-
     /**
      * Determine the path to the "energy readings index" database.
      *

--- a/src/main/kotlin/com/zepben/evolve/database/paths/EwbDataFilePaths.kt
+++ b/src/main/kotlin/com/zepben/evolve/database/paths/EwbDataFilePaths.kt
@@ -13,6 +13,7 @@ import java.nio.file.Files
 import java.nio.file.Path
 import java.nio.file.Paths
 import java.time.LocalDate
+import java.util.*
 import kotlin.io.path.name
 
 
@@ -88,6 +89,8 @@ class EwbDataFilePaths @JvmOverloads constructor(
      * @return The path to the "energy readings" database for the specified date.
      */
     fun energyReading(date: LocalDate): Path = date.toDatedPath(DatabaseType.ENERGY_READING.fileDescriptor)
+
+    fun jobDescriptor(date: LocalDate, jobId: UUID): Path = date.toDatedPath(jobId.toString())
 
     /**
      * Determine the path to the "energy readings index" database.

--- a/src/main/kotlin/com/zepben/evolve/database/paths/EwbDataFilePaths.kt
+++ b/src/main/kotlin/com/zepben/evolve/database/paths/EwbDataFilePaths.kt
@@ -13,7 +13,6 @@ import java.nio.file.Files
 import java.nio.file.Path
 import java.nio.file.Paths
 import java.time.LocalDate
-import java.util.*
 import kotlin.io.path.name
 
 

--- a/src/main/kotlin/com/zepben/evolve/database/sqlite/metrics/MetricsDatabaseWriter.kt
+++ b/src/main/kotlin/com/zepben/evolve/database/sqlite/metrics/MetricsDatabaseWriter.kt
@@ -10,6 +10,7 @@ package com.zepben.evolve.database.sqlite.metrics
 
 import com.zepben.evolve.database.sqlite.common.BaseDatabaseWriter
 import com.zepben.evolve.metrics.IngestionJob
+import java.io.IOException
 import java.nio.file.Path
 import java.sql.Connection
 import java.sql.DriverManager
@@ -37,11 +38,15 @@ class MetricsDatabaseWriter @JvmOverloads constructor(
     /**
      * Save the ingestion job (and associated data).
      */
-    override fun saveSchema(): Boolean = metricsWriter.save() && run {
-        createJobIdFile()
-        true
-    }
+    override fun saveSchema(): Boolean = metricsWriter.save() && createJobIdFile()
 
-    private fun createJobIdFile() = modelPath?.resolve(job.id.toString())?.toFile()?.createNewFile()
+    private fun createJobIdFile(): Boolean = modelPath?.resolve(job.id.toString())?.toFile()?.let { jobIdFile ->
+        try {
+            jobIdFile.createNewFile()
+        } catch (e: IOException) {
+            logger.error("Could not save job ID file at ${jobIdFile.absolutePath}.")
+            false
+        }
+    } ?: true
 
 }

--- a/src/main/kotlin/com/zepben/evolve/database/sqlite/metrics/MetricsDatabaseWriter.kt
+++ b/src/main/kotlin/com/zepben/evolve/database/sqlite/metrics/MetricsDatabaseWriter.kt
@@ -19,18 +19,18 @@ import java.sql.DriverManager
  *
  * @param databaseFile The filename of the metrics database.
  * @param job The ingestion job to write.
- * @param databaseTables The tables in the database.
- * @param metricsWriter The metrics writer to use.
  * @param modelPath The directory containing the output model files for the ingestion job. If specified, a file will be created in this directory and
  *                  named using the UUID of the ingestion job.
+ * @param databaseTables The tables in the database.
+ * @param metricsWriter The metrics writer to use.
  * @param getConnection Provider of the connection to the specified database.
  */
 class MetricsDatabaseWriter @JvmOverloads constructor(
     databaseFile: String,
     private val job: IngestionJob,
+    private val modelPath: Path? = null,
     databaseTables: MetricsDatabaseTables = MetricsDatabaseTables(),
     private val metricsWriter: MetricsWriter = MetricsWriter(job, databaseTables),
-    private val modelPath: Path? = null,
     getConnection: (String) -> Connection = DriverManager::getConnection
 ) : BaseDatabaseWriter(databaseFile, databaseTables, getConnection, persistFile = true) {
 

--- a/src/main/kotlin/com/zepben/evolve/database/sqlite/metrics/MetricsDatabaseWriter.kt
+++ b/src/main/kotlin/com/zepben/evolve/database/sqlite/metrics/MetricsDatabaseWriter.kt
@@ -38,10 +38,10 @@ class MetricsDatabaseWriter @JvmOverloads constructor(
      * Save the ingestion job (and associated data).
      */
     override fun saveSchema(): Boolean = metricsWriter.save() && run {
-        createMetadataFile()
+        createJobIdFile()
         true
     }
 
-    private fun createMetadataFile() = modelPath?.resolve(job.id.toString())?.toFile()?.createNewFile()
+    private fun createJobIdFile() = modelPath?.resolve(job.id.toString())?.toFile()?.createNewFile()
 
 }

--- a/src/main/kotlin/com/zepben/evolve/metrics/NetworkContainer.kt
+++ b/src/main/kotlin/com/zepben/evolve/metrics/NetworkContainer.kt
@@ -49,14 +49,14 @@ fun LvFeeder.toNetworkContainer(): PartialNetworkContainer =
     PartialNetworkContainer(NetworkLevel.LvFeeder, mRID, name)
 
 // Java interop
-fun networkContainer(geographicalRegion: GeographicalRegion) = geographicalRegion.toNetworkContainer()
+fun networkContainer(geographicalRegion: GeographicalRegion): PartialNetworkContainer = geographicalRegion.toNetworkContainer()
 
-fun networkContainer(subGeographicalRegion: SubGeographicalRegion) = subGeographicalRegion.toNetworkContainer()
-
-@JvmOverloads
-fun networkContainer(substation: Substation, includeDownstream: Boolean = false) = substation.toNetworkContainer(includeDownstream)
+fun networkContainer(subGeographicalRegion: SubGeographicalRegion): PartialNetworkContainer = subGeographicalRegion.toNetworkContainer()
 
 @JvmOverloads
-fun networkContainer(feeder: Feeder, includeDownstream: Boolean = false) = feeder.toNetworkContainer(includeDownstream)
+fun networkContainer(substation: Substation, includeDownstream: Boolean = false): PartialNetworkContainer = substation.toNetworkContainer(includeDownstream)
 
-fun networkContainer(lvFeeder: LvFeeder) = lvFeeder.toNetworkContainer()
+@JvmOverloads
+fun networkContainer(feeder: Feeder, includeDownstream: Boolean = false): PartialNetworkContainer = feeder.toNetworkContainer(includeDownstream)
+
+fun networkContainer(lvFeeder: LvFeeder): PartialNetworkContainer = lvFeeder.toNetworkContainer()

--- a/src/main/kotlin/com/zepben/evolve/metrics/NetworkContainerMetrics.kt
+++ b/src/main/kotlin/com/zepben/evolve/metrics/NetworkContainerMetrics.kt
@@ -11,22 +11,27 @@ package com.zepben.evolve.metrics
 /**
  * A map from metric names to their values.
  */
-typealias NetworkContainerMetrics = MutableMap<String, Double>
+class NetworkContainerMetrics(private val map: MutableMap<String, Double> = mutableMapOf()) : MutableMap<String, Double> by map {
 
-/**
- * Increases a metric by name and delta. If no metric by that name is found, it defaults to 0 first before the addition of the delta.
- *
- * @param key The name of the metric to increase.
- * @param delta The amount to increase the metric by. This value may be negative.
- *
- * @return The new value of the metric.
- */
-fun NetworkContainerMetrics.increase(key: String, delta: Number = 1.0): Double = compute(key) { _, n -> (n ?: 0.0) + delta.toDouble() }!!
+    /**
+     * Increment the value of the metric named [key]. If no such metric exists, it is automatically created with an initial value of zero.
+     */
+    fun inc(key: String): NetworkContainerMetrics = plus(key, 1.0)
 
-/**
- * Helper function to set a metric to an integer value.
- *
- * @param key The name of the metric to set.
- * @param n The value to set the metric to.
- */
-operator fun NetworkContainerMetrics.set(key: String, n: Int) { this[key] = n.toDouble() }
+    /**
+     * Increase the value of the metric named [key] by [amount]. If no such metric exists, it is automatically created with an initial value of zero.
+     */
+    fun plus(key: String, amount: Number = 1.0): NetworkContainerMetrics = apply { merge(key, amount.toDouble(), Double::plus) }
+
+    /**
+     * Set the value of the metric named [key] to [value].
+     */
+    operator fun set(key: String, value: Int) {
+        this[key] = value.toDouble()
+    }
+
+    // Make this work as the map.
+    override fun hashCode(): Int = map.hashCode()
+    override fun equals(other: Any?): Boolean = map == other
+    override fun toString(): String = map.toString()
+}

--- a/src/main/kotlin/com/zepben/evolve/metrics/NetworkContainerMetrics.kt
+++ b/src/main/kotlin/com/zepben/evolve/metrics/NetworkContainerMetrics.kt
@@ -28,7 +28,7 @@ class NetworkContainerMetrics(private val map: MutableMap<String, Double> = muta
      * @param amount The amount to increase the metric by. A negative value will decrease the metric.
      * @return This object, for fluent use
      */
-    fun plus(key: String, amount: Number = 1.0): NetworkContainerMetrics = apply { merge(key, amount.toDouble(), Double::plus) }
+    fun plus(key: String, amount: Number): NetworkContainerMetrics = apply { merge(key, amount.toDouble(), Double::plus) }
 
     /**
      * Set the value of the metric named [key] to [value].

--- a/src/main/kotlin/com/zepben/evolve/metrics/NetworkContainerMetrics.kt
+++ b/src/main/kotlin/com/zepben/evolve/metrics/NetworkContainerMetrics.kt
@@ -15,16 +15,26 @@ class NetworkContainerMetrics(private val map: MutableMap<String, Double> = muta
 
     /**
      * Increment the value of the metric named [key]. If no such metric exists, it is automatically created with an initial value of zero.
+     *
+     * @param key The metric to increment
+     * @return This object, for fluent use
      */
     fun inc(key: String): NetworkContainerMetrics = plus(key, 1.0)
 
     /**
      * Increase the value of the metric named [key] by [amount]. If no such metric exists, it is automatically created with an initial value of zero.
+     *
+     * @param key The metric to increase
+     * @param amount The amount to increase the metric by. A negative value will decrease the metric.
+     * @return This object, for fluent use
      */
     fun plus(key: String, amount: Number = 1.0): NetworkContainerMetrics = apply { merge(key, amount.toDouble(), Double::plus) }
 
     /**
      * Set the value of the metric named [key] to [value].
+     *
+     * @param key The metric to set
+     * @param value the value to set the metric to
      */
     operator fun set(key: String, value: Int) {
         this[key] = value.toDouble()

--- a/src/main/kotlin/com/zepben/evolve/metrics/NetworkContainerMetrics.kt
+++ b/src/main/kotlin/com/zepben/evolve/metrics/NetworkContainerMetrics.kt
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2024 Zeppelin Bend Pty Ltd
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+package com.zepben.evolve.metrics
+
+/**
+ * A map from metric names to their values.
+ */
+typealias NetworkContainerMetrics = MutableMap<String, Double>
+
+/**
+ * Increases a metric by name and delta. If no metric by that name is found, it defaults to 0 first before the addition of the delta.
+ *
+ * @param key The name of the metric to increase.
+ * @param delta The amount to increase the metric by. This value may be negative.
+ *
+ * @return The new value of the metric.
+ */
+fun NetworkContainerMetrics.increase(key: String, delta: Number = 1.0): Double = compute(key) { _, n -> (n ?: 0.0) + delta.toDouble() }!!
+
+/**
+ * Helper function to set a metric to an integer value.
+ *
+ * @param key The name of the metric to set.
+ * @param n The value to set the metric to.
+ */
+operator fun NetworkContainerMetrics.set(key: String, n: Int) { this[key] = n.toDouble() }

--- a/src/main/kotlin/com/zepben/evolve/metrics/NetworkMetrics.kt
+++ b/src/main/kotlin/com/zepben/evolve/metrics/NetworkMetrics.kt
@@ -18,6 +18,6 @@ typealias NetworkMetric = Map.Entry<NetworkContainer, NetworkContainerMetrics>
  */
 class NetworkMetrics : AutoMap<NetworkContainer, NetworkContainerMetrics>() {
 
-    override fun defaultValue(): NetworkContainerMetrics = mutableMapOf()
+    override fun defaultValue(): NetworkContainerMetrics = NetworkContainerMetrics()
 
 }

--- a/src/main/kotlin/com/zepben/evolve/metrics/NetworkMetrics.kt
+++ b/src/main/kotlin/com/zepben/evolve/metrics/NetworkMetrics.kt
@@ -9,11 +9,6 @@
 package com.zepben.evolve.metrics
 
 /**
- * A map from metric names to their values.
- */
-typealias NetworkContainerMetrics = MutableMap<String, Double>
-
-/**
  * Type holding a network container (partial or total) and its corresponding metrics.
  */
 typealias NetworkMetric = Map.Entry<NetworkContainer, NetworkContainerMetrics>

--- a/src/test/kotlin/com/zepben/evolve/database/sqlite/metrics/MetricsDatabaseWriterTest.kt
+++ b/src/test/kotlin/com/zepben/evolve/database/sqlite/metrics/MetricsDatabaseWriterTest.kt
@@ -48,8 +48,8 @@ internal class MetricsDatabaseWriterTest {
         MetricsDatabaseWriter(
             "databaseFile",
             IngestionJob(uuid),
-            metricsWriter = writer,
-            modelPath = modelPath
+            modelPath = modelPath,
+            metricsWriter = writer
         ).saveSchema()
 
         assertThat("Job ID file should exist", modelPath.resolve(uuid.toString()).exists())

--- a/src/test/kotlin/com/zepben/evolve/database/sqlite/metrics/MetricsDatabaseWriterTest.kt
+++ b/src/test/kotlin/com/zepben/evolve/database/sqlite/metrics/MetricsDatabaseWriterTest.kt
@@ -8,13 +8,21 @@
 
 package com.zepben.evolve.database.sqlite.metrics
 
+import com.zepben.evolve.metrics.IngestionJob
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
 import org.hamcrest.MatcherAssert.assertThat
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import java.nio.file.Path
+import java.util.*
+import kotlin.io.path.exists
 
 internal class MetricsDatabaseWriterTest {
+
+    @TempDir
+    lateinit var modelPath: Path
 
     private val writer = mockk<MetricsWriter> {
         every { save() } returns true
@@ -29,6 +37,22 @@ internal class MetricsDatabaseWriterTest {
         ).saveSchema()
 
         assertThat("Should have saved successfully", result)
+
+        verify { writer.save() }
+    }
+
+    @Test
+    internal fun createsJobIdFile() {
+        val uuid = UUID.randomUUID()
+
+        MetricsDatabaseWriter(
+            "databaseFile",
+            IngestionJob(uuid),
+            metricsWriter = writer,
+            modelPath = modelPath
+        ).saveSchema()
+
+        assertThat("Job ID file should exist", modelPath.resolve(uuid.toString()).exists())
 
         verify { writer.save() }
     }

--- a/src/test/kotlin/com/zepben/evolve/metrics/NetworkContainerMetricsTest.kt
+++ b/src/test/kotlin/com/zepben/evolve/metrics/NetworkContainerMetricsTest.kt
@@ -17,7 +17,7 @@ internal class NetworkContainerMetricsTest {
     @Test
     internal fun plus() {
         val ncMetrics = NetworkContainerMetrics()
-            .plus("a")
+            .plus("a", 1)
             .plus("b", 2.5)
             .plus("c", 0)
             .plus("d", -3.3)
@@ -26,7 +26,7 @@ internal class NetworkContainerMetricsTest {
 
     @Test
     internal fun plusExisting() {
-        val ncMetrics = NetworkContainerMetrics(mutableMapOf("a" to 1.0)).plus("a")
+        val ncMetrics = NetworkContainerMetrics(mutableMapOf("a" to 1.0)).plus("a", 1)
         assertThat(ncMetrics["a"], equalTo(2.0))
         ncMetrics.plus("a", -2)
         assertThat(ncMetrics["a"], equalTo(0.0))

--- a/src/test/kotlin/com/zepben/evolve/metrics/NetworkContainerMetricsTest.kt
+++ b/src/test/kotlin/com/zepben/evolve/metrics/NetworkContainerMetricsTest.kt
@@ -1,0 +1,38 @@
+package com.zepben.evolve.metrics
+
+import org.hamcrest.MatcherAssert
+import org.hamcrest.Matchers
+import org.junit.jupiter.api.Test
+
+internal class NetworkContainerMetricsTest {
+
+    @Test
+    internal fun increaseMissing() {
+        val ncMetrics = mutableMapOf<String, Double>()
+        MatcherAssert.assertThat(ncMetrics.increase("a"), Matchers.equalTo(1.0))
+        MatcherAssert.assertThat(ncMetrics.increase("b", 2.5), Matchers.equalTo(2.5))
+        MatcherAssert.assertThat(ncMetrics.increase("c", 0), Matchers.equalTo(0.0))
+        MatcherAssert.assertThat(ncMetrics.increase("d", -3.3), Matchers.equalTo(-3.3))
+        MatcherAssert.assertThat(ncMetrics, Matchers.equalTo(mapOf("a" to 1.0, "b" to 2.5, "c" to 0.0, "d" to -3.3)))
+    }
+
+    @Test
+    internal fun increaseExisting() {
+        val ncMetrics = mutableMapOf("a" to 1.0)
+        MatcherAssert.assertThat(ncMetrics.increase("a"), Matchers.equalTo(2.0))
+        MatcherAssert.assertThat(ncMetrics, Matchers.equalTo(mapOf("a" to 2.0)))
+        MatcherAssert.assertThat(ncMetrics.increase("a", -2), Matchers.equalTo(0.0))
+        MatcherAssert.assertThat(ncMetrics, Matchers.equalTo(mapOf("a" to 0.0)))
+        MatcherAssert.assertThat(ncMetrics.increase("a", 1.5), Matchers.equalTo(1.5))
+        MatcherAssert.assertThat(ncMetrics, Matchers.equalTo(mapOf("a" to 1.5)))
+    }
+
+    @Test
+    internal fun set() {
+        val ncMetrics = mutableMapOf("a" to 1.5)
+        ncMetrics["a"] = 3
+        ncMetrics["b"] = 5
+        MatcherAssert.assertThat(ncMetrics, Matchers.equalTo(mapOf("a" to 3.0, "b" to 5.0)))
+    }
+
+}

--- a/src/test/kotlin/com/zepben/evolve/metrics/NetworkContainerMetricsTest.kt
+++ b/src/test/kotlin/com/zepben/evolve/metrics/NetworkContainerMetricsTest.kt
@@ -8,8 +8,8 @@
 
 package com.zepben.evolve.metrics
 
-import org.hamcrest.MatcherAssert
-import org.hamcrest.Matchers
+import org.hamcrest.MatcherAssert.assertThat
+import org.hamcrest.Matchers.equalTo
 import org.junit.jupiter.api.Test
 
 internal class NetworkContainerMetricsTest {
@@ -17,22 +17,22 @@ internal class NetworkContainerMetricsTest {
     @Test
     internal fun increaseMissing() {
         val ncMetrics = mutableMapOf<String, Double>()
-        MatcherAssert.assertThat(ncMetrics.increase("a"), Matchers.equalTo(1.0))
-        MatcherAssert.assertThat(ncMetrics.increase("b", 2.5), Matchers.equalTo(2.5))
-        MatcherAssert.assertThat(ncMetrics.increase("c", 0), Matchers.equalTo(0.0))
-        MatcherAssert.assertThat(ncMetrics.increase("d", -3.3), Matchers.equalTo(-3.3))
-        MatcherAssert.assertThat(ncMetrics, Matchers.equalTo(mapOf("a" to 1.0, "b" to 2.5, "c" to 0.0, "d" to -3.3)))
+        assertThat(ncMetrics.increase("a"), equalTo(1.0))
+        assertThat(ncMetrics.increase("b", 2.5), equalTo(2.5))
+        assertThat(ncMetrics.increase("c", 0), equalTo(0.0))
+        assertThat(ncMetrics.increase("d", -3.3), equalTo(-3.3))
+        assertThat(ncMetrics, equalTo(mapOf("a" to 1.0, "b" to 2.5, "c" to 0.0, "d" to -3.3)))
     }
 
     @Test
     internal fun increaseExisting() {
         val ncMetrics = mutableMapOf("a" to 1.0)
-        MatcherAssert.assertThat(ncMetrics.increase("a"), Matchers.equalTo(2.0))
-        MatcherAssert.assertThat(ncMetrics, Matchers.equalTo(mapOf("a" to 2.0)))
-        MatcherAssert.assertThat(ncMetrics.increase("a", -2), Matchers.equalTo(0.0))
-        MatcherAssert.assertThat(ncMetrics, Matchers.equalTo(mapOf("a" to 0.0)))
-        MatcherAssert.assertThat(ncMetrics.increase("a", 1.5), Matchers.equalTo(1.5))
-        MatcherAssert.assertThat(ncMetrics, Matchers.equalTo(mapOf("a" to 1.5)))
+        assertThat(ncMetrics.increase("a"), equalTo(2.0))
+        assertThat(ncMetrics, equalTo(mapOf("a" to 2.0)))
+        assertThat(ncMetrics.increase("a", -2), equalTo(0.0))
+        assertThat(ncMetrics, equalTo(mapOf("a" to 0.0)))
+        assertThat(ncMetrics.increase("a", 1.5), equalTo(1.5))
+        assertThat(ncMetrics, equalTo(mapOf("a" to 1.5)))
     }
 
     @Test
@@ -40,7 +40,7 @@ internal class NetworkContainerMetricsTest {
         val ncMetrics = mutableMapOf("a" to 1.5)
         ncMetrics["a"] = 3
         ncMetrics["b"] = 5
-        MatcherAssert.assertThat(ncMetrics, Matchers.equalTo(mapOf("a" to 3.0, "b" to 5.0)))
+        assertThat(ncMetrics, equalTo(mapOf("a" to 3.0, "b" to 5.0)))
     }
 
 }

--- a/src/test/kotlin/com/zepben/evolve/metrics/NetworkContainerMetricsTest.kt
+++ b/src/test/kotlin/com/zepben/evolve/metrics/NetworkContainerMetricsTest.kt
@@ -1,3 +1,11 @@
+/*
+ * Copyright 2024 Zeppelin Bend Pty Ltd
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
 package com.zepben.evolve.metrics
 
 import org.hamcrest.MatcherAssert

--- a/src/test/kotlin/com/zepben/evolve/metrics/NetworkContainerMetricsTest.kt
+++ b/src/test/kotlin/com/zepben/evolve/metrics/NetworkContainerMetricsTest.kt
@@ -15,29 +15,43 @@ import org.junit.jupiter.api.Test
 internal class NetworkContainerMetricsTest {
 
     @Test
-    internal fun increaseMissing() {
-        val ncMetrics = mutableMapOf<String, Double>()
-        assertThat(ncMetrics.increase("a"), equalTo(1.0))
-        assertThat(ncMetrics.increase("b", 2.5), equalTo(2.5))
-        assertThat(ncMetrics.increase("c", 0), equalTo(0.0))
-        assertThat(ncMetrics.increase("d", -3.3), equalTo(-3.3))
+    internal fun plus() {
+        val ncMetrics = NetworkContainerMetrics()
+            .plus("a")
+            .plus("b", 2.5)
+            .plus("c", 0)
+            .plus("d", -3.3)
         assertThat(ncMetrics, equalTo(mapOf("a" to 1.0, "b" to 2.5, "c" to 0.0, "d" to -3.3)))
     }
 
     @Test
-    internal fun increaseExisting() {
-        val ncMetrics = mutableMapOf("a" to 1.0)
-        assertThat(ncMetrics.increase("a"), equalTo(2.0))
-        assertThat(ncMetrics, equalTo(mapOf("a" to 2.0)))
-        assertThat(ncMetrics.increase("a", -2), equalTo(0.0))
-        assertThat(ncMetrics, equalTo(mapOf("a" to 0.0)))
-        assertThat(ncMetrics.increase("a", 1.5), equalTo(1.5))
+    internal fun plusExisting() {
+        val ncMetrics = NetworkContainerMetrics(mutableMapOf("a" to 1.0)).plus("a")
+        assertThat(ncMetrics["a"], equalTo(2.0))
+        ncMetrics.plus("a", -2)
+        assertThat(ncMetrics["a"], equalTo(0.0))
+        ncMetrics.plus("a", 1.5)
+        assertThat(ncMetrics["a"], equalTo(1.5))
         assertThat(ncMetrics, equalTo(mapOf("a" to 1.5)))
     }
 
     @Test
+    internal fun inc() {
+        val ncMetrics = NetworkContainerMetrics().inc("a")
+
+        assertThat(ncMetrics, equalTo(mapOf("a" to 1.0)))
+    }
+
+    @Test
+    internal fun incExisting() {
+        val ncMetrics = NetworkContainerMetrics(mutableMapOf("a" to 1.5)).inc("a")
+
+        assertThat(ncMetrics, equalTo(mapOf("a" to 2.5)))
+    }
+
+    @Test
     internal fun set() {
-        val ncMetrics = mutableMapOf("a" to 1.5)
+        val ncMetrics = NetworkContainerMetrics(mutableMapOf("a" to 1.5))
         ncMetrics["a"] = 3
         ncMetrics["b"] = 5
         assertThat(ncMetrics, equalTo(mapOf("a" to 3.0, "b" to 5.0)))

--- a/src/test/kotlin/com/zepben/evolve/metrics/NetworkContainerMetricsTest.kt
+++ b/src/test/kotlin/com/zepben/evolve/metrics/NetworkContainerMetricsTest.kt
@@ -54,7 +54,8 @@ internal class NetworkContainerMetricsTest {
         val ncMetrics = NetworkContainerMetrics(mutableMapOf("a" to 1.5))
         ncMetrics["a"] = 3
         ncMetrics["b"] = 5
-        assertThat(ncMetrics, equalTo(mapOf("a" to 3.0, "b" to 5.0)))
+        ncMetrics["c"] = 1.23
+        assertThat(ncMetrics, equalTo(mapOf("a" to 3.0, "b" to 5.0, "c" to 1.23)))
     }
 
 }

--- a/src/test/kotlin/com/zepben/evolve/services/network/tracing/CoreTraceTest.kt
+++ b/src/test/kotlin/com/zepben/evolve/services/network/tracing/CoreTraceTest.kt
@@ -89,7 +89,7 @@ internal class CoreTraceTest {
         // Test from partway downstream to make sure we don't go upstream
         start = n["j1"]!!
         visited = normalDownstreamTrace(start, SinglePhaseKind.A)
-        var visitedMRIDs = visited.map { it.conductingEquipment.mRID }
+        val visitedMRIDs = visited.map { it.conductingEquipment.mRID }
         assertThat(visited, hasSize(4))
         assertThat(visited, hasItems(createResultItem(n, "j1", SinglePhaseKind.A), createResultItem(n, "j2", SinglePhaseKind.A)))
         assertThat(visitedMRIDs, not(contains("acLineSegment1")))


### PR DESCRIPTION
# Description

See title. File is created in the folder specified in an additional constructor arg for `MetricsDatabaseWriter` (ideally one holding the network, customer, and diagram databases)

# Associated tasks

Tasks blocking this one:
- None

Tasks this is blocking:
- Use this feature in ingestors

# Test Steps

To use this feature in an ingestor, edit the `MetricsDatabaseWriter` constructor to include the path of the model directory (most likely provided by a `EwbDataFilePaths` instance):
```
val ewbDataFilePaths = EwbDataFilePaths(Path.of("/path/to/ewb-data"))
val today = LocalDate.now()
val modelPath = ewbDataFilePaths.createDirectories(today)
val ingestionJob = IngestionJob(UUID.randomUUID())

// fill ingestion job with metrics...

val metricsDatabaseWriter = MetricsDatabaseWriter(
    ewbDataFilePaths.metrics(),
    ingestionJob,
    modelPath
)
metricsDatabaseWriter.save()
// there should now be a file at /path/to/ewb-data/<today's date>/<job UUID>.zjid
```

# Checklist

If any of these are not applicable, strikethrough the line `~like this~`. **Do not delete it!**. Let the reviewer decide if you should have done it.

### Code
- [x] I have performed a self review of my own code (including checking issues raised when creating the PR).
- [x] I have added/updated unit tests for these changes, and if not I have explained why they are not necessary.
- [x] I have commented my code in any hard-to-understand or hacky areas.
- [x] I have handled all new warnings generated by the compiler or IDE.
- [x] I have rebased onto the target branch (usually main).

### Documentation
- [x] I have updated the changelog.
- [x] I have updated any documentation required for these changes.

# Breaking Changes
- [x] I have considered if this is a breaking change and will communicate it with other team members if so.

No breaking changes.
