### PR TITLE
[DEV-1534] `Switch.ratedCurrent` and `SynchronousMachine.reactiveCapabilityCurveMRIDs` fixes

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -21,6 +21,8 @@
 *  Refactored `EwbDataFilePaths`: 
   * The `EwbDataFilePaths` class has been refactored into an interface to enhance flexibility and abstraction. 
   * A new class, `LocalEwbDataFilePaths`, has been introduced to specifically handle the resolution of database paths for the local file system.
+* `Switch.ratedCurrent` has been converted to a `double` (used to be an `integer`). Type safe languages will need to be updated to support floating point
+  arithmatic/syntax.
 
 ### New Features
 * A file named after the ID of an ingestion job is now created when running `MetricsDatabaseWriter.save()`. For this feature to take effect, a `modelPath` must

--- a/changelog.md
+++ b/changelog.md
@@ -42,7 +42,7 @@
     * `ReactiveCapabilityCurve`
     * `RotatingMachine`
     * `SynchronousMachine`
-* The evolve-grpc version now includes the failure opendss report type.
+* Added `OpenDssReportBatch` and a new `failure` OpenDSS report type to the hosting capacity API.
 
 ### Enhancements
 * Added feature list in documentation.

--- a/pom.xml
+++ b/pom.xml
@@ -74,7 +74,7 @@
         <dependency>
             <groupId>com.zepben.protobuf</groupId>
             <artifactId>evolve-grpc</artifactId>
-            <version>0.31.0-SNAPSHOT5</version>
+            <version>0.31.0-SNAPSHOT6</version>
         </dependency>
 
         <dependency>

--- a/src/main/kotlin/com/zepben/evolve/cim/iec61970/base/wires/Switch.kt
+++ b/src/main/kotlin/com/zepben/evolve/cim/iec61970/base/wires/Switch.kt
@@ -29,7 +29,7 @@ abstract class Switch(mRID: String = "") : ConductingEquipment(mRID) {
 
     override var assetInfo: SwitchInfo? = null
 
-    var ratedCurrent: Int? = null
+    var ratedCurrent: Double? = null
     internal var normalOpen: Int = 0
     internal var open: Int = 0
 

--- a/src/main/kotlin/com/zepben/evolve/database/sqlite/cim/network/NetworkCimReader.kt
+++ b/src/main/kotlin/com/zepben/evolve/database/sqlite/cim/network/NetworkCimReader.kt
@@ -2282,7 +2282,7 @@ class NetworkCimReader(
     private fun loadSwitch(switch: Switch, table: TableSwitches, resultSet: ResultSet): Boolean {
         switch.apply {
             assetInfo = service.ensureGet(resultSet.getNullableString(table.SWITCH_INFO_MRID.queryIndex), typeNameAndMRID())
-            ratedCurrent = resultSet.getNullableInt(table.RATED_CURRENT.queryIndex)
+            ratedCurrent = resultSet.getNullableDouble(table.RATED_CURRENT.queryIndex)
             normalOpen = resultSet.getInt(table.NORMAL_OPEN.queryIndex)
             open = resultSet.getInt(table.OPEN.queryIndex)
         }

--- a/src/main/kotlin/com/zepben/evolve/database/sqlite/cim/network/NetworkCimWriter.kt
+++ b/src/main/kotlin/com/zepben/evolve/database/sqlite/cim/network/NetworkCimWriter.kt
@@ -2082,7 +2082,7 @@ class NetworkCimWriter(
     private fun saveSwitch(table: TableSwitches, insert: PreparedStatement, switch: Switch, description: String): Boolean {
         insert.setInt(table.NORMAL_OPEN.queryIndex, switch.normalOpen)
         insert.setInt(table.OPEN.queryIndex, switch.open)
-        insert.setNullableInt(table.RATED_CURRENT.queryIndex, switch.ratedCurrent)
+        insert.setNullableDouble(table.RATED_CURRENT.queryIndex, switch.ratedCurrent)
         insert.setNullableString(table.SWITCH_INFO_MRID.queryIndex, switch.assetInfo?.mRID)
 
         return saveConductingEquipment(table, insert, switch, description)

--- a/src/main/kotlin/com/zepben/evolve/database/sqlite/cim/tables/TableCimVersion.kt
+++ b/src/main/kotlin/com/zepben/evolve/database/sqlite/cim/tables/TableCimVersion.kt
@@ -13,4 +13,4 @@ import com.zepben.evolve.database.sqlite.common.TableVersion
 /**
  * The `version` table in the CIM databases. Increment this when doing a schema update.
  */
-val tableCimVersion: TableVersion = TableVersion(55)
+val tableCimVersion: TableVersion = TableVersion(56)

--- a/src/main/kotlin/com/zepben/evolve/database/sqlite/cim/tables/iec61970/base/wires/TableSwitches.kt
+++ b/src/main/kotlin/com/zepben/evolve/database/sqlite/cim/tables/iec61970/base/wires/TableSwitches.kt
@@ -13,12 +13,20 @@ import com.zepben.evolve.database.sqlite.cim.tables.Column.Nullable.NOT_NULL
 import com.zepben.evolve.database.sqlite.cim.tables.Column.Nullable.NULL
 import com.zepben.evolve.database.sqlite.cim.tables.iec61970.base.core.TableConductingEquipment
 
+/**
+ * A class representing the Switch columns required for the database table.
+ *
+ * @property NORMAL_OPEN A column storing the normally open state of the switch.
+ * @property OPEN A column storing the currently open state of the switch.
+ * @property RATED_CURRENT A column storing the rated current of the switch.
+ * @property SWITCH_INFO_MRID A column storing the mRID of the catalog information for this switch.
+ */
 @Suppress("PropertyName")
 abstract class TableSwitches : TableConductingEquipment() {
 
     val NORMAL_OPEN: Column = Column(++columnIndex, "normal_open", "INTEGER", NOT_NULL)
     val OPEN: Column = Column(++columnIndex, "open", "INTEGER", NOT_NULL)
-    val RATED_CURRENT: Column = Column(++columnIndex, "rated_current", "INTEGER", NULL)
+    val RATED_CURRENT: Column = Column(++columnIndex, "rated_current", "NUMBER", NULL)
     val SWITCH_INFO_MRID: Column = Column(++columnIndex, "switch_info_mrid", "TEXT", NULL)
 
 }

--- a/src/main/kotlin/com/zepben/evolve/database/sqlite/cim/upgrade/UpgradeRunner.kt
+++ b/src/main/kotlin/com/zepben/evolve/database/sqlite/cim/upgrade/UpgradeRunner.kt
@@ -40,7 +40,8 @@ class UpgradeRunner @JvmOverloads constructor(
         changeSet52(),
         changeSet53(),
         changeSet54(),
-        changeSet55()
+        changeSet55(),
+        changeSet56()
     ),
     private val tableVersion: TableVersion = tableCimVersion
 ) {

--- a/src/main/kotlin/com/zepben/evolve/database/sqlite/cim/upgrade/changesets/ChangeSet56.kt
+++ b/src/main/kotlin/com/zepben/evolve/database/sqlite/cim/upgrade/changesets/ChangeSet56.kt
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2024 Zeppelin Bend Pty Ltd
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+package com.zepben.evolve.database.sqlite.cim.upgrade.changesets
+
+import com.zepben.evolve.database.paths.DatabaseType
+import com.zepben.evolve.database.sqlite.cim.upgrade.Change
+import com.zepben.evolve.database.sqlite.cim.upgrade.ChangeSet
+
+internal fun changeSet56() = ChangeSet(
+    56,
+    listOf(
+        // Network Changes.
+        `Change switch rated_current to float`,
+    )
+)
+
+// ###################
+// # Network Changes #
+// ###################
+
+@Suppress("ObjectPropertyName")
+private val `Change switch rated_current to float` = Change(
+    listOf(
+        "breakers",
+        "disconnectors",
+        "fuses",
+        "ground_disconnectors",
+        "jumpers",
+        "load_break_switches",
+        "reclosers",
+    ).flatMap { table ->
+        listOf(
+            "ALTER TABLE $table ADD COLUMN new_rated_current NUMBER NULL DEFAULT NULL;",
+            "UPDATE $table SET new_rated_current = rated_current * 1.0 where rated_current IS NOT NULL;",
+            "ALTER TABLE $table DROP COLUMN rated_current;",
+            "ALTER TABLE $table RENAME COLUMN new_rated_current TO rated_current;",
+        )
+    },
+    targetDatabases = setOf(DatabaseType.NETWORK_MODEL)
+)

--- a/src/main/kotlin/com/zepben/evolve/services/network/translator/NetworkCimToProto.kt
+++ b/src/main/kotlin/com/zepben/evolve/services/network/translator/NetworkCimToProto.kt
@@ -186,11 +186,27 @@ import com.zepben.protobuf.cim.iec61970.infiec61970.feeder.LvFeeder as PBLvFeede
 import com.zepben.protobuf.cim.iec61970.infiec61970.protection.ProtectionKind as PBProtectionKind
 import com.zepben.protobuf.cim.iec61970.infiec61970.wires.generation.production.EvChargingUnit as PBEvChargingUnit
 
-/************ IEC61968 ASSET INFO ************/
+// #######################
+// # IEC61968 ASSET INFO #
+// #######################
 
+/**
+ * Convert the [CableInfo] into its protobuf counterpart.
+ *
+ * @param cim The [CableInfo] to convert.
+ * @param pb The protobuf builder to populate.
+ * @return [pb] for fluent use.
+ */
 fun toPb(cim: CableInfo, pb: PBCableInfo.Builder): PBCableInfo.Builder =
     pb.apply { toPb(cim, wiBuilder) }
 
+/**
+ * Convert the [NoLoadTest] into its protobuf counterpart.
+ *
+ * @param cim The [NoLoadTest] to convert.
+ * @param pb The protobuf builder to populate.
+ * @return [pb] for fluent use.
+ */
 fun toPb(cim: NoLoadTest, pb: PBNoLoadTest.Builder): PBNoLoadTest.Builder =
     pb.apply {
         energisedEndVoltage = cim.energisedEndVoltage ?: UNKNOWN_INT
@@ -201,6 +217,13 @@ fun toPb(cim: NoLoadTest, pb: PBNoLoadTest.Builder): PBNoLoadTest.Builder =
         toPb(cim, ttBuilder)
     }
 
+/**
+ * Convert the [OpenCircuitTest] into its protobuf counterpart.
+ *
+ * @param cim The [OpenCircuitTest] to convert.
+ * @param pb The protobuf builder to populate.
+ * @return [pb] for fluent use.
+ */
 fun toPb(cim: OpenCircuitTest, pb: PBOpenCircuitTest.Builder): PBOpenCircuitTest.Builder =
     pb.apply {
         energisedEndStep = cim.energisedEndStep ?: UNKNOWN_INT
@@ -211,9 +234,23 @@ fun toPb(cim: OpenCircuitTest, pb: PBOpenCircuitTest.Builder): PBOpenCircuitTest
         toPb(cim, ttBuilder)
     }
 
+/**
+ * Convert the [OverheadWireInfo] into its protobuf counterpart.
+ *
+ * @param cim The [OverheadWireInfo] to convert.
+ * @param pb The protobuf builder to populate.
+ * @return [pb] for fluent use.
+ */
 fun toPb(cim: OverheadWireInfo, pb: PBOverheadWireInfo.Builder): PBOverheadWireInfo.Builder =
     pb.apply { toPb(cim, wiBuilder) }
 
+/**
+ * Convert the [PowerTransformerInfo] into its protobuf counterpart.
+ *
+ * @param cim The [PowerTransformerInfo] to convert.
+ * @param pb The protobuf builder to populate.
+ * @return [pb] for fluent use.
+ */
 fun toPb(cim: PowerTransformerInfo, pb: PBPowerTransformerInfo.Builder): PBPowerTransformerInfo.Builder =
     pb.apply {
         clearTransformerTankInfoMRIDs()
@@ -221,6 +258,13 @@ fun toPb(cim: PowerTransformerInfo, pb: PBPowerTransformerInfo.Builder): PBPower
         toPb(cim, aiBuilder)
     }
 
+/**
+ * Convert the [ShortCircuitTest] into its protobuf counterpart.
+ *
+ * @param cim The [ShortCircuitTest] to convert.
+ * @param pb The protobuf builder to populate.
+ * @return [pb] for fluent use.
+ */
 fun toPb(cim: ShortCircuitTest, pb: PBShortCircuitTest.Builder): PBShortCircuitTest.Builder =
     pb.apply {
         current = cim.current ?: UNKNOWN_DOUBLE
@@ -236,6 +280,13 @@ fun toPb(cim: ShortCircuitTest, pb: PBShortCircuitTest.Builder): PBShortCircuitT
         toPb(cim, ttBuilder)
     }
 
+/**
+ * Convert the [ShuntCompensatorInfo] into its protobuf counterpart.
+ *
+ * @param cim The [ShuntCompensatorInfo] to convert.
+ * @param pb The protobuf builder to populate.
+ * @return [pb] for fluent use.
+ */
 fun toPb(cim: ShuntCompensatorInfo, pb: PBShuntCompensatorInfo.Builder): PBShuntCompensatorInfo.Builder =
     pb.apply {
         maxPowerLoss = cim.maxPowerLoss ?: UNKNOWN_INT
@@ -246,12 +297,26 @@ fun toPb(cim: ShuntCompensatorInfo, pb: PBShuntCompensatorInfo.Builder): PBShunt
         toPb(cim, aiBuilder)
     }
 
+/**
+ * Convert the [SwitchInfo] into its protobuf counterpart.
+ *
+ * @param cim The [SwitchInfo] to convert.
+ * @param pb The protobuf builder to populate.
+ * @return [pb] for fluent use.
+ */
 fun toPb(cim: SwitchInfo, pb: PBSwitchInfo.Builder): PBSwitchInfo.Builder =
     pb.apply {
         ratedInterruptingTime = cim.ratedInterruptingTime ?: UNKNOWN_DOUBLE
         toPb(cim, aiBuilder)
     }
 
+/**
+ * Convert the [TransformerEndInfo] into its protobuf counterpart.
+ *
+ * @param cim The [TransformerEndInfo] to convert.
+ * @param pb The protobuf builder to populate.
+ * @return [pb] for fluent use.
+ */
 fun toPb(cim: TransformerEndInfo, pb: PBTransformerEndInfo.Builder): PBTransformerEndInfo.Builder =
     pb.apply {
         connectionKind = WindingConnection.valueOf(cim.connectionKind.name)
@@ -275,6 +340,13 @@ fun toPb(cim: TransformerEndInfo, pb: PBTransformerEndInfo.Builder): PBTransform
         toPb(cim, aiBuilder)
     }
 
+/**
+ * Convert the [TransformerTankInfo] into its protobuf counterpart.
+ *
+ * @param cim The [TransformerTankInfo] to convert.
+ * @param pb The protobuf builder to populate.
+ * @return [pb] for fluent use.
+ */
 fun toPb(cim: TransformerTankInfo, pb: PBTransformerTankInfo.Builder): PBTransformerTankInfo.Builder =
     pb.apply {
         cim.powerTransformerInfo?.let { powerTransformerInfoMRID = it.mRID } ?: clearPowerTransformerInfoMRID()
@@ -283,6 +355,13 @@ fun toPb(cim: TransformerTankInfo, pb: PBTransformerTankInfo.Builder): PBTransfo
         toPb(cim, aiBuilder)
     }
 
+/**
+ * Convert the [TransformerTest] into its protobuf counterpart.
+ *
+ * @param cim The [TransformerTest] to convert.
+ * @param pb The protobuf builder to populate.
+ * @return [pb] for fluent use.
+ */
 fun toPb(cim: TransformerTest, pb: PBTransformerTest.Builder): PBTransformerTest.Builder =
     pb.apply {
         basePower = cim.basePower ?: UNKNOWN_INT
@@ -290,6 +369,13 @@ fun toPb(cim: TransformerTest, pb: PBTransformerTest.Builder): PBTransformerTest
         toPb(cim, ioBuilder)
     }
 
+/**
+ * Convert the [WireInfo] into its protobuf counterpart.
+ *
+ * @param cim The [WireInfo] to convert.
+ * @param pb The protobuf builder to populate.
+ * @return [pb] for fluent use.
+ */
 fun toPb(cim: WireInfo, pb: PBWireInfo.Builder): PBWireInfo.Builder =
     pb.apply {
         ratedCurrent = cim.ratedCurrent ?: UNKNOWN_INT
@@ -297,19 +383,67 @@ fun toPb(cim: WireInfo, pb: PBWireInfo.Builder): PBWireInfo.Builder =
         toPb(cim, aiBuilder)
     }
 
+/**
+ * An extension for converting any CableInfo into its protobuf counterpart.
+ */
 fun CableInfo.toPb(): PBCableInfo = toPb(this, PBCableInfo.newBuilder()).build()
+
+/**
+ * An extension for converting any NoLoadTest into its protobuf counterpart.
+ */
 fun NoLoadTest.toPb(): PBNoLoadTest = toPb(this, PBNoLoadTest.newBuilder()).build()
+
+/**
+ * An extension for converting any OpenCircuitTest into its protobuf counterpart.
+ */
 fun OpenCircuitTest.toPb(): PBOpenCircuitTest = toPb(this, PBOpenCircuitTest.newBuilder()).build()
+
+/**
+ * An extension for converting any OverheadWireInfo into its protobuf counterpart.
+ */
 fun OverheadWireInfo.toPb(): PBOverheadWireInfo = toPb(this, PBOverheadWireInfo.newBuilder()).build()
+
+/**
+ * An extension for converting any PowerTransformerInfo into its protobuf counterpart.
+ */
 fun PowerTransformerInfo.toPb(): PBPowerTransformerInfo = toPb(this, PBPowerTransformerInfo.newBuilder()).build()
+
+/**
+ * An extension for converting any ShortCircuitTest into its protobuf counterpart.
+ */
 fun ShortCircuitTest.toPb(): PBShortCircuitTest = toPb(this, PBShortCircuitTest.newBuilder()).build()
+
+/**
+ * An extension for converting any ShuntCompensatorInfo into its protobuf counterpart.
+ */
 fun ShuntCompensatorInfo.toPb(): PBShuntCompensatorInfo = toPb(this, PBShuntCompensatorInfo.newBuilder()).build()
+
+/**
+ * An extension for converting any SwitchInfo into its protobuf counterpart.
+ */
 fun SwitchInfo.toPb(): PBSwitchInfo = toPb(this, PBSwitchInfo.newBuilder()).build()
+
+/**
+ * An extension for converting any TransformerEndInfo into its protobuf counterpart.
+ */
 fun TransformerEndInfo.toPb(): PBTransformerEndInfo = toPb(this, PBTransformerEndInfo.newBuilder()).build()
+
+/**
+ * An extension for converting any TransformerTankInfo into its protobuf counterpart.
+ */
 fun TransformerTankInfo.toPb(): PBTransformerTankInfo = toPb(this, PBTransformerTankInfo.newBuilder()).build()
 
-/************ IEC61968 ASSETS ************/
+// ###################
+// # IEC61968 ASSETS #
+// ###################
 
+/**
+ * Convert the [Asset] into its protobuf counterpart.
+ *
+ * @param cim The [Asset] to convert.
+ * @param pb The protobuf builder to populate.
+ * @return [pb] for fluent use.
+ */
 fun toPb(cim: Asset, pb: PBAsset.Builder): PBAsset.Builder =
     pb.apply {
         cim.location?.let { locationMRID = it.mRID } ?: clearLocationMRID()
@@ -318,18 +452,53 @@ fun toPb(cim: Asset, pb: PBAsset.Builder): PBAsset.Builder =
         toPb(cim, ioBuilder)
     }
 
+/**
+ * Convert the [AssetContainer] into its protobuf counterpart.
+ *
+ * @param cim The [AssetContainer] to convert.
+ * @param pb The protobuf builder to populate.
+ * @return [pb] for fluent use.
+ */
 fun toPb(cim: AssetContainer, pb: PBAssetContainer.Builder): PBAssetContainer.Builder =
     pb.apply { toPb(cim, atBuilder) }
 
+/**
+ * Convert the [AssetInfo] into its protobuf counterpart.
+ *
+ * @param cim The [AssetInfo] to convert.
+ * @param pb The protobuf builder to populate.
+ * @return [pb] for fluent use.
+ */
 fun toPb(cim: AssetInfo, pb: PBAssetInfo.Builder): PBAssetInfo.Builder =
     pb.apply { toPb(cim, ioBuilder) }
 
+/**
+ * Convert the [AssetOrganisationRole] into its protobuf counterpart.
+ *
+ * @param cim The [AssetOrganisationRole] to convert.
+ * @param pb The protobuf builder to populate.
+ * @return [pb] for fluent use.
+ */
 fun toPb(cim: AssetOrganisationRole, pb: PBAssetOrganisationRole.Builder): PBAssetOrganisationRole.Builder =
     pb.apply { toPb(cim, orBuilder) }
 
+/**
+ * Convert the [AssetOwner] into its protobuf counterpart.
+ *
+ * @param cim The [AssetOwner] to convert.
+ * @param pb The protobuf builder to populate.
+ * @return [pb] for fluent use.
+ */
 fun toPb(cim: AssetOwner, pb: PBAssetOwner.Builder): PBAssetOwner.Builder =
     pb.apply { toPb(cim, aorBuilder) }
 
+/**
+ * Convert the [Pole] into its protobuf counterpart.
+ *
+ * @param cim The [Pole] to convert.
+ * @param pb The protobuf builder to populate.
+ * @return [pb] for fluent use.
+ */
 fun toPb(cim: Pole, pb: PBPole.Builder): PBPole.Builder =
     pb.apply {
         classification = cim.classification
@@ -338,6 +507,13 @@ fun toPb(cim: Pole, pb: PBPole.Builder): PBPole.Builder =
         toPb(cim, stBuilder)
     }
 
+/**
+ * Convert the [Streetlight] into its protobuf counterpart.
+ *
+ * @param cim The [Streetlight] to convert.
+ * @param pb The protobuf builder to populate.
+ * @return [pb] for fluent use.
+ */
 fun toPb(cim: Streetlight, pb: PBStreetlight.Builder): PBStreetlight.Builder =
     pb.apply {
         lightRating = cim.lightRating ?: UNKNOWN_UINT
@@ -346,15 +522,42 @@ fun toPb(cim: Streetlight, pb: PBStreetlight.Builder): PBStreetlight.Builder =
         toPb(cim, atBuilder)
     }
 
+/**
+ * Convert the [Structure] into its protobuf counterpart.
+ *
+ * @param cim The [Structure] to convert.
+ * @param pb The protobuf builder to populate.
+ * @return [pb] for fluent use.
+ */
 fun toPb(cim: Structure, pb: PBStructure.Builder): PBStructure.Builder =
     pb.apply { toPb(cim, acBuilder) }
 
+/**
+ * An extension for converting any AssetOwner into its protobuf counterpart.
+ */
 fun AssetOwner.toPb(): PBAssetOwner = toPb(this, PBAssetOwner.newBuilder()).build()
+
+/**
+ * An extension for converting any Pole into its protobuf counterpart.
+ */
 fun Pole.toPb(): PBPole = toPb(this, PBPole.newBuilder()).build()
+
+/**
+ * An extension for converting any Streetlight into its protobuf counterpart.
+ */
 fun Streetlight.toPb(): PBStreetlight = toPb(this, PBStreetlight.newBuilder()).build()
 
-/************ IEC61968 COMMON ************/
+// ###################
+// # IEC61968 COMMON #
+// ###################
 
+/**
+ * Convert the [Location] into its protobuf counterpart.
+ *
+ * @param cim The [Location] to convert.
+ * @param pb The protobuf builder to populate.
+ * @return [pb] for fluent use.
+ */
 fun toPb(cim: Location, pb: PBLocation.Builder): PBLocation.Builder =
     pb.apply {
         cim.mainAddress?.let { toPb(it, mainAddressBuilder) } ?: clearMainAddress()
@@ -363,12 +566,26 @@ fun toPb(cim: Location, pb: PBLocation.Builder): PBLocation.Builder =
         toPb(cim, ioBuilder)
     }
 
+/**
+ * Convert the [PositionPoint] into its protobuf counterpart.
+ *
+ * @param cim The [PositionPoint] to convert.
+ * @param pb The protobuf builder to populate.
+ * @return [pb] for fluent use.
+ */
 fun toPb(cim: PositionPoint, pb: PBPositionPoint.Builder): PBPositionPoint.Builder =
     pb.apply {
         xPosition = cim.xPosition
         yPosition = cim.yPosition
     }
 
+/**
+ * Convert the [StreetAddress] into its protobuf counterpart.
+ *
+ * @param cim The [StreetAddress] to convert.
+ * @param pb The protobuf builder to populate.
+ * @return [pb] for fluent use.
+ */
 fun toPb(cim: StreetAddress, pb: PBStreetAddress.Builder): PBStreetAddress.Builder =
     pb.apply {
         postalCode = cim.postalCode
@@ -377,6 +594,13 @@ fun toPb(cim: StreetAddress, pb: PBStreetAddress.Builder): PBStreetAddress.Build
         cim.streetDetail?.let { toPb(it, streetDetailBuilder) } ?: clearStreetDetail()
     }
 
+/**
+ * Convert the [StreetDetail] into its protobuf counterpart.
+ *
+ * @param cim The [StreetDetail] to convert.
+ * @param pb The protobuf builder to populate.
+ * @return [pb] for fluent use.
+ */
 fun toPb(cim: StreetDetail, pb: PBStreetDetail.Builder): PBStreetDetail.Builder =
     pb.apply {
         buildingName = cim.buildingName
@@ -388,16 +612,35 @@ fun toPb(cim: StreetDetail, pb: PBStreetDetail.Builder): PBStreetDetail.Builder 
         displayAddress = cim.displayAddress
     }
 
+/**
+ * Convert the [TownDetail] into its protobuf counterpart.
+ *
+ * @param cim The [TownDetail] to convert.
+ * @param pb The protobuf builder to populate.
+ * @return [pb] for fluent use.
+ */
 fun toPb(cim: TownDetail, pb: PBTownDetail.Builder): PBTownDetail.Builder =
     pb.apply {
         cim.name?.let { name = it } ?: clearName()
         cim.stateOrProvince?.let { stateOrProvince = it } ?: clearStateOrProvince()
     }
 
+/**
+ * An extension for converting any Location into its protobuf counterpart.
+ */
 fun Location.toPb(): PBLocation = toPb(this, PBLocation.newBuilder()).build()
 
-/************ IEC61968 infIEC61968 InfAssetInfo ************/
+// #####################################
+// # IEC61968 infIEC61968 InfAssetInfo #
+// #####################################
 
+/**
+ * Convert the [CurrentTransformerInfo] into its protobuf counterpart.
+ *
+ * @param cim The [CurrentTransformerInfo] to convert.
+ * @param pb The protobuf builder to populate.
+ * @return [pb] for fluent use.
+ */
 fun toPb(cim: CurrentTransformerInfo, pb: PBCurrentTransformerInfo.Builder): PBCurrentTransformerInfo.Builder =
     pb.apply {
         cim.accuracyClass?.let { accuracyClass = it } ?: clearAccuracyClass()
@@ -415,6 +658,13 @@ fun toPb(cim: CurrentTransformerInfo, pb: PBCurrentTransformerInfo.Builder): PBC
         toPb(cim, aiBuilder)
     }
 
+/**
+ * Convert the [PotentialTransformerInfo] into its protobuf counterpart.
+ *
+ * @param cim The [PotentialTransformerInfo] to convert.
+ * @param pb The protobuf builder to populate.
+ * @return [pb] for fluent use.
+ */
 fun toPb(cim: PotentialTransformerInfo, pb: PBPotentialTransformerInfo.Builder): PBPotentialTransformerInfo.Builder =
     pb.apply {
         cim.accuracyClass?.let { accuracyClass = it } ?: clearAccuracyClass()
@@ -426,6 +676,13 @@ fun toPb(cim: PotentialTransformerInfo, pb: PBPotentialTransformerInfo.Builder):
         toPb(cim, aiBuilder)
     }
 
+/**
+ * Convert the [RelayInfo] into its protobuf counterpart.
+ *
+ * @param cim The [RelayInfo] to convert.
+ * @param pb The protobuf builder to populate.
+ * @return [pb] for fluent use.
+ */
 fun toPb(cim: RelayInfo, pb: PBRelayInfo.Builder): PBRelayInfo.Builder =
     pb.apply {
         cim.curveSetting?.let { curveSetting = it } ?: clearCurveSetting()
@@ -434,20 +691,49 @@ fun toPb(cim: RelayInfo, pb: PBRelayInfo.Builder): PBRelayInfo.Builder =
         toPb(cim, aiBuilder)
     }
 
+/**
+ * An extension for converting any CurrentTransformerInfo into its protobuf counterpart.
+ */
 fun CurrentTransformerInfo.toPb(): PBCurrentTransformerInfo = toPb(this, PBCurrentTransformerInfo.newBuilder()).build()
+
+/**
+ * An extension for converting any PotentialTransformerInfo into its protobuf counterpart.
+ */
 fun PotentialTransformerInfo.toPb(): PBPotentialTransformerInfo = toPb(this, PBPotentialTransformerInfo.newBuilder()).build()
+
+/**
+ * An extension for converting any RelayInfo into its protobuf counterpart.
+ */
 fun RelayInfo.toPb(): PBRelayInfo = toPb(this, PBRelayInfo.newBuilder()).build()
 
-/************ IEC61968 infIEC61968 InfCommon ************/
+// ##################################
+// # IEC61968 infIEC61968 InfCommon #
+// ##################################
 
+/**
+ * Convert the [Ratio] into its protobuf counterpart.
+ *
+ * @param cim The [Ratio] to convert.
+ * @param pb The protobuf builder to populate.
+ * @return [pb] for fluent use.
+ */
 fun toPb(cim: Ratio, pb: PBRatio.Builder): PBRatio.Builder =
     pb.apply {
         denominator = cim.denominator
         numerator = cim.numerator
     }
 
-/************ IEC61968 METERING ************/
+// #####################
+// # IEC61968 METERING #
+// #####################
 
+/**
+ * Convert the [EndDevice] into its protobuf counterpart.
+ *
+ * @param cim The [EndDevice] to convert.
+ * @param pb The protobuf builder to populate.
+ * @return [pb] for fluent use.
+ */
 fun toPb(cim: EndDevice, pb: PBEndDevice.Builder): PBEndDevice.Builder =
     pb.apply {
         clearUsagePointMRIDs()
@@ -457,11 +743,25 @@ fun toPb(cim: EndDevice, pb: PBEndDevice.Builder): PBEndDevice.Builder =
         toPb(cim, acBuilder)
     }
 
+/**
+ * Convert the [Meter] into its protobuf counterpart.
+ *
+ * @param cim The [Meter] to convert.
+ * @param pb The protobuf builder to populate.
+ * @return [pb] for fluent use.
+ */
 fun toPb(cim: Meter, pb: PBMeter.Builder): PBMeter.Builder =
     pb.apply {
         toPb(cim, edBuilder)
     }
 
+/**
+ * Convert the [UsagePoint] into its protobuf counterpart.
+ *
+ * @param cim The [UsagePoint] to convert.
+ * @param pb The protobuf builder to populate.
+ * @return [pb] for fluent use.
+ */
 fun toPb(cim: UsagePoint, pb: PBUsagePoint.Builder): PBUsagePoint.Builder =
     pb.apply {
         cim.usagePointLocation?.let { usagePointLocationMRID = it.mRID } ?: clearUsagePointLocationMRID()
@@ -477,60 +777,150 @@ fun toPb(cim: UsagePoint, pb: PBUsagePoint.Builder): PBUsagePoint.Builder =
         toPb(cim, ioBuilder)
     }
 
+/**
+ * An extension for converting any Meter into its protobuf counterpart.
+ */
 fun Meter.toPb(): PBMeter = toPb(this, PBMeter.newBuilder()).build()
+
+/**
+ * An extension for converting any UsagePoint into its protobuf counterpart.
+ */
 fun UsagePoint.toPb(): PBUsagePoint = toPb(this, PBUsagePoint.newBuilder()).build()
 
-/************ IEC61968 OPERATIONS ************/
+// #######################
+// # IEC61968 OPERATIONS #
+// #######################
 
+/**
+ * Convert the [OperationalRestriction] into its protobuf counterpart.
+ *
+ * @param cim The [OperationalRestriction] to convert.
+ * @param pb The protobuf builder to populate.
+ * @return [pb] for fluent use.
+ */
 fun toPb(cim: OperationalRestriction, pb: PBOperationalRestriction.Builder): PBOperationalRestriction.Builder =
     pb.apply { toPb(cim, docBuilder) }
 
+/**
+ * An extension for converting any OperationalRestriction into its protobuf counterpart.
+ */
 fun OperationalRestriction.toPb(): PBOperationalRestriction = toPb(this, PBOperationalRestriction.newBuilder()).build()
 
-/************ IEC61970 BASE AUXILIARY EQUIPMENT ************/
+// #####################################
+// # IEC61970 BASE AUXILIARY EQUIPMENT #
+// #####################################
 
+/**
+ * Convert the [AuxiliaryEquipment] into its protobuf counterpart.
+ *
+ * @param cim The [AuxiliaryEquipment] to convert.
+ * @param pb The protobuf builder to populate.
+ * @return [pb] for fluent use.
+ */
 fun toPb(cim: AuxiliaryEquipment, pb: PBAuxiliaryEquipment.Builder): PBAuxiliaryEquipment.Builder =
     pb.apply {
         cim.terminal?.let { terminalMRID = it.mRID } ?: clearTerminalMRID()
         toPb(cim, eqBuilder)
     }
 
+/**
+ * Convert the [CurrentTransformer] into its protobuf counterpart.
+ *
+ * @param cim The [CurrentTransformer] to convert.
+ * @param pb The protobuf builder to populate.
+ * @return [pb] for fluent use.
+ */
 fun toPb(cim: CurrentTransformer, pb: PBCurrentTransformer.Builder): PBCurrentTransformer.Builder =
     pb.apply {
         coreBurden = cim.coreBurden ?: UNKNOWN_INT
         toPb(cim, snBuilder)
     }
 
+/**
+ * Convert the [FaultIndicator] into its protobuf counterpart.
+ *
+ * @param cim The [FaultIndicator] to convert.
+ * @param pb The protobuf builder to populate.
+ * @return [pb] for fluent use.
+ */
 fun toPb(cim: FaultIndicator, pb: PBFaultIndicator.Builder): PBFaultIndicator.Builder =
     pb.apply { toPb(cim, aeBuilder) }
 
+/**
+ * Convert the [PotentialTransformer] into its protobuf counterpart.
+ *
+ * @param cim The [PotentialTransformer] to convert.
+ * @param pb The protobuf builder to populate.
+ * @return [pb] for fluent use.
+ */
 fun toPb(cim: PotentialTransformer, pb: PBPotentialTransformer.Builder): PBPotentialTransformer.Builder =
     pb.apply {
         type = PotentialTransformerKind.valueOf(cim.type.name)
         toPb(cim, snBuilder)
     }
 
+/**
+ * Convert the [Sensor] into its protobuf counterpart.
+ *
+ * @param cim The [Sensor] to convert.
+ * @param pb The protobuf builder to populate.
+ * @return [pb] for fluent use.
+ */
 fun toPb(cim: Sensor, pb: PBSensor.Builder): PBSensor.Builder =
     pb.apply {
         cim.relayFunctions.forEach { addRelayFunctionMRIDs(it.mRID) }
         toPb(cim, aeBuilder)
     }
 
+/**
+ * An extension for converting any CurrentTransformer into its protobuf counterpart.
+ */
 fun CurrentTransformer.toPb(): PBCurrentTransformer = toPb(this, PBCurrentTransformer.newBuilder()).build()
+
+/**
+ * An extension for converting any FaultIndicator into its protobuf counterpart.
+ */
 fun FaultIndicator.toPb(): PBFaultIndicator = toPb(this, PBFaultIndicator.newBuilder()).build()
+
+/**
+ * An extension for converting any PotentialTransformer into its protobuf counterpart.
+ */
 fun PotentialTransformer.toPb(): PBPotentialTransformer = toPb(this, PBPotentialTransformer.newBuilder()).build()
 
-/************ IEC61970 BASE CORE ************/
+// ######################
+// # IEC61970 BASE CORE #
+// ######################
 
+/**
+ * Convert the [AcDcTerminal] into its protobuf counterpart.
+ *
+ * @param cim The [AcDcTerminal] to convert.
+ * @param pb The protobuf builder to populate.
+ * @return [pb] for fluent use.
+ */
 fun toPb(cim: AcDcTerminal, pb: PBAcDcTerminal.Builder): PBAcDcTerminal.Builder =
     pb.apply { toPb(cim, ioBuilder) }
 
+/**
+ * Convert the [BaseVoltage] into its protobuf counterpart.
+ *
+ * @param cim The [BaseVoltage] to convert.
+ * @param pb The protobuf builder to populate.
+ * @return [pb] for fluent use.
+ */
 fun toPb(cim: BaseVoltage, pb: PBBaseVoltage.Builder): PBBaseVoltage.Builder =
     pb.apply {
         nominalVoltage = cim.nominalVoltage
         toPb(cim, ioBuilder)
     }
 
+/**
+ * Convert the [ConductingEquipment] into its protobuf counterpart.
+ *
+ * @param cim The [ConductingEquipment] to convert.
+ * @param pb The protobuf builder to populate.
+ * @return [pb] for fluent use.
+ */
 fun toPb(cim: ConductingEquipment, pb: PBConductingEquipment.Builder): PBConductingEquipment.Builder =
     pb.apply {
         cim.baseVoltage?.let { baseVoltageMRID = it.mRID } ?: clearBaseVoltageMRID()
@@ -539,18 +929,46 @@ fun toPb(cim: ConductingEquipment, pb: PBConductingEquipment.Builder): PBConduct
         toPb(cim, eqBuilder)
     }
 
+/**
+ * Convert the [ConnectivityNode] into its protobuf counterpart.
+ *
+ * @param cim The [ConnectivityNode] to convert.
+ * @param pb The protobuf builder to populate.
+ * @return [pb] for fluent use.
+ */
 fun toPb(cim: ConnectivityNode, pb: PBConnectivityNode.Builder): PBConnectivityNode.Builder =
     pb.apply { toPb(cim, ioBuilder) }
 
+/**
+ * Convert the [ConnectivityNodeContainer] into its protobuf counterpart.
+ *
+ * @param cim The [ConnectivityNodeContainer] to convert.
+ * @param pb The protobuf builder to populate.
+ * @return [pb] for fluent use.
+ */
 fun toPb(cim: ConnectivityNodeContainer, pb: PBConnectivityNodeContainer.Builder): PBConnectivityNodeContainer.Builder =
     pb.apply { toPb(cim, psrBuilder) }
 
+/**
+ * Convert the [Curve] into its protobuf counterpart.
+ *
+ * @param cim The [Curve] to convert.
+ * @param pb The protobuf builder to populate.
+ * @return [pb] for fluent use.
+ */
 fun toPb(cim: Curve, pb: PBCurve.Builder): PBCurve.Builder =
     pb.apply {
         cim.data.forEachIndexed { i, data -> addCurveDataBuilder(i).apply { toPb(data, this) } }
         toPb(cim, ioBuilder)
     }
 
+/**
+ * Convert the [CurveData] into its protobuf counterpart.
+ *
+ * @param cim The [CurveData] to convert.
+ * @param pb The protobuf builder to populate.
+ * @return [pb] for fluent use.
+ */
 fun toPb(cim: CurveData, pb: PBCurveData.Builder): PBCurveData.Builder =
     pb.apply {
         xValue = cim.xValue
@@ -559,6 +977,13 @@ fun toPb(cim: CurveData, pb: PBCurveData.Builder): PBCurveData.Builder =
         y3Value = cim.y3Value ?: UNKNOWN_FLOAT
     }
 
+/**
+ * Convert the [Equipment] into its protobuf counterpart.
+ *
+ * @param cim The [Equipment] to convert.
+ * @param pb The protobuf builder to populate.
+ * @return [pb] for fluent use.
+ */
 fun toPb(cim: Equipment, pb: PBEquipment.Builder): PBEquipment.Builder =
     pb.apply {
         inService = cim.inService
@@ -581,11 +1006,25 @@ fun toPb(cim: Equipment, pb: PBEquipment.Builder): PBEquipment.Builder =
         toPb(cim, psrBuilder)
     }
 
+/**
+ * Convert the [EquipmentContainer] into its protobuf counterpart.
+ *
+ * @param cim The [EquipmentContainer] to convert.
+ * @param pb The protobuf builder to populate.
+ * @return [pb] for fluent use.
+ */
 fun toPb(cim: EquipmentContainer, pb: PBEquipmentContainer.Builder): PBEquipmentContainer.Builder =
     pb.apply {
         toPb(cim, cncBuilder)
     }
 
+/**
+ * Convert the [Feeder] into its protobuf counterpart.
+ *
+ * @param cim The [Feeder] to convert.
+ * @param pb The protobuf builder to populate.
+ * @return [pb] for fluent use.
+ */
 fun toPb(cim: Feeder, pb: PBFeeder.Builder): PBFeeder.Builder =
     pb.apply {
         cim.normalHeadTerminal?.let { normalHeadTerminalMRID = it.mRID } ?: clearNormalHeadTerminalMRID()
@@ -597,6 +1036,13 @@ fun toPb(cim: Feeder, pb: PBFeeder.Builder): PBFeeder.Builder =
         toPb(cim, ecBuilder)
     }
 
+/**
+ * Convert the [GeographicalRegion] into its protobuf counterpart.
+ *
+ * @param cim The [GeographicalRegion] to convert.
+ * @param pb The protobuf builder to populate.
+ * @return [pb] for fluent use.
+ */
 fun toPb(cim: GeographicalRegion, pb: PBGeographicalRegion.Builder): PBGeographicalRegion.Builder =
     pb.apply {
         clearSubGeographicalRegionMRIDs()
@@ -604,6 +1050,13 @@ fun toPb(cim: GeographicalRegion, pb: PBGeographicalRegion.Builder): PBGeographi
         toPb(cim, ioBuilder)
     }
 
+/**
+ * Convert the [PowerSystemResource] into its protobuf counterpart.
+ *
+ * @param cim The [PowerSystemResource] to convert.
+ * @param pb The protobuf builder to populate.
+ * @return [pb] for fluent use.
+ */
 fun toPb(cim: PowerSystemResource, pb: PBPowerSystemResource.Builder): PBPowerSystemResource.Builder =
     pb.apply {
         cim.location?.let { locationMRID = it.mRID } ?: clearLocationMRID()
@@ -612,9 +1065,23 @@ fun toPb(cim: PowerSystemResource, pb: PBPowerSystemResource.Builder): PBPowerSy
         toPb(cim, ioBuilder)
     }
 
+/**
+ * Convert the [Site] into its protobuf counterpart.
+ *
+ * @param cim The [Site] to convert.
+ * @param pb The protobuf builder to populate.
+ * @return [pb] for fluent use.
+ */
 fun toPb(cim: Site, pb: PBSite.Builder): PBSite.Builder =
     pb.apply { toPb(cim, ecBuilder) }
 
+/**
+ * Convert the [SubGeographicalRegion] into its protobuf counterpart.
+ *
+ * @param cim The [SubGeographicalRegion] to convert.
+ * @param pb The protobuf builder to populate.
+ * @return [pb] for fluent use.
+ */
 fun toPb(cim: SubGeographicalRegion, pb: PBSubGeographicalRegion.Builder): PBSubGeographicalRegion.Builder =
     pb.apply {
         cim.geographicalRegion?.let { geographicalRegionMRID = it.mRID } ?: clearGeographicalRegionMRID()
@@ -623,6 +1090,13 @@ fun toPb(cim: SubGeographicalRegion, pb: PBSubGeographicalRegion.Builder): PBSub
         toPb(cim, ioBuilder)
     }
 
+/**
+ * Convert the [Substation] into its protobuf counterpart.
+ *
+ * @param cim The [Substation] to convert.
+ * @param pb The protobuf builder to populate.
+ * @return [pb] for fluent use.
+ */
 fun toPb(cim: Substation, pb: PBSubstation.Builder): PBSubstation.Builder =
     pb.apply {
         cim.subGeographicalRegion?.let { subGeographicalRegionMRID = it.mRID } ?: clearSubGeographicalRegionMRID()
@@ -637,6 +1111,13 @@ fun toPb(cim: Substation, pb: PBSubstation.Builder): PBSubstation.Builder =
         toPb(cim, ecBuilder)
     }
 
+/**
+ * Convert the [Terminal] into its protobuf counterpart.
+ *
+ * @param cim The [Terminal] to convert.
+ * @param pb The protobuf builder to populate.
+ * @return [pb] for fluent use.
+ */
 fun toPb(cim: Terminal, pb: PBTerminal.Builder): PBTerminal.Builder =
     pb.apply {
         cim.conductingEquipment?.let { conductingEquipmentMRID = it.mRID } ?: clearConductingEquipmentMRID()
@@ -649,18 +1130,62 @@ fun toPb(cim: Terminal, pb: PBTerminal.Builder): PBTerminal.Builder =
         toPb(cim, adBuilder)
     }
 
+/**
+ * An extension for converting any BaseVoltage into its protobuf counterpart.
+ */
 fun BaseVoltage.toPb(): PBBaseVoltage = toPb(this, PBBaseVoltage.newBuilder()).build()
+
+/**
+ * An extension for converting any ConnectivityNode into its protobuf counterpart.
+ */
 fun ConnectivityNode.toPb(): PBConnectivityNode = toPb(this, PBConnectivityNode.newBuilder()).build()
+
+/**
+ * An extension for converting any CurveData into its protobuf counterpart.
+ */
 fun CurveData.toPb(): PBCurveData = toPb(this, PBCurveData.newBuilder()).build()
+
+/**
+ * An extension for converting any Feeder into its protobuf counterpart.
+ */
 fun Feeder.toPb(): PBFeeder = toPb(this, PBFeeder.newBuilder()).build()
+
+/**
+ * An extension for converting any GeographicalRegion into its protobuf counterpart.
+ */
 fun GeographicalRegion.toPb(): PBGeographicalRegion = toPb(this, PBGeographicalRegion.newBuilder()).build()
+
+/**
+ * An extension for converting any Site into its protobuf counterpart.
+ */
 fun Site.toPb(): PBSite = toPb(this, PBSite.newBuilder()).build()
+
+/**
+ * An extension for converting any SubGeographicalRegion into its protobuf counterpart.
+ */
 fun SubGeographicalRegion.toPb(): PBSubGeographicalRegion = toPb(this, PBSubGeographicalRegion.newBuilder()).build()
+
+/**
+ * An extension for converting any Substation into its protobuf counterpart.
+ */
 fun Substation.toPb(): PBSubstation = toPb(this, PBSubstation.newBuilder()).build()
+
+/**
+ * An extension for converting any Terminal into its protobuf counterpart.
+ */
 fun Terminal.toPb(): PBTerminal = toPb(this, PBTerminal.newBuilder()).build()
 
-/************ IEC61970 BASE EQUIVALENTS ************/
+// #############################
+// # IEC61970 BASE EQUIVALENTS #
+// #############################
 
+/**
+ * Convert the [EquivalentBranch] into its protobuf counterpart.
+ *
+ * @param cim The [EquivalentBranch] to convert.
+ * @param pb The protobuf builder to populate.
+ * @return [pb] for fluent use.
+ */
 fun toPb(cim: EquivalentBranch, pb: PBEquivalentBranch.Builder): PBEquivalentBranch.Builder =
     pb.apply {
         negativeR12 = cim.negativeR12 ?: UNKNOWN_DOUBLE
@@ -682,21 +1207,54 @@ fun toPb(cim: EquivalentBranch, pb: PBEquivalentBranch.Builder): PBEquivalentBra
         toPb(cim, eeBuilder)
     }
 
+/**
+ * Convert the [EquivalentEquipment] into its protobuf counterpart.
+ *
+ * @param cim The [EquivalentEquipment] to convert.
+ * @param pb The protobuf builder to populate.
+ * @return [pb] for fluent use.
+ */
 fun toPb(cim: EquivalentEquipment, pb: PBEquivalentEquipment.Builder): PBEquivalentEquipment.Builder =
     pb.apply { toPb(cim, ceBuilder) }
 
+/**
+ * An extension for converting any EquivalentBranch into its protobuf counterpart.
+ */
 fun EquivalentBranch.toPb(): PBEquivalentBranch = toPb(this, PBEquivalentBranch.newBuilder()).build()
 
-/************ IEC61970 BASE MEAS ************/
+// ######################
+// # IEC61970 BASE MEAS #
+// ######################
 
+/**
+ * Convert the [Accumulator] into its protobuf counterpart.
+ *
+ * @param cim The [Accumulator] to convert.
+ * @param pb The protobuf builder to populate.
+ * @return [pb] for fluent use.
+ */
 fun toPb(cim: Accumulator, pb: PBAccumulator.Builder): PBAccumulator.Builder = pb.apply { toPb(cim, measurementBuilder) }
 
+/**
+ * Convert the [Analog] into its protobuf counterpart.
+ *
+ * @param cim The [Analog] to convert.
+ * @param pb The protobuf builder to populate.
+ * @return [pb] for fluent use.
+ */
 fun toPb(cim: Analog, pb: PBAnalog.Builder): PBAnalog.Builder =
     pb.apply {
         positiveFlowIn = cim.positiveFlowIn
         toPb(cim, measurementBuilder)
     }
 
+/**
+ * Convert the [Control] into its protobuf counterpart.
+ *
+ * @param cim The [Control] to convert.
+ * @param pb The protobuf builder to populate.
+ * @return [pb] for fluent use.
+ */
 fun toPb(cim: Control, pb: PBControl.Builder): PBControl.Builder =
     pb.apply {
         cim.remoteControl?.let { remoteControlMRID = it.mRID } ?: clearRemoteControlMRID()
@@ -704,10 +1262,31 @@ fun toPb(cim: Control, pb: PBControl.Builder): PBControl.Builder =
         toPb(cim, ipBuilder)
     }
 
+/**
+ * Convert the [Discrete] into its protobuf counterpart.
+ *
+ * @param cim The [Discrete] to convert.
+ * @param pb The protobuf builder to populate.
+ * @return [pb] for fluent use.
+ */
 fun toPb(cim: Discrete, pb: PBDiscrete.Builder): PBDiscrete.Builder = pb.apply { toPb(cim, measurementBuilder) }
 
+/**
+ * Convert the [IoPoint] into its protobuf counterpart.
+ *
+ * @param cim The [IoPoint] to convert.
+ * @param pb The protobuf builder to populate.
+ * @return [pb] for fluent use.
+ */
 fun toPb(cim: IoPoint, pb: PBIoPoint.Builder): PBIoPoint.Builder = pb.apply { toPb(cim, ioBuilder) }
 
+/**
+ * Convert the [Measurement] into its protobuf counterpart.
+ *
+ * @param cim The [Measurement] to convert.
+ * @param pb The protobuf builder to populate.
+ * @return [pb] for fluent use.
+ */
 fun toPb(cim: Measurement, pb: PBMeasurement.Builder): PBMeasurement.Builder =
     pb.apply {
         cim.remoteSource?.let { remoteSourceMRID = it.mRID } ?: clearRemoteSourceMRID()
@@ -718,13 +1297,37 @@ fun toPb(cim: Measurement, pb: PBMeasurement.Builder): PBMeasurement.Builder =
         unitSymbol = PBUnitSymbol.valueOf(cim.unitSymbol.name)
     }
 
+/**
+ * An extension for converting any Accumulator into its protobuf counterpart.
+ */
 fun Accumulator.toPb(): PBAccumulator = toPb(this, PBAccumulator.newBuilder()).build()
+
+/**
+ * An extension for converting any Analog into its protobuf counterpart.
+ */
 fun Analog.toPb(): PBAnalog = toPb(this, PBAnalog.newBuilder()).build()
+
+/**
+ * An extension for converting any Control into its protobuf counterpart.
+ */
 fun Control.toPb(): PBControl = toPb(this, PBControl.newBuilder()).build()
+
+/**
+ * An extension for converting any Discrete into its protobuf counterpart.
+ */
 fun Discrete.toPb(): PBDiscrete = toPb(this, PBDiscrete.newBuilder()).build()
 
-/************ IEC61970 Base Protection ************/
+// ############################
+// # IEC61970 Base Protection #
+// ############################
 
+/**
+ * Convert the [CurrentRelay] into its protobuf counterpart.
+ *
+ * @param cim The [CurrentRelay] to convert.
+ * @param pb The protobuf builder to populate.
+ * @return [pb] for fluent use.
+ */
 fun toPb(cim: CurrentRelay, pb: PBCurrentRelay.Builder): PBCurrentRelay.Builder =
     pb.apply {
         currentLimit1 = cim.currentLimit1 ?: UNKNOWN_DOUBLE
@@ -733,6 +1336,13 @@ fun toPb(cim: CurrentRelay, pb: PBCurrentRelay.Builder): PBCurrentRelay.Builder 
         toPb(cim, prfBuilder)
     }
 
+/**
+ * Convert the [DistanceRelay] into its protobuf counterpart.
+ *
+ * @param cim The [DistanceRelay] to convert.
+ * @param pb The protobuf builder to populate.
+ * @return [pb] for fluent use.
+ */
 fun toPb(cim: DistanceRelay, pb: PBDistanceRelay.Builder): PBDistanceRelay.Builder =
     pb.apply {
         backwardBlind = cim.backwardBlind ?: UNKNOWN_DOUBLE
@@ -747,6 +1357,13 @@ fun toPb(cim: DistanceRelay, pb: PBDistanceRelay.Builder): PBDistanceRelay.Build
         toPb(cim, prfBuilder)
     }
 
+/**
+ * Convert the [ProtectionRelayFunction] into its protobuf counterpart.
+ *
+ * @param cim The [ProtectionRelayFunction] to convert.
+ * @param pb The protobuf builder to populate.
+ * @return [pb] for fluent use.
+ */
 fun toPb(cim: ProtectionRelayFunction, pb: PBProtectionRelayFunction.Builder): PBProtectionRelayFunction.Builder =
     pb.apply {
         cim.model?.let { model = it } ?: clearModel()
@@ -763,6 +1380,13 @@ fun toPb(cim: ProtectionRelayFunction, pb: PBProtectionRelayFunction.Builder): P
         toPb(cim, psrBuilder)
     }
 
+/**
+ * Convert the [ProtectionRelayScheme] into its protobuf counterpart.
+ *
+ * @param cim The [ProtectionRelayScheme] to convert.
+ * @param pb The protobuf builder to populate.
+ * @return [pb] for fluent use.
+ */
 fun toPb(cim: ProtectionRelayScheme, pb: PBProtectionRelayScheme.Builder): PBProtectionRelayScheme.Builder =
     pb.apply {
         cim.system?.let { systemMRID = it.mRID } ?: clearSystemMRID()
@@ -770,6 +1394,13 @@ fun toPb(cim: ProtectionRelayScheme, pb: PBProtectionRelayScheme.Builder): PBPro
         toPb(cim, ioBuilder)
     }
 
+/**
+ * Convert the [ProtectionRelaySystem] into its protobuf counterpart.
+ *
+ * @param cim The [ProtectionRelaySystem] to convert.
+ * @param pb The protobuf builder to populate.
+ * @return [pb] for fluent use.
+ */
 fun toPb(cim: ProtectionRelaySystem, pb: PBProtectionRelaySystem.Builder): PBProtectionRelaySystem.Builder =
     pb.apply {
         protectionKind = PBProtectionKind.valueOf(cim.protectionKind.name)
@@ -777,6 +1408,12 @@ fun toPb(cim: ProtectionRelaySystem, pb: PBProtectionRelaySystem.Builder): PBPro
         toPb(cim, eqBuilder)
     }
 
+/**
+ * Convert the [RelaySetting] into its protobuf counterpart.
+ *
+ * @param cim The [RelaySetting] to convert.
+ * @return The protobuf form of [cim].
+ */
 fun toPb(cim: RelaySetting): PBRelaySetting.Builder =
     PBRelaySetting.newBuilder().apply {
         unitSymbol = PBUnitSymbol.valueOf(cim.unitSymbol.name)
@@ -784,39 +1421,104 @@ fun toPb(cim: RelaySetting): PBRelaySetting.Builder =
         cim.name?.let { name = it } ?: clearName()
     }
 
+/**
+ * Convert the [VoltageRelay] into its protobuf counterpart.
+ *
+ * @param cim The [VoltageRelay] to convert.
+ * @param pb The protobuf builder to populate.
+ * @return [pb] for fluent use.
+ */
 fun toPb(cim: VoltageRelay, pb: PBVoltageRelay.Builder): PBVoltageRelay.Builder =
     pb.apply {
         toPb(cim, prfBuilder)
     }
 
+/**
+ * An extension for converting any CurrentRelay into its protobuf counterpart.
+ */
 fun CurrentRelay.toPb(): PBCurrentRelay = toPb(this, PBCurrentRelay.newBuilder()).build()
+
+/**
+ * An extension for converting any DistanceRelay into its protobuf counterpart.
+ */
 fun DistanceRelay.toPb(): PBDistanceRelay = toPb(this, PBDistanceRelay.newBuilder()).build()
+
+/**
+ * An extension for converting any ProtectionRelayScheme into its protobuf counterpart.
+ */
 fun ProtectionRelayScheme.toPb(): PBProtectionRelayScheme = toPb(this, PBProtectionRelayScheme.newBuilder()).build()
+
+/**
+ * An extension for converting any ProtectionRelaySystem into its protobuf counterpart.
+ */
 fun ProtectionRelaySystem.toPb(): PBProtectionRelaySystem = toPb(this, PBProtectionRelaySystem.newBuilder()).build()
+
+/**
+ * An extension for converting any VoltageRelay into its protobuf counterpart.
+ */
 fun VoltageRelay.toPb(): PBVoltageRelay = toPb(this, PBVoltageRelay.newBuilder()).build()
 
-/************ IEC61970 BASE SCADA ************/
+// #######################
+// # IEC61970 BASE SCADA #
+// #######################
 
+/**
+ * Convert the [RemoteControl] into its protobuf counterpart.
+ *
+ * @param cim The [RemoteControl] to convert.
+ * @param pb The protobuf builder to populate.
+ * @return [pb] for fluent use.
+ */
 fun toPb(cim: RemoteControl, pb: PBRemoteControl.Builder): PBRemoteControl.Builder =
     pb.apply {
         cim.control?.let { controlMRID = it.mRID } ?: clearControlMRID()
         toPb(cim, rpBuilder)
     }
 
+/**
+ * Convert the [RemotePoint] into its protobuf counterpart.
+ *
+ * @param cim The [RemotePoint] to convert.
+ * @param pb The protobuf builder to populate.
+ * @return [pb] for fluent use.
+ */
 fun toPb(cim: RemotePoint, pb: PBRemotePoint.Builder): PBRemotePoint.Builder =
     pb.apply { toPb(cim, ioBuilder) }
 
+/**
+ * Convert the [RemoteSource] into its protobuf counterpart.
+ *
+ * @param cim The [RemoteSource] to convert.
+ * @param pb The protobuf builder to populate.
+ * @return [pb] for fluent use.
+ */
 fun toPb(cim: RemoteSource, pb: PBRemoteSource.Builder): PBRemoteSource.Builder =
     pb.apply {
         cim.measurement?.let { measurementMRID = it.mRID } ?: clearMeasurementMRID()
         toPb(cim, rpBuilder)
     }
 
+/**
+ * An extension for converting any RemoteControl into its protobuf counterpart.
+ */
 fun RemoteControl.toPb(): PBRemoteControl = toPb(this, PBRemoteControl.newBuilder()).build()
+
+/**
+ * An extension for converting any RemoteSource into its protobuf counterpart.
+ */
 fun RemoteSource.toPb(): PBRemoteSource = toPb(this, PBRemoteSource.newBuilder()).build()
 
-/************ IEC61970 BASE WIRES GENERATION PRODUCTION ************/
+// #############################################
+// # IEC61970 BASE WIRES GENERATION PRODUCTION #
+// #############################################
 
+/**
+ * Convert the [BatteryUnit] into its protobuf counterpart.
+ *
+ * @param cim The [BatteryUnit] to convert.
+ * @param pb The protobuf builder to populate.
+ * @return [pb] for fluent use.
+ */
 fun toPb(cim: BatteryUnit, pb: PBBatteryUnit.Builder): PBBatteryUnit.Builder =
     pb.apply {
         batteryState = BatteryStateKind.valueOf(cim.batteryState.name)
@@ -825,11 +1527,25 @@ fun toPb(cim: BatteryUnit, pb: PBBatteryUnit.Builder): PBBatteryUnit.Builder =
         toPb(cim, peuBuilder)
     }
 
+/**
+ * Convert the [PhotoVoltaicUnit] into its protobuf counterpart.
+ *
+ * @param cim The [PhotoVoltaicUnit] to convert.
+ * @param pb The protobuf builder to populate.
+ * @return [pb] for fluent use.
+ */
 fun toPb(cim: PhotoVoltaicUnit, pb: PBPhotoVoltaicUnit.Builder): PBPhotoVoltaicUnit.Builder =
     pb.apply {
         toPb(cim, peuBuilder)
     }
 
+/**
+ * Convert the [PowerElectronicsUnit] into its protobuf counterpart.
+ *
+ * @param cim The [PowerElectronicsUnit] to convert.
+ * @param pb The protobuf builder to populate.
+ * @return [pb] for fluent use.
+ */
 fun toPb(cim: PowerElectronicsUnit, pb: PBPowerElectronicsUnit.Builder): PBPowerElectronicsUnit.Builder =
     pb.apply {
         cim.powerElectronicsConnection?.let { powerElectronicsConnectionMRID = it.mRID } ?: clearPowerElectronicsConnectionMRID()
@@ -838,32 +1554,80 @@ fun toPb(cim: PowerElectronicsUnit, pb: PBPowerElectronicsUnit.Builder): PBPower
         toPb(cim, eqBuilder)
     }
 
+/**
+ * Convert the [PowerElectronicsWindUnit] into its protobuf counterpart.
+ *
+ * @param cim The [PowerElectronicsWindUnit] to convert.
+ * @param pb The protobuf builder to populate.
+ * @return [pb] for fluent use.
+ */
 fun toPb(cim: PowerElectronicsWindUnit, pb: PBPowerElectronicsWindUnit.Builder): PBPowerElectronicsWindUnit.Builder =
     pb.apply {
         toPb(cim, peuBuilder)
     }
 
+/**
+ * An extension for converting any BatteryUnit into its protobuf counterpart.
+ */
 fun BatteryUnit.toPb(): PBBatteryUnit = toPb(this, PBBatteryUnit.newBuilder()).build()
+
+/**
+ * An extension for converting any PhotoVoltaicUnit into its protobuf counterpart.
+ */
 fun PhotoVoltaicUnit.toPb(): PBPhotoVoltaicUnit = toPb(this, PBPhotoVoltaicUnit.newBuilder()).build()
+
+/**
+ * An extension for converting any PowerElectronicsWindUnit into its protobuf counterpart.
+ */
 fun PowerElectronicsWindUnit.toPb(): PBPowerElectronicsWindUnit = toPb(this, PBPowerElectronicsWindUnit.newBuilder()).build()
 
-/************ IEC61970 BASE WIRES ************/
+// #######################
+// # IEC61970 BASE WIRES #
+// #######################
 
+/**
+ * Convert the [AcLineSegment] into its protobuf counterpart.
+ *
+ * @param cim The [AcLineSegment] to convert.
+ * @param pb The protobuf builder to populate.
+ * @return [pb] for fluent use.
+ */
 fun toPb(cim: AcLineSegment, pb: PBAcLineSegment.Builder): PBAcLineSegment.Builder =
     pb.apply {
         cim.perLengthSequenceImpedance?.let { perLengthSequenceImpedanceMRID = it.mRID } ?: clearPerLengthSequenceImpedanceMRID()
         toPb(cim, cdBuilder)
     }
 
+/**
+ * Convert the [Breaker] into its protobuf counterpart.
+ *
+ * @param cim The [Breaker] to convert.
+ * @param pb The protobuf builder to populate.
+ * @return [pb] for fluent use.
+ */
 fun toPb(cim: Breaker, pb: PBBreaker.Builder): PBBreaker.Builder =
     pb.apply {
         inTransitTime = cim.inTransitTime ?: UNKNOWN_DOUBLE
         toPb(cim, swBuilder)
     }
 
+/**
+ * Convert the [BusbarSection] into its protobuf counterpart.
+ *
+ * @param cim The [BusbarSection] to convert.
+ * @param pb The protobuf builder to populate.
+ * @return [pb] for fluent use.
+ */
 fun toPb(cim: BusbarSection, pb: PBBusbarSection.Builder): PBBusbarSection.Builder =
     pb.apply { toPb(cim, cnBuilder) }
 
+/**
+ * Convert the [Conductor] into its protobuf counterpart.
+ *
+ * @param cim The [Conductor] to convert.
+ * @param pb The protobuf builder to populate.
+ * @return [pb] for fluent use.
+ */
 fun toPb(cim: Conductor, pb: PBConductor.Builder): PBConductor.Builder =
     pb.apply {
         length = cim.length ?: UNKNOWN_DOUBLE
@@ -872,21 +1636,56 @@ fun toPb(cim: Conductor, pb: PBConductor.Builder): PBConductor.Builder =
         toPb(cim, ceBuilder)
     }
 
+/**
+ * Convert the [Connector] into its protobuf counterpart.
+ *
+ * @param cim The [Connector] to convert.
+ * @param pb The protobuf builder to populate.
+ * @return [pb] for fluent use.
+ */
 fun toPb(cim: Connector, pb: PBConnector.Builder): PBConnector.Builder =
     pb.apply { toPb(cim, ceBuilder) }
 
+/**
+ * Convert the [Disconnector] into its protobuf counterpart.
+ *
+ * @param cim The [Disconnector] to convert.
+ * @param pb The protobuf builder to populate.
+ * @return [pb] for fluent use.
+ */
 fun toPb(cim: Disconnector, pb: PBDisconnector.Builder): PBDisconnector.Builder =
     pb.apply { toPb(cim, swBuilder) }
 
+/**
+ * Convert the [EarthFaultCompensator] into its protobuf counterpart.
+ *
+ * @param cim The [EarthFaultCompensator] to convert.
+ * @param pb The protobuf builder to populate.
+ * @return [pb] for fluent use.
+ */
 fun toPb(cim: EarthFaultCompensator, pb: PBEarthFaultCompensator.Builder): PBEarthFaultCompensator.Builder =
     pb.apply {
         r = cim.r ?: UNKNOWN_DOUBLE
         toPb(cim, ceBuilder)
     }
 
+/**
+ * Convert the [EnergyConnection] into its protobuf counterpart.
+ *
+ * @param cim The [EnergyConnection] to convert.
+ * @param pb The protobuf builder to populate.
+ * @return [pb] for fluent use.
+ */
 fun toPb(cim: EnergyConnection, pb: PBEnergyConnection.Builder): PBEnergyConnection.Builder =
     pb.apply { toPb(cim, ceBuilder) }
 
+/**
+ * Convert the [EnergyConsumer] into its protobuf counterpart.
+ *
+ * @param cim The [EnergyConsumer] to convert.
+ * @param pb The protobuf builder to populate.
+ * @return [pb] for fluent use.
+ */
 fun toPb(cim: EnergyConsumer, pb: PBEnergyConsumer.Builder): PBEnergyConsumer.Builder =
     pb.apply {
         clearEnergyConsumerPhasesMRIDs()
@@ -901,6 +1700,13 @@ fun toPb(cim: EnergyConsumer, pb: PBEnergyConsumer.Builder): PBEnergyConsumer.Bu
         toPb(cim, ecBuilder)
     }
 
+/**
+ * Convert the [EnergyConsumerPhase] into its protobuf counterpart.
+ *
+ * @param cim The [EnergyConsumerPhase] to convert.
+ * @param pb The protobuf builder to populate.
+ * @return [pb] for fluent use.
+ */
 fun toPb(cim: EnergyConsumerPhase, pb: PBEnergyConsumerPhase.Builder): PBEnergyConsumerPhase.Builder =
     pb.apply {
         cim.energyConsumer?.let { energyConsumerMRID = it.mRID } ?: clearEnergyConsumerMRID()
@@ -912,6 +1718,13 @@ fun toPb(cim: EnergyConsumerPhase, pb: PBEnergyConsumerPhase.Builder): PBEnergyC
         toPb(cim, psrBuilder)
     }
 
+/**
+ * Convert the [EnergySource] into its protobuf counterpart.
+ *
+ * @param cim The [EnergySource] to convert.
+ * @param pb The protobuf builder to populate.
+ * @return [pb] for fluent use.
+ */
 fun toPb(cim: EnergySource, pb: PBEnergySource.Builder): PBEnergySource.Builder =
     pb.apply {
         clearEnergySourcePhasesMRIDs()
@@ -946,6 +1759,13 @@ fun toPb(cim: EnergySource, pb: PBEnergySource.Builder): PBEnergySource.Builder 
         toPb(cim, ecBuilder)
     }
 
+/**
+ * Convert the [EnergySourcePhase] into its protobuf counterpart.
+ *
+ * @param cim The [EnergySourcePhase] to convert.
+ * @param pb The protobuf builder to populate.
+ * @return [pb] for fluent use.
+ */
 fun toPb(cim: EnergySourcePhase, pb: PBEnergySourcePhase.Builder): PBEnergySourcePhase.Builder =
     pb.apply {
         cim.energySource?.let { energySourceMRID = it.mRID } ?: clearEnergySourceMRID()
@@ -953,33 +1773,89 @@ fun toPb(cim: EnergySourcePhase, pb: PBEnergySourcePhase.Builder): PBEnergySourc
         toPb(cim, psrBuilder)
     }
 
+/**
+ * Convert the [Fuse] into its protobuf counterpart.
+ *
+ * @param cim The [Fuse] to convert.
+ * @param pb The protobuf builder to populate.
+ * @return [pb] for fluent use.
+ */
 fun toPb(cim: Fuse, pb: PBFuse.Builder): PBFuse.Builder =
     pb.apply {
         cim.function?.let { functionMRID = it.mRID } ?: clearFunctionMRID()
         toPb(cim, swBuilder)
     }
 
+/**
+ * Convert the [Ground] into its protobuf counterpart.
+ *
+ * @param cim The [Ground] to convert.
+ * @param pb The protobuf builder to populate.
+ * @return [pb] for fluent use.
+ */
 fun toPb(cim: Ground, pb: PBGround.Builder): PBGround.Builder =
     pb.apply { toPb(cim, ceBuilder) }
 
+/**
+ * Convert the [GroundDisconnector] into its protobuf counterpart.
+ *
+ * @param cim The [GroundDisconnector] to convert.
+ * @param pb The protobuf builder to populate.
+ * @return [pb] for fluent use.
+ */
 fun toPb(cim: GroundDisconnector, pb: PBGroundDisconnector.Builder): PBGroundDisconnector.Builder =
     pb.apply { toPb(cim, swBuilder) }
 
+/**
+ * Convert the [GroundingImpedance] into its protobuf counterpart.
+ *
+ * @param cim The [GroundingImpedance] to convert.
+ * @param pb The protobuf builder to populate.
+ * @return [pb] for fluent use.
+ */
 fun toPb(cim: GroundingImpedance, pb: PBGroundingImpedance.Builder): PBGroundingImpedance.Builder =
     pb.apply {
         x = cim.x ?: UNKNOWN_DOUBLE
         toPb(cim, efcBuilder)
     }
 
+/**
+ * Convert the [Jumper] into its protobuf counterpart.
+ *
+ * @param cim The [Jumper] to convert.
+ * @param pb The protobuf builder to populate.
+ * @return [pb] for fluent use.
+ */
 fun toPb(cim: Jumper, pb: PBJumper.Builder): PBJumper.Builder =
     pb.apply { toPb(cim, swBuilder) }
 
+/**
+ * Convert the [Junction] into its protobuf counterpart.
+ *
+ * @param cim The [Junction] to convert.
+ * @param pb The protobuf builder to populate.
+ * @return [pb] for fluent use.
+ */
 fun toPb(cim: Junction, pb: PBJunction.Builder): PBJunction.Builder =
     pb.apply { toPb(cim, cnBuilder) }
 
+/**
+ * Convert the [Line] into its protobuf counterpart.
+ *
+ * @param cim The [Line] to convert.
+ * @param pb The protobuf builder to populate.
+ * @return [pb] for fluent use.
+ */
 fun toPb(cim: Line, pb: PBLine.Builder): PBLine.Builder =
     pb.apply { toPb(cim, ecBuilder) }
 
+/**
+ * Convert the [LinearShuntCompensator] into its protobuf counterpart.
+ *
+ * @param cim The [LinearShuntCompensator] to convert.
+ * @param pb The protobuf builder to populate.
+ * @return [pb] for fluent use.
+ */
 fun toPb(cim: LinearShuntCompensator, pb: PBLinearShuntCompensator.Builder): PBLinearShuntCompensator.Builder =
     pb.apply {
         b0PerSection = cim.b0PerSection ?: UNKNOWN_DOUBLE
@@ -989,15 +1865,43 @@ fun toPb(cim: LinearShuntCompensator, pb: PBLinearShuntCompensator.Builder): PBL
         toPb(cim, scBuilder)
     }
 
+/**
+ * Convert the [LoadBreakSwitch] into its protobuf counterpart.
+ *
+ * @param cim The [LoadBreakSwitch] to convert.
+ * @param pb The protobuf builder to populate.
+ * @return [pb] for fluent use.
+ */
 fun toPb(cim: LoadBreakSwitch, pb: PBLoadBreakSwitch.Builder): PBLoadBreakSwitch.Builder =
     pb.apply { toPb(cim, psBuilder) }
 
+/**
+ * Convert the [PerLengthImpedance] into its protobuf counterpart.
+ *
+ * @param cim The [PerLengthImpedance] to convert.
+ * @param pb The protobuf builder to populate.
+ * @return [pb] for fluent use.
+ */
 fun toPb(cim: PerLengthImpedance, pb: PBPerLengthImpedance.Builder): PBPerLengthImpedance.Builder =
     pb.apply { toPb(cim, lpBuilder) }
 
+/**
+ * Convert the [PerLengthLineParameter] into its protobuf counterpart.
+ *
+ * @param cim The [PerLengthLineParameter] to convert.
+ * @param pb The protobuf builder to populate.
+ * @return [pb] for fluent use.
+ */
 fun toPb(cim: PerLengthLineParameter, pb: PBPerLengthLineParameter.Builder): PBPerLengthLineParameter.Builder =
     pb.apply { toPb(cim, ioBuilder) }
 
+/**
+ * Convert the [PerLengthSequenceImpedance] into its protobuf counterpart.
+ *
+ * @param cim The [PerLengthSequenceImpedance] to convert.
+ * @param pb The protobuf builder to populate.
+ * @return [pb] for fluent use.
+ */
 fun toPb(cim: PerLengthSequenceImpedance, pb: PBPerLengthSequenceImpedance.Builder): PBPerLengthSequenceImpedance.Builder =
     pb.apply {
         r = cim.r ?: UNKNOWN_DOUBLE
@@ -1011,12 +1915,26 @@ fun toPb(cim: PerLengthSequenceImpedance, pb: PBPerLengthSequenceImpedance.Build
         toPb(cim, pliBuilder)
     }
 
+/**
+ * Convert the [PetersenCoil] into its protobuf counterpart.
+ *
+ * @param cim The [PetersenCoil] to convert.
+ * @param pb The protobuf builder to populate.
+ * @return [pb] for fluent use.
+ */
 fun toPb(cim: PetersenCoil, pb: PBPetersenCoil.Builder): PBPetersenCoil.Builder =
     pb.apply {
         xGroundNominal = cim.xGroundNominal ?: UNKNOWN_DOUBLE
         toPb(cim, efcBuilder)
     }
 
+/**
+ * Convert the [PowerElectronicsConnection] into its protobuf counterpart.
+ *
+ * @param cim The [PowerElectronicsConnection] to convert.
+ * @param pb The protobuf builder to populate.
+ * @return [pb] for fluent use.
+ */
 fun toPb(cim: PowerElectronicsConnection, pb: PBPowerElectronicsConnection.Builder): PBPowerElectronicsConnection.Builder =
     pb.apply {
         clearPowerElectronicsUnitMRIDs()
@@ -1059,6 +1977,13 @@ fun toPb(cim: PowerElectronicsConnection, pb: PBPowerElectronicsConnection.Build
         toPb(cim, rceBuilder)
     }
 
+/**
+ * Convert the [PowerElectronicsConnectionPhase] into its protobuf counterpart.
+ *
+ * @param cim The [PowerElectronicsConnectionPhase] to convert.
+ * @param pb The protobuf builder to populate.
+ * @return [pb] for fluent use.
+ */
 fun toPb(cim: PowerElectronicsConnectionPhase, pb: PBPowerElectronicsConnectionPhase.Builder): PBPowerElectronicsConnectionPhase.Builder =
     pb.apply {
         cim.powerElectronicsConnection?.let { powerElectronicsConnectionMRID = it.mRID } ?: clearPowerElectronicsConnectionMRID()
@@ -1068,6 +1993,13 @@ fun toPb(cim: PowerElectronicsConnectionPhase, pb: PBPowerElectronicsConnectionP
         toPb(cim, psrBuilder)
     }
 
+/**
+ * Convert the [PowerTransformer] into its protobuf counterpart.
+ *
+ * @param cim The [PowerTransformer] to convert.
+ * @param pb The protobuf builder to populate.
+ * @return [pb] for fluent use.
+ */
 fun toPb(cim: PowerTransformer, pb: PBPowerTransformer.Builder): PBPowerTransformer.Builder =
     pb.apply {
         clearPowerTransformerEndMRIDs()
@@ -1079,6 +2011,13 @@ fun toPb(cim: PowerTransformer, pb: PBPowerTransformer.Builder): PBPowerTransfor
         toPb(cim, ceBuilder)
     }
 
+/**
+ * Convert the [PowerTransformerEnd] into its protobuf counterpart.
+ *
+ * @param cim The [PowerTransformerEnd] to convert.
+ * @param pb The protobuf builder to populate.
+ * @return [pb] for fluent use.
+ */
 fun toPb(cim: PowerTransformerEnd, pb: PBPowerTransformerEnd.Builder): PBPowerTransformerEnd.Builder =
     pb.apply {
         cim.powerTransformer?.let { powerTransformerMRID = it.mRID } ?: clearPowerTransformerMRID()
@@ -1097,6 +2036,13 @@ fun toPb(cim: PowerTransformerEnd, pb: PBPowerTransformerEnd.Builder): PBPowerTr
         toPb(cim, teBuilder)
     }
 
+/**
+ * Convert the [ProtectedSwitch] into its protobuf counterpart.
+ *
+ * @param cim The [ProtectedSwitch] to convert.
+ * @param pb The protobuf builder to populate.
+ * @return [pb] for fluent use.
+ */
 fun toPb(cim: ProtectedSwitch, pb: PBProtectedSwitch.Builder): PBProtectedSwitch.Builder =
     pb.apply {
         cim.relayFunctions.forEach { addRelayFunctionMRIDs(it.mRID) }
@@ -1104,6 +2050,13 @@ fun toPb(cim: ProtectedSwitch, pb: PBProtectedSwitch.Builder): PBProtectedSwitch
         toPb(cim, swBuilder)
     }
 
+/**
+ * Convert the [RatioTapChanger] into its protobuf counterpart.
+ *
+ * @param cim The [RatioTapChanger] to convert.
+ * @param pb The protobuf builder to populate.
+ * @return [pb] for fluent use.
+ */
 fun toPb(cim: RatioTapChanger, pb: PBRatioTapChanger.Builder): PBRatioTapChanger.Builder =
     pb.apply {
         cim.transformerEnd?.let { transformerEndMRID = it.mRID } ?: clearTransformerEndMRID()
@@ -1111,14 +2064,35 @@ fun toPb(cim: RatioTapChanger, pb: PBRatioTapChanger.Builder): PBRatioTapChanger
         toPb(cim, tcBuilder)
     }
 
+/**
+ * Convert the [ReactiveCapabilityCurve] into its protobuf counterpart.
+ *
+ * @param cim The [ReactiveCapabilityCurve] to convert.
+ * @param pb The protobuf builder to populate.
+ * @return [pb] for fluent use.
+ */
 fun toPb(cim: ReactiveCapabilityCurve, pb: PBReactiveCapabilityCurve.Builder): PBReactiveCapabilityCurve.Builder =
     pb.apply {
         toPb(cim, cBuilder)
     }
 
+/**
+ * Convert the [Recloser] into its protobuf counterpart.
+ *
+ * @param cim The [Recloser] to convert.
+ * @param pb The protobuf builder to populate.
+ * @return [pb] for fluent use.
+ */
 fun toPb(cim: Recloser, pb: PBRecloser.Builder): PBRecloser.Builder =
     pb.apply { toPb(cim, swBuilder) }
 
+/**
+ * Convert the [RegulatingCondEq] into its protobuf counterpart.
+ *
+ * @param cim The [RegulatingCondEq] to convert.
+ * @param pb The protobuf builder to populate.
+ * @return [pb] for fluent use.
+ */
 fun toPb(cim: RegulatingCondEq, pb: PBRegulatingCondEq.Builder): PBRegulatingCondEq.Builder =
     pb.apply {
         controlEnabled = cim.controlEnabled
@@ -1126,6 +2100,13 @@ fun toPb(cim: RegulatingCondEq, pb: PBRegulatingCondEq.Builder): PBRegulatingCon
         toPb(cim, ecBuilder)
     }
 
+/**
+ * Convert the [RegulatingControl] into its protobuf counterpart.
+ *
+ * @param cim The [RegulatingControl] to convert.
+ * @param pb The protobuf builder to populate.
+ * @return [pb] for fluent use.
+ */
 fun toPb(cim: RegulatingControl, pb: PBRegulatingControl.Builder): PBRegulatingControl.Builder =
     pb.apply {
         cim.discrete?.let { discreteSet = it } ?: run { discreteNull = NullValue.NULL_VALUE }
@@ -1144,6 +2125,13 @@ fun toPb(cim: RegulatingControl, pb: PBRegulatingControl.Builder): PBRegulatingC
         toPb(cim, psrBuilder)
     }
 
+/**
+ * Convert the [RotatingMachine] into its protobuf counterpart.
+ *
+ * @param cim The [RotatingMachine] to convert.
+ * @param pb The protobuf builder to populate.
+ * @return [pb] for fluent use.
+ */
 fun toPb(cim: RotatingMachine, pb: PBRotatingMachine.Builder): PBRotatingMachine.Builder =
     pb.apply {
         ratedPowerFactor = cim.ratedPowerFactor ?: UNKNOWN_DOUBLE
@@ -1154,6 +2142,13 @@ fun toPb(cim: RotatingMachine, pb: PBRotatingMachine.Builder): PBRotatingMachine
         toPb(cim, rceBuilder)
     }
 
+/**
+ * Convert the [SeriesCompensator] into its protobuf counterpart.
+ *
+ * @param cim The [SeriesCompensator] to convert.
+ * @param pb The protobuf builder to populate.
+ * @return [pb] for fluent use.
+ */
 fun toPb(cim: SeriesCompensator, pb: PBSeriesCompensator.Builder): PBSeriesCompensator.Builder =
     pb.apply {
         r = cim.r ?: UNKNOWN_DOUBLE
@@ -1165,6 +2160,13 @@ fun toPb(cim: SeriesCompensator, pb: PBSeriesCompensator.Builder): PBSeriesCompe
         toPb(cim, ceBuilder)
     }
 
+/**
+ * Convert the [ShuntCompensator] into its protobuf counterpart.
+ *
+ * @param cim The [ShuntCompensator] to convert.
+ * @param pb The protobuf builder to populate.
+ * @return [pb] for fluent use.
+ */
 fun toPb(cim: ShuntCompensator, pb: PBShuntCompensator.Builder): PBShuntCompensator.Builder =
     pb.apply {
         sections = cim.sections ?: UNKNOWN_DOUBLE
@@ -1174,6 +2176,13 @@ fun toPb(cim: ShuntCompensator, pb: PBShuntCompensator.Builder): PBShuntCompensa
         toPb(cim, rceBuilder)
     }
 
+/**
+ * Convert the [Switch] into its protobuf counterpart.
+ *
+ * @param cim The [Switch] to convert.
+ * @param pb The protobuf builder to populate.
+ * @return [pb] for fluent use.
+ */
 fun toPb(cim: Switch, pb: PBSwitch.Builder): PBSwitch.Builder =
     pb.apply {
         ratedCurrent = cim.ratedCurrent ?: UNKNOWN_DOUBLE
@@ -1185,6 +2194,13 @@ fun toPb(cim: Switch, pb: PBSwitch.Builder): PBSwitch.Builder =
         toPb(cim, ceBuilder)
     }
 
+/**
+ * Convert the [SynchronousMachine] into its protobuf counterpart.
+ *
+ * @param cim The [SynchronousMachine] to convert.
+ * @param pb The protobuf builder to populate.
+ * @return [pb] for fluent use.
+ */
 fun toPb(cim: SynchronousMachine, pb: PBSynchronousMachine.Builder): PBSynchronousMachine.Builder =
     pb.apply {
         clearReactiveCapabilityCurveMRIDs()
@@ -1214,6 +2230,13 @@ fun toPb(cim: SynchronousMachine, pb: PBSynchronousMachine.Builder): PBSynchrono
         toPb(cim, rmBuilder)
     }
 
+/**
+ * Convert the [TapChanger] into its protobuf counterpart.
+ *
+ * @param cim The [TapChanger] to convert.
+ * @param pb The protobuf builder to populate.
+ * @return [pb] for fluent use.
+ */
 fun toPb(cim: TapChanger, pb: PBTapChanger.Builder): PBTapChanger.Builder =
     pb.apply {
         highStep = cim.highStep ?: UNKNOWN_INT
@@ -1228,6 +2251,13 @@ fun toPb(cim: TapChanger, pb: PBTapChanger.Builder): PBTapChanger.Builder =
         toPb(cim, psrBuilder)
     }
 
+/**
+ * Convert the [TapChangerControl] into its protobuf counterpart.
+ *
+ * @param cim The [TapChangerControl] to convert.
+ * @param pb The protobuf builder to populate.
+ * @return [pb] for fluent use.
+ */
 fun toPb(cim: TapChangerControl, pb: PBTapChangerControl.Builder): PBTapChangerControl.Builder =
     pb.apply {
         limitVoltage = cim.limitVoltage ?: UNKNOWN_INT
@@ -1246,6 +2276,13 @@ fun toPb(cim: TapChangerControl, pb: PBTapChangerControl.Builder): PBTapChangerC
         toPb(cim, rcBuilder)
     }
 
+/**
+ * Convert the [TransformerEnd] into its protobuf counterpart.
+ *
+ * @param cim The [TransformerEnd] to convert.
+ * @param pb The protobuf builder to populate.
+ * @return [pb] for fluent use.
+ */
 fun toPb(cim: TransformerEnd, pb: PBTransformerEnd.Builder): PBTransformerEnd.Builder =
     pb.apply {
         cim.terminal?.let { terminalMRID = it.mRID } ?: clearTerminalMRID()
@@ -1259,12 +2296,25 @@ fun toPb(cim: TransformerEnd, pb: PBTransformerEnd.Builder): PBTransformerEnd.Bu
         toPb(cim, ioBuilder)
     }
 
+/**
+ * Convert the [TransformerEndRatedS] into its protobuf counterpart.
+ *
+ * @param cim The [TransformerEndRatedS] to convert.
+ * @return The protobuf form of [cim].
+ */
 fun toPb(cim: TransformerEndRatedS): PBTransformerEndRatedS.Builder =
     PBTransformerEndRatedS.newBuilder().apply {
         ratedS = cim.ratedS
         coolingType = TransformerCoolingType.valueOf(cim.coolingType.name)
     }
 
+/**
+ * Convert the [TransformerStarImpedance] into its protobuf counterpart.
+ *
+ * @param cim The [TransformerStarImpedance] to convert.
+ * @param pb The protobuf builder to populate.
+ * @return [pb] for fluent use.
+ */
 fun toPb(cim: TransformerStarImpedance, pb: PBTransformerStarImpedance.Builder): PBTransformerStarImpedance.Builder =
     pb.apply {
         cim.transformerEndInfo?.let { transformerEndInfoMRID = it.mRID } ?: clearTransformerEndInfoMRID()
@@ -1275,38 +2325,162 @@ fun toPb(cim: TransformerStarImpedance, pb: PBTransformerStarImpedance.Builder):
         toPb(cim, ioBuilder)
     }
 
+/**
+ * An extension for converting any AcLineSegment into its protobuf counterpart.
+ */
 fun AcLineSegment.toPb(): PBAcLineSegment = toPb(this, PBAcLineSegment.newBuilder()).build()
+
+/**
+ * An extension for converting any Breaker into its protobuf counterpart.
+ */
 fun Breaker.toPb(): PBBreaker = toPb(this, PBBreaker.newBuilder()).build()
+
+/**
+ * An extension for converting any BusbarSection into its protobuf counterpart.
+ */
 fun BusbarSection.toPb(): PBBusbarSection = toPb(this, PBBusbarSection.newBuilder()).build()
+
+/**
+ * An extension for converting any Disconnector into its protobuf counterpart.
+ */
 fun Disconnector.toPb(): PBDisconnector = toPb(this, PBDisconnector.newBuilder()).build()
+
+/**
+ * An extension for converting any EnergyConsumer into its protobuf counterpart.
+ */
 fun EnergyConsumer.toPb(): PBEnergyConsumer = toPb(this, PBEnergyConsumer.newBuilder()).build()
+
+/**
+ * An extension for converting any EnergyConsumerPhase into its protobuf counterpart.
+ */
 fun EnergyConsumerPhase.toPb(): PBEnergyConsumerPhase = toPb(this, PBEnergyConsumerPhase.newBuilder()).build()
+
+/**
+ * An extension for converting any EnergySource into its protobuf counterpart.
+ */
 fun EnergySource.toPb(): PBEnergySource = toPb(this, PBEnergySource.newBuilder()).build()
+
+/**
+ * An extension for converting any EnergySourcePhase into its protobuf counterpart.
+ */
 fun EnergySourcePhase.toPb(): PBEnergySourcePhase = toPb(this, PBEnergySourcePhase.newBuilder()).build()
+
+/**
+ * An extension for converting any Fuse into its protobuf counterpart.
+ */
 fun Fuse.toPb(): PBFuse = toPb(this, PBFuse.newBuilder()).build()
+
+/**
+ * An extension for converting any Ground into its protobuf counterpart.
+ */
 fun Ground.toPb(): PBGround = toPb(this, PBGround.newBuilder()).build()
+
+/**
+ * An extension for converting any GroundDisconnector into its protobuf counterpart.
+ */
 fun GroundDisconnector.toPb(): PBGroundDisconnector = toPb(this, PBGroundDisconnector.newBuilder()).build()
+
+/**
+ * An extension for converting any GroundingImpedance into its protobuf counterpart.
+ */
 fun GroundingImpedance.toPb(): PBGroundingImpedance = toPb(this, PBGroundingImpedance.newBuilder()).build()
+
+/**
+ * An extension for converting any Jumper into its protobuf counterpart.
+ */
 fun Jumper.toPb(): PBJumper = toPb(this, PBJumper.newBuilder()).build()
+
+/**
+ * An extension for converting any Junction into its protobuf counterpart.
+ */
 fun Junction.toPb(): PBJunction = toPb(this, PBJunction.newBuilder()).build()
+
+/**
+ * An extension for converting any LinearShuntCompensator into its protobuf counterpart.
+ */
 fun LinearShuntCompensator.toPb(): PBLinearShuntCompensator = toPb(this, PBLinearShuntCompensator.newBuilder()).build()
+
+/**
+ * An extension for converting any LoadBreakSwitch into its protobuf counterpart.
+ */
 fun LoadBreakSwitch.toPb(): PBLoadBreakSwitch = toPb(this, PBLoadBreakSwitch.newBuilder()).build()
+
+/**
+ * An extension for converting any PerLengthSequenceImpedance into its protobuf counterpart.
+ */
 fun PerLengthSequenceImpedance.toPb(): PBPerLengthSequenceImpedance = toPb(this, PBPerLengthSequenceImpedance.newBuilder()).build()
+
+/**
+ * An extension for converting any PetersenCoil into its protobuf counterpart.
+ */
 fun PetersenCoil.toPb(): PBPetersenCoil = toPb(this, PBPetersenCoil.newBuilder()).build()
+
+/**
+ * An extension for converting any PowerElectronicsConnection into its protobuf counterpart.
+ */
 fun PowerElectronicsConnection.toPb(): PBPowerElectronicsConnection = toPb(this, PBPowerElectronicsConnection.newBuilder()).build()
+
+/**
+ * An extension for converting any PowerElectronicsConnectionPhase into its protobuf counterpart.
+ */
 fun PowerElectronicsConnectionPhase.toPb(): PBPowerElectronicsConnectionPhase = toPb(this, PBPowerElectronicsConnectionPhase.newBuilder()).build()
+
+/**
+ * An extension for converting any PowerTransformer into its protobuf counterpart.
+ */
 fun PowerTransformer.toPb(): PBPowerTransformer = toPb(this, PBPowerTransformer.newBuilder()).build()
+
+/**
+ * An extension for converting any PowerTransformerEnd into its protobuf counterpart.
+ */
 fun PowerTransformerEnd.toPb(): PBPowerTransformerEnd = toPb(this, PBPowerTransformerEnd.newBuilder()).build()
+
+/**
+ * An extension for converting any RatioTapChanger into its protobuf counterpart.
+ */
 fun RatioTapChanger.toPb(): PBRatioTapChanger = toPb(this, PBRatioTapChanger.newBuilder()).build()
+
+/**
+ * An extension for converting any ReactiveCapabilityCurve into its protobuf counterpart.
+ */
 fun ReactiveCapabilityCurve.toPb(): PBReactiveCapabilityCurve = toPb(this, PBReactiveCapabilityCurve.newBuilder()).build()
+
+/**
+ * An extension for converting any Recloser into its protobuf counterpart.
+ */
 fun Recloser.toPb(): PBRecloser = toPb(this, PBRecloser.newBuilder()).build()
+
+/**
+ * An extension for converting any SeriesCompensator into its protobuf counterpart.
+ */
 fun SeriesCompensator.toPb(): PBSeriesCompensator = toPb(this, PBSeriesCompensator.newBuilder()).build()
+
+/**
+ * An extension for converting any SynchronousMachine into its protobuf counterpart.
+ */
 fun SynchronousMachine.toPb(): PBSynchronousMachine = toPb(this, PBSynchronousMachine.newBuilder()).build()
+
+/**
+ * An extension for converting any TapChangerControl into its protobuf counterpart.
+ */
 fun TapChangerControl.toPb(): PBTapChangerControl = toPb(this, PBTapChangerControl.newBuilder()).build()
+
+/**
+ * An extension for converting any TransformerStarImpedance into its protobuf counterpart.
+ */
 fun TransformerStarImpedance.toPb(): PBTransformerStarImpedance = toPb(this, PBTransformerStarImpedance.newBuilder()).build()
 
-/************ IEC61970 InfIEC61970 Feeder ************/
+// ###############################
+// # IEC61970 InfIEC61970 Feeder #
+// ###############################
 
+/**
+ * Convert the [Circuit] into its protobuf counterpart.
+ *
+ * @param cim The [Circuit] to convert.
+ * @param pb The protobuf builder to populate.
+ * @return [pb] for fluent use.
+ */
 fun toPb(cim: Circuit, pb: PBCircuit.Builder): PBCircuit.Builder =
     pb.apply {
         cim.loop?.let { loopMRID = it.mRID } ?: clearLoopMRID()
@@ -1320,6 +2494,13 @@ fun toPb(cim: Circuit, pb: PBCircuit.Builder): PBCircuit.Builder =
         toPb(cim, lBuilder)
     }
 
+/**
+ * Convert the [Loop] into its protobuf counterpart.
+ *
+ * @param cim The [Loop] to convert.
+ * @param pb The protobuf builder to populate.
+ * @return [pb] for fluent use.
+ */
 fun toPb(cim: Loop, pb: PBLoop.Builder): PBLoop.Builder =
     pb.apply {
         clearCircuitMRIDs()
@@ -1334,6 +2515,13 @@ fun toPb(cim: Loop, pb: PBLoop.Builder): PBLoop.Builder =
         toPb(cim, ioBuilder)
     }
 
+/**
+ * Convert the [LvFeeder] into its protobuf counterpart.
+ *
+ * @param cim The [LvFeeder] to convert.
+ * @param pb The protobuf builder to populate.
+ * @return [pb] for fluent use.
+ */
 fun toPb(cim: LvFeeder, pb: PBLvFeeder.Builder): PBLvFeeder.Builder =
     pb.apply {
         cim.normalHeadTerminal?.let { normalHeadTerminalMRID = it.mRID } ?: clearNormalHeadTerminalMRID()
@@ -1344,133 +2532,753 @@ fun toPb(cim: LvFeeder, pb: PBLvFeeder.Builder): PBLvFeeder.Builder =
         toPb(cim, ecBuilder)
     }
 
+/**
+ * An extension for converting any Circuit into its protobuf counterpart.
+ */
 fun Circuit.toPb(): PBCircuit = toPb(this, PBCircuit.newBuilder()).build()
+
+/**
+ * An extension for converting any Loop into its protobuf counterpart.
+ */
 fun Loop.toPb(): PBLoop = toPb(this, PBLoop.newBuilder()).build()
+
+/**
+ * An extension for converting any LvFeeder into its protobuf counterpart.
+ */
 fun LvFeeder.toPb(): PBLvFeeder = toPb(this, PBLvFeeder.newBuilder()).build()
 
-/************ IEC61970 InfIEC61970 Wires.Generation.Production ************/
+// ####################################################
+// # IEC61970 InfIEC61970 Wires.Generation.Production #
+// ####################################################
 
+/**
+ * Convert the [EvChargingUnit] into its protobuf counterpart.
+ *
+ * @param cim The [EvChargingUnit] to convert.
+ * @param pb The protobuf builder to populate.
+ * @return [pb] for fluent use.
+ */
 fun toPb(cim: EvChargingUnit, pb: PBEvChargingUnit.Builder): PBEvChargingUnit.Builder =
     pb.apply {
         toPb(cim, peuBuilder)
     }
 
+/**
+ * An extension for converting any EvChargingUnit into its protobuf counterpart.
+ */
 fun EvChargingUnit.toPb(): PBEvChargingUnit = toPb(this, PBEvChargingUnit.newBuilder()).build()
 
-/************ Class for Java friendly usage ************/
+// #################################
+// # Class for Java friendly usage #
+// #################################
 
+/**
+ * A helper class for Java friendly convertion from CIM objects to their protobuf counterparts.
+ */
 class NetworkCimToProto : BaseCimToProto() {
 
-    // IEC61968 ASSET INFO
+    // #######################
+    // # IEC61968 ASSET INFO #
+    // #######################
+
+    /**
+     * Convert the [CableInfo] into its protobuf counterpart.
+     *
+     * @param cim The [CableInfo] to convert.
+     * @return The protobuf form of [cim].
+     */
     fun toPb(cim: CableInfo): PBCableInfo = cim.toPb()
+
+    /**
+     * Convert the [NoLoadTest] into its protobuf counterpart.
+     *
+     * @param cim The [NoLoadTest] to convert.
+     * @return The protobuf form of [cim].
+     */
     fun toPb(cim: NoLoadTest): PBNoLoadTest = cim.toPb()
+
+    /**
+     * Convert the [OpenCircuitTest] into its protobuf counterpart.
+     *
+     * @param cim The [OpenCircuitTest] to convert.
+     * @return The protobuf form of [cim].
+     */
     fun toPb(cim: OpenCircuitTest): PBOpenCircuitTest = cim.toPb()
+
+    /**
+     * Convert the [OverheadWireInfo] into its protobuf counterpart.
+     *
+     * @param cim The [OverheadWireInfo] to convert.
+     * @return The protobuf form of [cim].
+     */
     fun toPb(cim: OverheadWireInfo): PBOverheadWireInfo = cim.toPb()
+
+    /**
+     * Convert the [PowerTransformerInfo] into its protobuf counterpart.
+     *
+     * @param cim The [PowerTransformerInfo] to convert.
+     * @return The protobuf form of [cim].
+     */
     fun toPb(cim: PowerTransformerInfo): PBPowerTransformerInfo = cim.toPb()
+
+    /**
+     * Convert the [ShortCircuitTest] into its protobuf counterpart.
+     *
+     * @param cim The [ShortCircuitTest] to convert.
+     * @return The protobuf form of [cim].
+     */
     fun toPb(cim: ShortCircuitTest): PBShortCircuitTest = cim.toPb()
+
+    /**
+     * Convert the [ShuntCompensatorInfo] into its protobuf counterpart.
+     *
+     * @param cim The [ShuntCompensatorInfo] to convert.
+     * @return The protobuf form of [cim].
+     */
     fun toPb(cim: ShuntCompensatorInfo): PBShuntCompensatorInfo = cim.toPb()
+
+    /**
+     * Convert the [SwitchInfo] into its protobuf counterpart.
+     *
+     * @param cim The [SwitchInfo] to convert.
+     * @return The protobuf form of [cim].
+     */
     fun toPb(cim: SwitchInfo): PBSwitchInfo = cim.toPb()
+
+    /**
+     * Convert the [TransformerEndInfo] into its protobuf counterpart.
+     *
+     * @param cim The [TransformerEndInfo] to convert.
+     * @return The protobuf form of [cim].
+     */
     fun toPb(cim: TransformerEndInfo): PBTransformerEndInfo = cim.toPb()
+
+    /**
+     * Convert the [TransformerTankInfo] into its protobuf counterpart.
+     *
+     * @param cim The [TransformerTankInfo] to convert.
+     * @return The protobuf form of [cim].
+     */
     fun toPb(cim: TransformerTankInfo): PBTransformerTankInfo = cim.toPb()
 
-    // IEC61968 ASSETS
+    // ###################
+    // # IEC61968 ASSETS #
+    // ###################
+
+    /**
+     * Convert the [AssetOwner] into its protobuf counterpart.
+     *
+     * @param cim The [AssetOwner] to convert.
+     * @return The protobuf form of [cim].
+     */
     fun toPb(cim: AssetOwner): PBAssetOwner = cim.toPb()
+
+    /**
+     * Convert the [Pole] into its protobuf counterpart.
+     *
+     * @param cim The [Pole] to convert.
+     * @return The protobuf form of [cim].
+     */
     fun toPb(cim: Pole): PBPole = cim.toPb()
+
+    /**
+     * Convert the [Streetlight] into its protobuf counterpart.
+     *
+     * @param cim The [Streetlight] to convert.
+     * @return The protobuf form of [cim].
+     */
     fun toPb(cim: Streetlight): PBStreetlight = cim.toPb()
 
-    // IEC61968 COMMON
+    // ###################
+    // # IEC61968 COMMON #
+    // ###################
+
+    /**
+     * Convert the [Location] into its protobuf counterpart.
+     *
+     * @param cim The [Location] to convert.
+     * @return The protobuf form of [cim].
+     */
     fun toPb(cim: Location): PBLocation = cim.toPb()
 
-    // IEC61968 infIEC61968 InfAssetInfo
+    // #####################################
+    // # IEC61968 infIEC61968 InfAssetInfo #
+    // #####################################
+
+    /**
+     * Convert the [RelayInfo] into its protobuf counterpart.
+     *
+     * @param cim The [RelayInfo] to convert.
+     * @return The protobuf form of [cim].
+     */
     fun toPb(cim: RelayInfo): PBRelayInfo = cim.toPb()
+
+    /**
+     * Convert the [CurrentTransformerInfo] into its protobuf counterpart.
+     *
+     * @param cim The [CurrentTransformerInfo] to convert.
+     * @return The protobuf form of [cim].
+     */
     fun toPb(cim: CurrentTransformerInfo): PBCurrentTransformerInfo = cim.toPb()
+
+    /**
+     * Convert the [PotentialTransformerInfo] into its protobuf counterpart.
+     *
+     * @param cim The [PotentialTransformerInfo] to convert.
+     * @return The protobuf form of [cim].
+     */
     fun toPb(cim: PotentialTransformerInfo): PBPotentialTransformerInfo = cim.toPb()
 
-    // IEC61968 METERING
+    // #####################
+    // # IEC61968 METERING #
+    // #####################
+
+    /**
+     * Convert the [Meter] into its protobuf counterpart.
+     *
+     * @param cim The [Meter] to convert.
+     * @return The protobuf form of [cim].
+     */
     fun toPb(cim: Meter): PBMeter = cim.toPb()
+
+    /**
+     * Convert the [UsagePoint] into its protobuf counterpart.
+     *
+     * @param cim The [UsagePoint] to convert.
+     * @return The protobuf form of [cim].
+     */
     fun toPb(cim: UsagePoint): PBUsagePoint = cim.toPb()
 
-    // IEC61968 OPERATIONS
+    // #######################
+    // # IEC61968 OPERATIONS #
+    // #######################
+
+    /**
+     * Convert the [OperationalRestriction] into its protobuf counterpart.
+     *
+     * @param cim The [OperationalRestriction] to convert.
+     * @return The protobuf form of [cim].
+     */
     fun toPb(cim: OperationalRestriction): PBOperationalRestriction = cim.toPb()
 
-    // IEC61970 BASE AUXILIARY EQUIPMENT
+    // #####################################
+    // # IEC61970 BASE AUXILIARY EQUIPMENT #
+    // #####################################
+
+    /**
+     * Convert the [CurrentTransformer] into its protobuf counterpart.
+     *
+     * @param cim The [CurrentTransformer] to convert.
+     * @return The protobuf form of [cim].
+     */
     fun toPb(cim: CurrentTransformer): PBCurrentTransformer = cim.toPb()
+
+    /**
+     * Convert the [FaultIndicator] into its protobuf counterpart.
+     *
+     * @param cim The [FaultIndicator] to convert.
+     * @return The protobuf form of [cim].
+     */
     fun toPb(cim: FaultIndicator): PBFaultIndicator = cim.toPb()
+
+    /**
+     * Convert the [PotentialTransformer] into its protobuf counterpart.
+     *
+     * @param cim The [PotentialTransformer] to convert.
+     * @return The protobuf form of [cim].
+     */
     fun toPb(cim: PotentialTransformer): PBPotentialTransformer = cim.toPb()
 
-    // IEC61970 BASE CORE
+    // ######################
+    // # IEC61970 BASE CORE #
+    // ######################
+
+    /**
+     * Convert the [BaseVoltage] into its protobuf counterpart.
+     *
+     * @param cim The [BaseVoltage] to convert.
+     * @return The protobuf form of [cim].
+     */
     fun toPb(cim: BaseVoltage): PBBaseVoltage = cim.toPb()
+
+    /**
+     * Convert the [ConnectivityNode] into its protobuf counterpart.
+     *
+     * @param cim The [ConnectivityNode] to convert.
+     * @return The protobuf form of [cim].
+     */
     fun toPb(cim: ConnectivityNode): PBConnectivityNode = cim.toPb()
+
+    /**
+     * Convert the [CurveData] into its protobuf counterpart.
+     *
+     * @param cim The [CurveData] to convert.
+     * @return The protobuf form of [cim].
+     */
     fun toPb(cim: CurveData): PBCurveData = cim.toPb()
+
+    /**
+     * Convert the [Feeder] into its protobuf counterpart.
+     *
+     * @param cim The [Feeder] to convert.
+     * @return The protobuf form of [cim].
+     */
     fun toPb(cim: Feeder): PBFeeder = cim.toPb()
+
+    /**
+     * Convert the [GeographicalRegion] into its protobuf counterpart.
+     *
+     * @param cim The [GeographicalRegion] to convert.
+     * @return The protobuf form of [cim].
+     */
     fun toPb(cim: GeographicalRegion): PBGeographicalRegion = cim.toPb()
+
+    /**
+     * Convert the [Site] into its protobuf counterpart.
+     *
+     * @param cim The [Site] to convert.
+     * @return The protobuf form of [cim].
+     */
     fun toPb(cim: Site): PBSite = cim.toPb()
+
+    /**
+     * Convert the [SubGeographicalRegion] into its protobuf counterpart.
+     *
+     * @param cim The [SubGeographicalRegion] to convert.
+     * @return The protobuf form of [cim].
+     */
     fun toPb(cim: SubGeographicalRegion): PBSubGeographicalRegion = cim.toPb()
+
+    /**
+     * Convert the [Substation] into its protobuf counterpart.
+     *
+     * @param cim The [Substation] to convert.
+     * @return The protobuf form of [cim].
+     */
     fun toPb(cim: Substation): PBSubstation = cim.toPb()
+
+    /**
+     * Convert the [Terminal] into its protobuf counterpart.
+     *
+     * @param cim The [Terminal] to convert.
+     * @return The protobuf form of [cim].
+     */
     fun toPb(cim: Terminal): PBTerminal = cim.toPb()
 
-    // IEC61970 BASE EQUIVALENTS
+    // #############################
+    // # IEC61970 BASE EQUIVALENTS #
+    // #############################
+
+    /**
+     * Convert the [EquivalentBranch] into its protobuf counterpart.
+     *
+     * @param cim The [EquivalentBranch] to convert.
+     * @return The protobuf form of [cim].
+     */
     fun toPb(cim: EquivalentBranch): PBEquivalentBranch = cim.toPb()
 
-    // IEC61970 BASE MEAS
+    // ######################
+    // # IEC61970 BASE MEAS #
+    // ######################
+
+    /**
+     * Convert the [Accumulator] into its protobuf counterpart.
+     *
+     * @param cim The [Accumulator] to convert.
+     * @return The protobuf form of [cim].
+     */
     fun toPb(cim: Accumulator): PBAccumulator = cim.toPb()
+
+    /**
+     * Convert the [Analog] into its protobuf counterpart.
+     *
+     * @param cim The [Analog] to convert.
+     * @return The protobuf form of [cim].
+     */
     fun toPb(cim: Analog): PBAnalog = cim.toPb()
+
+    /**
+     * Convert the [Control] into its protobuf counterpart.
+     *
+     * @param cim The [Control] to convert.
+     * @return The protobuf form of [cim].
+     */
     fun toPb(cim: Control): PBControl = cim.toPb()
+
+    /**
+     * Convert the [Discrete] into its protobuf counterpart.
+     *
+     * @param cim The [Discrete] to convert.
+     * @return The protobuf form of [cim].
+     */
     fun toPb(cim: Discrete): PBDiscrete = cim.toPb()
 
-    // IEC61970 Base Protection
+    // ############################
+    // # IEC61970 Base Protection #
+    // ############################
+
+    /**
+     * Convert the [CurrentRelay] into its protobuf counterpart.
+     *
+     * @param cim The [CurrentRelay] to convert.
+     * @return The protobuf form of [cim].
+     */
     fun toPb(cim: CurrentRelay): PBCurrentRelay = cim.toPb()
+
+    /**
+     * Convert the [DistanceRelay] into its protobuf counterpart.
+     *
+     * @param cim The [DistanceRelay] to convert.
+     * @return The protobuf form of [cim].
+     */
     fun toPb(cim: DistanceRelay): PBDistanceRelay = cim.toPb()
+
+    /**
+     * Convert the [ProtectionRelayScheme] into its protobuf counterpart.
+     *
+     * @param cim The [ProtectionRelayScheme] to convert.
+     * @return The protobuf form of [cim].
+     */
     fun toPb(cim: ProtectionRelayScheme): PBProtectionRelayScheme = cim.toPb()
+
+    /**
+     * Convert the [ProtectionRelaySystem] into its protobuf counterpart.
+     *
+     * @param cim The [ProtectionRelaySystem] to convert.
+     * @return The protobuf form of [cim].
+     */
     fun toPb(cim: ProtectionRelaySystem): PBProtectionRelaySystem = cim.toPb()
+
+    /**
+     * Convert the [VoltageRelay] into its protobuf counterpart.
+     *
+     * @param cim The [VoltageRelay] to convert.
+     * @return The protobuf form of [cim].
+     */
     fun toPb(cim: VoltageRelay): PBVoltageRelay = cim.toPb()
 
-    // IEC61970 BASE SCADA
+    // #######################
+    // # IEC61970 BASE SCADA #
+    // #######################
+
+    /**
+     * Convert the [RemoteControl] into its protobuf counterpart.
+     *
+     * @param cim The [RemoteControl] to convert.
+     * @return The protobuf form of [cim].
+     */
     fun toPb(cim: RemoteControl): PBRemoteControl = cim.toPb()
+
+    /**
+     * Convert the [RemoteSource] into its protobuf counterpart.
+     *
+     * @param cim The [RemoteSource] to convert.
+     * @return The protobuf form of [cim].
+     */
     fun toPb(cim: RemoteSource): PBRemoteSource = cim.toPb()
 
-    // IEC61970 BASE WIRES GENERATION PRODUCTION
+    // #############################################
+    // # IEC61970 BASE WIRES GENERATION PRODUCTION #
+    // #############################################
+
+    /**
+     * Convert the [BatteryUnit] into its protobuf counterpart.
+     *
+     * @param cim The [BatteryUnit] to convert.
+     * @return The protobuf form of [cim].
+     */
     fun toPb(cim: BatteryUnit): PBBatteryUnit = cim.toPb()
+
+    /**
+     * Convert the [PhotoVoltaicUnit] into its protobuf counterpart.
+     *
+     * @param cim The [PhotoVoltaicUnit] to convert.
+     * @return The protobuf form of [cim].
+     */
     fun toPb(cim: PhotoVoltaicUnit): PBPhotoVoltaicUnit = cim.toPb()
+
+    /**
+     * Convert the [PowerElectronicsWindUnit] into its protobuf counterpart.
+     *
+     * @param cim The [PowerElectronicsWindUnit] to convert.
+     * @return The protobuf form of [cim].
+     */
     fun toPb(cim: PowerElectronicsWindUnit): PBPowerElectronicsWindUnit = cim.toPb()
 
-    // IEC61970 BASE WIRES
+    // #######################
+    // # IEC61970 BASE WIRES #
+    // #######################
+
+    /**
+     * Convert the [AcLineSegment] into its protobuf counterpart.
+     *
+     * @param cim The [AcLineSegment] to convert.
+     * @return The protobuf form of [cim].
+     */
     fun toPb(cim: AcLineSegment): PBAcLineSegment = cim.toPb()
+
+    /**
+     * Convert the [Breaker] into its protobuf counterpart.
+     *
+     * @param cim The [Breaker] to convert.
+     * @return The protobuf form of [cim].
+     */
     fun toPb(cim: Breaker): PBBreaker = cim.toPb()
+
+    /**
+     * Convert the [BusbarSection] into its protobuf counterpart.
+     *
+     * @param cim The [BusbarSection] to convert.
+     * @return The protobuf form of [cim].
+     */
     fun toPb(cim: BusbarSection): PBBusbarSection = cim.toPb()
+
+    /**
+     * Convert the [Disconnector] into its protobuf counterpart.
+     *
+     * @param cim The [Disconnector] to convert.
+     * @return The protobuf form of [cim].
+     */
     fun toPb(cim: Disconnector): PBDisconnector = cim.toPb()
+
+    /**
+     * Convert the [EnergyConsumer] into its protobuf counterpart.
+     *
+     * @param cim The [EnergyConsumer] to convert.
+     * @return The protobuf form of [cim].
+     */
     fun toPb(cim: EnergyConsumer): PBEnergyConsumer = cim.toPb()
+
+    /**
+     * Convert the [EnergyConsumerPhase] into its protobuf counterpart.
+     *
+     * @param cim The [EnergyConsumerPhase] to convert.
+     * @return The protobuf form of [cim].
+     */
     fun toPb(cim: EnergyConsumerPhase): PBEnergyConsumerPhase = cim.toPb()
+
+    /**
+     * Convert the [EnergySource] into its protobuf counterpart.
+     *
+     * @param cim The [EnergySource] to convert.
+     * @return The protobuf form of [cim].
+     */
     fun toPb(cim: EnergySource): PBEnergySource = cim.toPb()
+
+    /**
+     * Convert the [EnergySourcePhase] into its protobuf counterpart.
+     *
+     * @param cim The [EnergySourcePhase] to convert.
+     * @return The protobuf form of [cim].
+     */
     fun toPb(cim: EnergySourcePhase): PBEnergySourcePhase = cim.toPb()
+
+    /**
+     * Convert the [Fuse] into its protobuf counterpart.
+     *
+     * @param cim The [Fuse] to convert.
+     * @return The protobuf form of [cim].
+     */
     fun toPb(cim: Fuse): PBFuse = cim.toPb()
+
+    /**
+     * Convert the [Ground] into its protobuf counterpart.
+     *
+     * @param cim The [Ground] to convert.
+     * @return The protobuf form of [cim].
+     */
     fun toPb(cim: Ground): PBGround = cim.toPb()
+
+    /**
+     * Convert the [GroundDisconnector] into its protobuf counterpart.
+     *
+     * @param cim The [GroundDisconnector] to convert.
+     * @return The protobuf form of [cim].
+     */
     fun toPb(cim: GroundDisconnector): PBGroundDisconnector = cim.toPb()
+
+    /**
+     * Convert the [GroundingImpedance] into its protobuf counterpart.
+     *
+     * @param cim The [GroundingImpedance] to convert.
+     * @return The protobuf form of [cim].
+     */
     fun toPb(cim: GroundingImpedance): PBGroundingImpedance = cim.toPb()
+
+    /**
+     * Convert the [Jumper] into its protobuf counterpart.
+     *
+     * @param cim The [Jumper] to convert.
+     * @return The protobuf form of [cim].
+     */
     fun toPb(cim: Jumper): PBJumper = cim.toPb()
+
+    /**
+     * Convert the [Junction] into its protobuf counterpart.
+     *
+     * @param cim The [Junction] to convert.
+     * @return The protobuf form of [cim].
+     */
     fun toPb(cim: Junction): PBJunction = cim.toPb()
+
+    /**
+     * Convert the [LinearShuntCompensator] into its protobuf counterpart.
+     *
+     * @param cim The [LinearShuntCompensator] to convert.
+     * @return The protobuf form of [cim].
+     */
     fun toPb(cim: LinearShuntCompensator): PBLinearShuntCompensator = cim.toPb()
+
+    /**
+     * Convert the [LoadBreakSwitch] into its protobuf counterpart.
+     *
+     * @param cim The [LoadBreakSwitch] to convert.
+     * @return The protobuf form of [cim].
+     */
     fun toPb(cim: LoadBreakSwitch): PBLoadBreakSwitch = cim.toPb()
+
+    /**
+     * Convert the [PerLengthSequenceImpedance] into its protobuf counterpart.
+     *
+     * @param cim The [PerLengthSequenceImpedance] to convert.
+     * @return The protobuf form of [cim].
+     */
     fun toPb(cim: PerLengthSequenceImpedance): PBPerLengthSequenceImpedance = cim.toPb()
+
+    /**
+     * Convert the [PetersenCoil] into its protobuf counterpart.
+     *
+     * @param cim The [PetersenCoil] to convert.
+     * @return The protobuf form of [cim].
+     */
     fun toPb(cim: PetersenCoil): PBPetersenCoil = cim.toPb()
+
+    /**
+     * Convert the [PowerElectronicsConnection] into its protobuf counterpart.
+     *
+     * @param cim The [PowerElectronicsConnection] to convert.
+     * @return The protobuf form of [cim].
+     */
     fun toPb(cim: PowerElectronicsConnection): PBPowerElectronicsConnection = cim.toPb()
+
+    /**
+     * Convert the [PowerElectronicsConnectionPhase] into its protobuf counterpart.
+     *
+     * @param cim The [PowerElectronicsConnectionPhase] to convert.
+     * @return The protobuf form of [cim].
+     */
     fun toPb(cim: PowerElectronicsConnectionPhase): PBPowerElectronicsConnectionPhase = cim.toPb()
+
+    /**
+     * Convert the [PowerTransformer] into its protobuf counterpart.
+     *
+     * @param cim The [PowerTransformer] to convert.
+     * @return The protobuf form of [cim].
+     */
     fun toPb(cim: PowerTransformer): PBPowerTransformer = cim.toPb()
+
+    /**
+     * Convert the [PowerTransformerEnd] into its protobuf counterpart.
+     *
+     * @param cim The [PowerTransformerEnd] to convert.
+     * @return The protobuf form of [cim].
+     */
     fun toPb(cim: PowerTransformerEnd): PBPowerTransformerEnd = cim.toPb()
+
+    /**
+     * Convert the [RatioTapChanger] into its protobuf counterpart.
+     *
+     * @param cim The [RatioTapChanger] to convert.
+     * @return The protobuf form of [cim].
+     */
     fun toPb(cim: RatioTapChanger): PBRatioTapChanger = cim.toPb()
+
+    /**
+     * Convert the [ReactiveCapabilityCurve] into its protobuf counterpart.
+     *
+     * @param cim The [ReactiveCapabilityCurve] to convert.
+     * @return The protobuf form of [cim].
+     */
     fun toPb(cim: ReactiveCapabilityCurve): PBReactiveCapabilityCurve = cim.toPb()
+
+    /**
+     * Convert the [Recloser] into its protobuf counterpart.
+     *
+     * @param cim The [Recloser] to convert.
+     * @return The protobuf form of [cim].
+     */
     fun toPb(cim: Recloser): PBRecloser = cim.toPb()
+
+    /**
+     * Convert the [SeriesCompensator] into its protobuf counterpart.
+     *
+     * @param cim The [SeriesCompensator] to convert.
+     * @return The protobuf form of [cim].
+     */
     fun toPb(cim: SeriesCompensator): PBSeriesCompensator = cim.toPb()
+
+    /**
+     * Convert the [SynchronousMachine] into its protobuf counterpart.
+     *
+     * @param cim The [SynchronousMachine] to convert.
+     * @return The protobuf form of [cim].
+     */
     fun toPb(cim: SynchronousMachine): PBSynchronousMachine = cim.toPb()
+
+    /**
+     * Convert the [TapChangerControl] into its protobuf counterpart.
+     *
+     * @param cim The [TapChangerControl] to convert.
+     * @return The protobuf form of [cim].
+     */
     fun toPb(cim: TapChangerControl): PBTapChangerControl = cim.toPb()
+
+    /**
+     * Convert the [TransformerStarImpedance] into its protobuf counterpart.
+     *
+     * @param cim The [TransformerStarImpedance] to convert.
+     * @return The protobuf form of [cim].
+     */
     fun toPb(cim: TransformerStarImpedance): PBTransformerStarImpedance = cim.toPb()
 
-    // IEC61970 InfIEC61970 Base Wires Generation Production
+    // #########################################################
+    // # IEC61970 InfIEC61970 Base Wires Generation Production #
+    // #########################################################
+
+    /**
+     * Convert the [EvChargingUnit] into its protobuf counterpart.
+     *
+     * @param cim The [EvChargingUnit] to convert.
+     * @return The protobuf form of [cim].
+     */
     fun toPb(cim: EvChargingUnit): PBEvChargingUnit = cim.toPb()
 
-    // IEC61970 InfIEC61970 Feeder
+    // ###############################
+    // # IEC61970 InfIEC61970 Feeder #
+    // ###############################
+
+    /**
+     * Convert the [Circuit] into its protobuf counterpart.
+     *
+     * @param cim The [Circuit] to convert.
+     * @return The protobuf form of [cim].
+     */
     fun toPb(cim: Circuit): PBCircuit = cim.toPb()
+
+    /**
+     * Convert the [Loop] into its protobuf counterpart.
+     *
+     * @param cim The [Loop] to convert.
+     * @return The protobuf form of [cim].
+     */
     fun toPb(cim: Loop): PBLoop = cim.toPb()
+
+    /**
+     * Convert the [LvFeeder] into its protobuf counterpart.
+     *
+     * @param cim The [LvFeeder] to convert.
+     * @return The protobuf form of [cim].
+     */
     fun toPb(cim: LvFeeder): PBLvFeeder = cim.toPb()
 
 }

--- a/src/main/kotlin/com/zepben/evolve/services/network/translator/NetworkCimToProto.kt
+++ b/src/main/kotlin/com/zepben/evolve/services/network/translator/NetworkCimToProto.kt
@@ -191,9 +191,6 @@ import com.zepben.protobuf.cim.iec61970.infiec61970.wires.generation.production.
 fun toPb(cim: CableInfo, pb: PBCableInfo.Builder): PBCableInfo.Builder =
     pb.apply { toPb(cim, wiBuilder) }
 
-fun toPb(cim: OverheadWireInfo, pb: PBOverheadWireInfo.Builder): PBOverheadWireInfo.Builder =
-    pb.apply { toPb(cim, wiBuilder) }
-
 fun toPb(cim: NoLoadTest, pb: PBNoLoadTest.Builder): PBNoLoadTest.Builder =
     pb.apply {
         energisedEndVoltage = cim.energisedEndVoltage ?: UNKNOWN_INT
@@ -213,6 +210,9 @@ fun toPb(cim: OpenCircuitTest, pb: PBOpenCircuitTest.Builder): PBOpenCircuitTest
         phaseShift = cim.phaseShift ?: UNKNOWN_DOUBLE
         toPb(cim, ttBuilder)
     }
+
+fun toPb(cim: OverheadWireInfo, pb: PBOverheadWireInfo.Builder): PBOverheadWireInfo.Builder =
+    pb.apply { toPb(cim, wiBuilder) }
 
 fun toPb(cim: PowerTransformerInfo, pb: PBPowerTransformerInfo.Builder): PBPowerTransformerInfo.Builder =
     pb.apply {
@@ -235,7 +235,6 @@ fun toPb(cim: ShortCircuitTest, pb: PBShortCircuitTest.Builder): PBShortCircuitT
         voltageOhmicPart = cim.voltageOhmicPart ?: UNKNOWN_DOUBLE
         toPb(cim, ttBuilder)
     }
-
 
 fun toPb(cim: ShuntCompensatorInfo, pb: PBShuntCompensatorInfo.Builder): PBShuntCompensatorInfo.Builder =
     pb.apply {
@@ -399,14 +398,6 @@ fun Location.toPb(): PBLocation = toPb(this, PBLocation.newBuilder()).build()
 
 /************ IEC61968 infIEC61968 InfAssetInfo ************/
 
-fun toPb(cim: RelayInfo, pb: PBRelayInfo.Builder): PBRelayInfo.Builder =
-    pb.apply {
-        cim.curveSetting?.let { curveSetting = it } ?: clearCurveSetting()
-        cim.recloseFast?.let { recloseFastSet = it } ?: run { recloseFastNull = NullValue.NULL_VALUE }
-        cim.recloseDelays.forEach { addRecloseDelays(it) }
-        toPb(cim, aiBuilder)
-    }
-
 fun toPb(cim: CurrentTransformerInfo, pb: PBCurrentTransformerInfo.Builder): PBCurrentTransformerInfo.Builder =
     pb.apply {
         cim.accuracyClass?.let { accuracyClass = it } ?: clearAccuracyClass()
@@ -435,9 +426,17 @@ fun toPb(cim: PotentialTransformerInfo, pb: PBPotentialTransformerInfo.Builder):
         toPb(cim, aiBuilder)
     }
 
-fun RelayInfo.toPb(): PBRelayInfo = toPb(this, PBRelayInfo.newBuilder()).build()
+fun toPb(cim: RelayInfo, pb: PBRelayInfo.Builder): PBRelayInfo.Builder =
+    pb.apply {
+        cim.curveSetting?.let { curveSetting = it } ?: clearCurveSetting()
+        cim.recloseFast?.let { recloseFastSet = it } ?: run { recloseFastNull = NullValue.NULL_VALUE }
+        cim.recloseDelays.forEach { addRecloseDelays(it) }
+        toPb(cim, aiBuilder)
+    }
+
 fun CurrentTransformerInfo.toPb(): PBCurrentTransformerInfo = toPb(this, PBCurrentTransformerInfo.newBuilder()).build()
 fun PotentialTransformerInfo.toPb(): PBPotentialTransformerInfo = toPb(this, PBPotentialTransformerInfo.newBuilder()).build()
+fun RelayInfo.toPb(): PBRelayInfo = toPb(this, PBRelayInfo.newBuilder()).build()
 
 /************ IEC61968 infIEC61968 InfCommon ************/
 
@@ -690,15 +689,6 @@ fun EquivalentBranch.toPb(): PBEquivalentBranch = toPb(this, PBEquivalentBranch.
 
 /************ IEC61970 BASE MEAS ************/
 
-fun toPb(cim: Control, pb: PBControl.Builder): PBControl.Builder =
-    pb.apply {
-        cim.remoteControl?.let { remoteControlMRID = it.mRID } ?: clearRemoteControlMRID()
-        cim.powerSystemResourceMRID?.let { powerSystemResourceMRID = it } ?: clearPowerSystemResourceMRID()
-        toPb(cim, ipBuilder)
-    }
-
-fun toPb(cim: IoPoint, pb: PBIoPoint.Builder): PBIoPoint.Builder = pb.apply { toPb(cim, ioBuilder) }
-
 fun toPb(cim: Accumulator, pb: PBAccumulator.Builder): PBAccumulator.Builder = pb.apply { toPb(cim, measurementBuilder) }
 
 fun toPb(cim: Analog, pb: PBAnalog.Builder): PBAnalog.Builder =
@@ -707,7 +697,16 @@ fun toPb(cim: Analog, pb: PBAnalog.Builder): PBAnalog.Builder =
         toPb(cim, measurementBuilder)
     }
 
+fun toPb(cim: Control, pb: PBControl.Builder): PBControl.Builder =
+    pb.apply {
+        cim.remoteControl?.let { remoteControlMRID = it.mRID } ?: clearRemoteControlMRID()
+        cim.powerSystemResourceMRID?.let { powerSystemResourceMRID = it } ?: clearPowerSystemResourceMRID()
+        toPb(cim, ipBuilder)
+    }
+
 fun toPb(cim: Discrete, pb: PBDiscrete.Builder): PBDiscrete.Builder = pb.apply { toPb(cim, measurementBuilder) }
+
+fun toPb(cim: IoPoint, pb: PBIoPoint.Builder): PBIoPoint.Builder = pb.apply { toPb(cim, ioBuilder) }
 
 fun toPb(cim: Measurement, pb: PBMeasurement.Builder): PBMeasurement.Builder =
     pb.apply {
@@ -818,14 +817,6 @@ fun RemoteSource.toPb(): PBRemoteSource = toPb(this, PBRemoteSource.newBuilder()
 
 /************ IEC61970 BASE WIRES GENERATION PRODUCTION ************/
 
-fun toPb(cim: PowerElectronicsUnit, pb: PBPowerElectronicsUnit.Builder): PBPowerElectronicsUnit.Builder =
-    pb.apply {
-        cim.powerElectronicsConnection?.let { powerElectronicsConnectionMRID = it.mRID } ?: clearPowerElectronicsConnectionMRID()
-        maxP = cim.maxP ?: UNKNOWN_INT
-        minP = cim.minP ?: UNKNOWN_INT
-        toPb(cim, eqBuilder)
-    }
-
 fun toPb(cim: BatteryUnit, pb: PBBatteryUnit.Builder): PBBatteryUnit.Builder =
     pb.apply {
         batteryState = BatteryStateKind.valueOf(cim.batteryState.name)
@@ -837,6 +828,14 @@ fun toPb(cim: BatteryUnit, pb: PBBatteryUnit.Builder): PBBatteryUnit.Builder =
 fun toPb(cim: PhotoVoltaicUnit, pb: PBPhotoVoltaicUnit.Builder): PBPhotoVoltaicUnit.Builder =
     pb.apply {
         toPb(cim, peuBuilder)
+    }
+
+fun toPb(cim: PowerElectronicsUnit, pb: PBPowerElectronicsUnit.Builder): PBPowerElectronicsUnit.Builder =
+    pb.apply {
+        cim.powerElectronicsConnection?.let { powerElectronicsConnectionMRID = it.mRID } ?: clearPowerElectronicsConnectionMRID()
+        maxP = cim.maxP ?: UNKNOWN_INT
+        minP = cim.minP ?: UNKNOWN_INT
+        toPb(cim, eqBuilder)
     }
 
 fun toPb(cim: PowerElectronicsWindUnit, pb: PBPowerElectronicsWindUnit.Builder): PBPowerElectronicsWindUnit.Builder =
@@ -861,9 +860,6 @@ fun toPb(cim: Breaker, pb: PBBreaker.Builder): PBBreaker.Builder =
         inTransitTime = cim.inTransitTime ?: UNKNOWN_DOUBLE
         toPb(cim, swBuilder)
     }
-
-fun toPb(cim: LoadBreakSwitch, pb: PBLoadBreakSwitch.Builder): PBLoadBreakSwitch.Builder =
-    pb.apply { toPb(cim, psBuilder) }
 
 fun toPb(cim: BusbarSection, pb: PBBusbarSection.Builder): PBBusbarSection.Builder =
     pb.apply { toPb(cim, cnBuilder) }
@@ -993,11 +989,14 @@ fun toPb(cim: LinearShuntCompensator, pb: PBLinearShuntCompensator.Builder): PBL
         toPb(cim, scBuilder)
     }
 
-fun toPb(cim: PerLengthLineParameter, pb: PBPerLengthLineParameter.Builder): PBPerLengthLineParameter.Builder =
-    pb.apply { toPb(cim, ioBuilder) }
+fun toPb(cim: LoadBreakSwitch, pb: PBLoadBreakSwitch.Builder): PBLoadBreakSwitch.Builder =
+    pb.apply { toPb(cim, psBuilder) }
 
 fun toPb(cim: PerLengthImpedance, pb: PBPerLengthImpedance.Builder): PBPerLengthImpedance.Builder =
     pb.apply { toPb(cim, lpBuilder) }
+
+fun toPb(cim: PerLengthLineParameter, pb: PBPerLengthLineParameter.Builder): PBPerLengthLineParameter.Builder =
+    pb.apply { toPb(cim, ioBuilder) }
 
 fun toPb(cim: PerLengthSequenceImpedance, pb: PBPerLengthSequenceImpedance.Builder): PBPerLengthSequenceImpedance.Builder =
     pb.apply {
@@ -1119,7 +1118,6 @@ fun toPb(cim: ReactiveCapabilityCurve, pb: PBReactiveCapabilityCurve.Builder): P
 
 fun toPb(cim: Recloser, pb: PBRecloser.Builder): PBRecloser.Builder =
     pb.apply { toPb(cim, swBuilder) }
-
 
 fun toPb(cim: RegulatingCondEq, pb: PBRegulatingCondEq.Builder): PBRegulatingCondEq.Builder =
     pb.apply {

--- a/src/main/kotlin/com/zepben/evolve/services/network/translator/NetworkCimToProto.kt
+++ b/src/main/kotlin/com/zepben/evolve/services/network/translator/NetworkCimToProto.kt
@@ -1178,7 +1178,7 @@ fun toPb(cim: ShuntCompensator, pb: PBShuntCompensator.Builder): PBShuntCompensa
 
 fun toPb(cim: Switch, pb: PBSwitch.Builder): PBSwitch.Builder =
     pb.apply {
-        ratedCurrent = cim.ratedCurrent ?: UNKNOWN_UINT
+        ratedCurrent = cim.ratedCurrent ?: UNKNOWN_DOUBLE
         normalOpen = cim.isNormallyOpen()
         open = cim.isOpen()
         // when unganged support is added to protobuf
@@ -1187,10 +1187,10 @@ fun toPb(cim: Switch, pb: PBSwitch.Builder): PBSwitch.Builder =
         toPb(cim, ceBuilder)
     }
 
-
 fun toPb(cim: SynchronousMachine, pb: PBSynchronousMachine.Builder): PBSynchronousMachine.Builder =
     pb.apply {
-        cim.curves.forEach { curve -> addReactiveCapabilityCurveMRIDsBuilder().apply { toPb(curve, this) } }
+        clearReactiveCapabilityCurveMRIDs()
+        cim.curves.forEach { addReactiveCapabilityCurveMRIDs(it.mRID) }
         baseQ = cim.baseQ ?: UNKNOWN_DOUBLE
         condenserP = cim.condenserP ?: UNKNOWN_INT
         earthing = cim.earthing

--- a/src/main/kotlin/com/zepben/evolve/services/network/translator/NetworkProtoToCim.kt
+++ b/src/main/kotlin/com/zepben/evolve/services/network/translator/NetworkProtoToCim.kt
@@ -170,18 +170,41 @@ import com.zepben.protobuf.cim.iec61970.infiec61970.feeder.Loop as PBLoop
 import com.zepben.protobuf.cim.iec61970.infiec61970.feeder.LvFeeder as PBLvFeeder
 import com.zepben.protobuf.cim.iec61970.infiec61970.wires.generation.production.EvChargingUnit as PBEvChargingUnit
 
-/************ IEC61968 ASSET INFO ************/
+// #######################
+// # IEC61968 ASSET INFO #
+// #######################
 
+/**
+ * Convert the protobuf [PBCableInfo] into its CIM counterpart.
+ *
+ * @param pb The protobuf [PBCableInfo] to convert.
+ * @param networkService The [NetworkService] the converted CIM object will be added too.
+ * @return The converted [pb] as a CIM [CableInfo].
+ */
 fun toCim(pb: PBCableInfo, networkService: NetworkService): CableInfo =
     CableInfo(pb.mRID()).apply {
         toCim(pb.wi, this, networkService)
     }
 
+/**
+ * Convert the protobuf [PBOverheadWireInfo] into its CIM counterpart.
+ *
+ * @param pb The protobuf [PBOverheadWireInfo] to convert.
+ * @param networkService The [NetworkService] the converted CIM object will be added too.
+ * @return The converted [pb] as a CIM [OverheadWireInfo].
+ */
 fun toCim(pb: PBOverheadWireInfo, networkService: NetworkService): OverheadWireInfo =
     OverheadWireInfo(pb.mRID()).apply {
         toCim(pb.wi, this, networkService)
     }
 
+/**
+ * Convert the protobuf [PBNoLoadTest] into its CIM counterpart.
+ *
+ * @param pb The protobuf [PBNoLoadTest] to convert.
+ * @param networkService The [NetworkService] the converted CIM object will be added too.
+ * @return The converted [pb] as a CIM [NoLoadTest].
+ */
 fun toCim(pb: PBNoLoadTest, networkService: NetworkService): NoLoadTest =
     NoLoadTest(pb.mRID()).apply {
         energisedEndVoltage = pb.energisedEndVoltage.takeUnless { it == UNKNOWN_INT }
@@ -192,6 +215,13 @@ fun toCim(pb: PBNoLoadTest, networkService: NetworkService): NoLoadTest =
         toCim(pb.tt, this, networkService)
     }
 
+/**
+ * Convert the protobuf [PBOpenCircuitTest] into its CIM counterpart.
+ *
+ * @param pb The protobuf [PBOpenCircuitTest] to convert.
+ * @param networkService The [NetworkService] the converted CIM object will be added too.
+ * @return The converted [pb] as a CIM [OpenCircuitTest].
+ */
 fun toCim(pb: PBOpenCircuitTest, networkService: NetworkService): OpenCircuitTest =
     OpenCircuitTest(pb.mRID()).apply {
         energisedEndStep = pb.energisedEndStep.takeUnless { it == UNKNOWN_INT }
@@ -202,6 +232,13 @@ fun toCim(pb: PBOpenCircuitTest, networkService: NetworkService): OpenCircuitTes
         toCim(pb.tt, this, networkService)
     }
 
+/**
+ * Convert the protobuf [PBPowerTransformerInfo] into its CIM counterpart.
+ *
+ * @param pb The protobuf [PBPowerTransformerInfo] to convert.
+ * @param networkService The [NetworkService] the converted CIM object will be added too.
+ * @return The converted [pb] as a CIM [PowerTransformerInfo].
+ */
 fun toCim(pb: PBPowerTransformerInfo, networkService: NetworkService): PowerTransformerInfo =
     PowerTransformerInfo(pb.mRID()).apply {
         pb.transformerTankInfoMRIDsList.forEach {
@@ -210,6 +247,13 @@ fun toCim(pb: PBPowerTransformerInfo, networkService: NetworkService): PowerTran
         toCim(pb.ai, this, networkService)
     }
 
+/**
+ * Convert the protobuf [PBShortCircuitTest] into its CIM counterpart.
+ *
+ * @param pb The protobuf [PBShortCircuitTest] to convert.
+ * @param networkService The [NetworkService] the converted CIM object will be added too.
+ * @return The converted [pb] as a CIM [ShortCircuitTest].
+ */
 fun toCim(pb: PBShortCircuitTest, networkService: NetworkService): ShortCircuitTest =
     ShortCircuitTest(pb.mRID()).apply {
         current = pb.current.takeUnless { it == UNKNOWN_DOUBLE }
@@ -226,6 +270,13 @@ fun toCim(pb: PBShortCircuitTest, networkService: NetworkService): ShortCircuitT
     }
 
 
+/**
+ * Convert the protobuf [PBShuntCompensatorInfo] into its CIM counterpart.
+ *
+ * @param pb The protobuf [PBShuntCompensatorInfo] to convert.
+ * @param networkService The [NetworkService] the converted CIM object will be added too.
+ * @return The converted [pb] as a CIM [ShuntCompensatorInfo].
+ */
 fun toCim(pb: PBShuntCompensatorInfo, networkService: NetworkService): ShuntCompensatorInfo =
     ShuntCompensatorInfo(pb.mRID()).apply {
         maxPowerLoss = pb.maxPowerLoss.takeUnless { it == UNKNOWN_INT }
@@ -236,12 +287,26 @@ fun toCim(pb: PBShuntCompensatorInfo, networkService: NetworkService): ShuntComp
         toCim(pb.ai, this, networkService)
     }
 
+/**
+ * Convert the protobuf [PBSwitchInfo] into its CIM counterpart.
+ *
+ * @param pb The protobuf [PBSwitchInfo] to convert.
+ * @param networkService The [NetworkService] the converted CIM object will be added too.
+ * @return The converted [pb] as a CIM [SwitchInfo].
+ */
 fun toCim(pb: PBSwitchInfo, networkService: NetworkService): SwitchInfo =
     SwitchInfo(pb.mRID()).apply {
         ratedInterruptingTime = pb.ratedInterruptingTime.takeUnless { it == UNKNOWN_DOUBLE }
         toCim(pb.ai, this, networkService)
     }
 
+/**
+ * Convert the protobuf [PBTransformerEndInfo] into its CIM counterpart.
+ *
+ * @param pb The protobuf [PBTransformerEndInfo] to convert.
+ * @param networkService The [NetworkService] the converted CIM object will be added too.
+ * @return The converted [pb] as a CIM [TransformerEndInfo].
+ */
 fun toCim(pb: PBTransformerEndInfo, networkService: NetworkService): TransformerEndInfo =
     TransformerEndInfo(pb.mRID()).apply {
         connectionKind = WindingConnection.valueOf(pb.connectionKind.name)
@@ -265,6 +330,13 @@ fun toCim(pb: PBTransformerEndInfo, networkService: NetworkService): Transformer
         toCim(pb.ai, this, networkService)
     }
 
+/**
+ * Convert the protobuf [PBTransformerTankInfo] into its CIM counterpart.
+ *
+ * @param pb The protobuf [PBTransformerTankInfo] to convert.
+ * @param networkService The [NetworkService] the converted CIM object will be added too.
+ * @return The converted [pb] as a CIM [TransformerTankInfo].
+ */
 fun toCim(pb: PBTransformerTankInfo, networkService: NetworkService): TransformerTankInfo =
     TransformerTankInfo(pb.mRID()).apply {
         networkService.resolveOrDeferReference(Resolvers.powerTransformerInfo(this), pb.powerTransformerInfoMRID)
@@ -274,6 +346,14 @@ fun toCim(pb: PBTransformerTankInfo, networkService: NetworkService): Transforme
         toCim(pb.ai, this, networkService)
     }
 
+/**
+ * Convert the protobuf [PBTransformerTest] into its CIM counterpart.
+ *
+ * @param pb The protobuf [PBTransformerTest] to convert.
+ * @param cim The CIM [TransformerTest] to populate.
+ * @param networkService The [NetworkService] the converted CIM object will be added too.
+ * @return The converted [pb] as a CIM [TransformerTest].
+ */
 fun toCim(pb: PBTransformerTest, cim: TransformerTest, networkService: NetworkService): TransformerTest =
     cim.apply {
         basePower = pb.basePower.takeUnless { it == UNKNOWN_INT }
@@ -281,6 +361,14 @@ fun toCim(pb: PBTransformerTest, cim: TransformerTest, networkService: NetworkSe
         toCim(pb.io, this, networkService)
     }
 
+/**
+ * Convert the protobuf [PBWireInfo] into its CIM counterpart.
+ *
+ * @param pb The protobuf [PBWireInfo] to convert.
+ * @param cim The CIM [WireInfo] to populate.
+ * @param networkService The [NetworkService] the converted CIM object will be added too.
+ * @return The converted [pb] as a CIM [WireInfo].
+ */
 fun toCim(pb: PBWireInfo, cim: WireInfo, networkService: NetworkService): WireInfo =
     cim.apply {
         ratedCurrent = pb.ratedCurrent.takeUnless { it == UNKNOWN_INT }
@@ -288,19 +376,68 @@ fun toCim(pb: PBWireInfo, cim: WireInfo, networkService: NetworkService): WireIn
         toCim(pb.ai, this, networkService)
     }
 
+/**
+ * An extension to add a converted copy of the protobuf [PBCableInfo] to the [NetworkService].
+ */
 fun NetworkService.addFromPb(pb: PBCableInfo): CableInfo? = tryAddOrNull(toCim(pb, this))
+
+/**
+ * An extension to add a converted copy of the protobuf [PBNoLoadTest] to the [NetworkService].
+ */
 fun NetworkService.addFromPb(pb: PBNoLoadTest): NoLoadTest? = tryAddOrNull(toCim(pb, this))
+
+/**
+ * An extension to add a converted copy of the protobuf [PBOpenCircuitTest] to the [NetworkService].
+ */
 fun NetworkService.addFromPb(pb: PBOpenCircuitTest): OpenCircuitTest? = tryAddOrNull(toCim(pb, this))
+
+/**
+ * An extension to add a converted copy of the protobuf [PBOverheadWireInfo] to the [NetworkService].
+ */
 fun NetworkService.addFromPb(pb: PBOverheadWireInfo): OverheadWireInfo? = tryAddOrNull(toCim(pb, this))
+
+/**
+ * An extension to add a converted copy of the protobuf [PBPowerTransformerInfo] to the [NetworkService].
+ */
 fun NetworkService.addFromPb(pb: PBPowerTransformerInfo): PowerTransformerInfo? = tryAddOrNull(toCim(pb, this))
+
+/**
+ * An extension to add a converted copy of the protobuf [PBShortCircuitTest] to the [NetworkService].
+ */
 fun NetworkService.addFromPb(pb: PBShortCircuitTest): ShortCircuitTest? = tryAddOrNull(toCim(pb, this))
+
+/**
+ * An extension to add a converted copy of the protobuf [PBShuntCompensatorInfo] to the [NetworkService].
+ */
 fun NetworkService.addFromPb(pb: PBShuntCompensatorInfo): ShuntCompensatorInfo? = tryAddOrNull(toCim(pb, this))
+
+/**
+ * An extension to add a converted copy of the protobuf [PBSwitchInfo] to the [NetworkService].
+ */
 fun NetworkService.addFromPb(pb: PBSwitchInfo): SwitchInfo? = tryAddOrNull(toCim(pb, this))
+
+/**
+ * An extension to add a converted copy of the protobuf [PBTransformerEndInfo] to the [NetworkService].
+ */
 fun NetworkService.addFromPb(pb: PBTransformerEndInfo): TransformerEndInfo? = tryAddOrNull(toCim(pb, this))
+
+/**
+ * An extension to add a converted copy of the protobuf [PBTransformerTankInfo] to the [NetworkService].
+ */
 fun NetworkService.addFromPb(pb: PBTransformerTankInfo): TransformerTankInfo? = tryAddOrNull(toCim(pb, this))
 
-/************ IEC61968 ASSETS ************/
+// ###################
+// # IEC61968 ASSETS #
+// ###################
 
+/**
+ * Convert the protobuf [PBAsset] into its CIM counterpart.
+ *
+ * @param pb The protobuf [PBAsset] to convert.
+ * @param cim The CIM [Asset] to populate.
+ * @param networkService The [NetworkService] the converted CIM object will be added too.
+ * @return The converted [pb] as a CIM [Asset].
+ */
 fun toCim(pb: PBAsset, cim: Asset, networkService: NetworkService): Asset =
     cim.apply {
         networkService.resolveOrDeferReference(Resolvers.location(this), pb.locationMRID)
@@ -310,20 +447,58 @@ fun toCim(pb: PBAsset, cim: Asset, networkService: NetworkService): Asset =
         toCim(pb.io, this, networkService)
     }
 
+/**
+ * Convert the protobuf [PBAssetContainer] into its CIM counterpart.
+ *
+ * @param pb The protobuf [PBAssetContainer] to convert.
+ * @param cim The CIM [AssetContainer] to populate.
+ * @param networkService The [NetworkService] the converted CIM object will be added too.
+ * @return The converted [pb] as a CIM [AssetContainer].
+ */
 fun toCim(pb: PBAssetContainer, cim: AssetContainer, networkService: NetworkService): AssetContainer =
     cim.apply { toCim(pb.at, this, networkService) }
 
+/**
+ * Convert the protobuf [PBAssetInfo] into its CIM counterpart.
+ *
+ * @param pb The protobuf [PBAssetInfo] to convert.
+ * @param cim The CIM [AssetInfo] to populate.
+ * @param networkService The [NetworkService] the converted CIM object will be added too.
+ * @return The converted [pb] as a CIM [AssetInfo].
+ */
 fun toCim(pb: PBAssetInfo, cim: AssetInfo, networkService: NetworkService): AssetInfo =
     cim.apply { toCim(pb.io, this, networkService) }
 
+/**
+ * Convert the protobuf [PBAssetOrganisationRole] into its CIM counterpart.
+ *
+ * @param pb The protobuf [PBAssetOrganisationRole] to convert.
+ * @param cim The CIM [AssetOrganisationRole] to populate.
+ * @param networkService The [NetworkService] the converted CIM object will be added too.
+ * @return The converted [pb] as a CIM [AssetOrganisationRole].
+ */
 fun toCim(pb: PBAssetOrganisationRole, cim: AssetOrganisationRole, networkService: NetworkService): AssetOrganisationRole =
     cim.apply { toCim(pb.or, this, networkService) }
 
+/**
+ * Convert the protobuf [PBAssetOwner] into its CIM counterpart.
+ *
+ * @param pb The protobuf [PBAssetOwner] to convert.
+ * @param networkService The [NetworkService] the converted CIM object will be added too.
+ * @return The converted [pb] as a CIM [AssetOwner].
+ */
 fun toCim(pb: PBAssetOwner, networkService: NetworkService): AssetOwner =
     AssetOwner(pb.mRID()).apply {
         toCim(pb.aor, this, networkService)
     }
 
+/**
+ * Convert the protobuf [PBPole] into its CIM counterpart.
+ *
+ * @param pb The protobuf [PBPole] to convert.
+ * @param networkService The [NetworkService] the converted CIM object will be added too.
+ * @return The converted [pb] as a CIM [Pole].
+ */
 fun toCim(pb: PBPole, networkService: NetworkService): Pole =
     Pole(pb.mRID()).apply {
         classification = pb.classification.internEmpty()
@@ -333,6 +508,13 @@ fun toCim(pb: PBPole, networkService: NetworkService): Pole =
         toCim(pb.st, this, networkService)
     }
 
+/**
+ * Convert the protobuf [PBStreetlight] into its CIM counterpart.
+ *
+ * @param pb The protobuf [PBStreetlight] to convert.
+ * @param networkService The [NetworkService] the converted CIM object will be added too.
+ * @return The converted [pb] as a CIM [Streetlight].
+ */
 fun toCim(pb: PBStreetlight, networkService: NetworkService): Streetlight =
     Streetlight(pb.mRID()).apply {
         lampKind = StreetlightLampKind.valueOf(pb.lampKind.name)
@@ -341,15 +523,43 @@ fun toCim(pb: PBStreetlight, networkService: NetworkService): Streetlight =
         toCim(pb.at, this, networkService)
     }
 
+/**
+ * Convert the protobuf [PBStructure] into its CIM counterpart.
+ *
+ * @param pb The protobuf [PBStructure] to convert.
+ * @param cim The CIM [Structure] to populate.
+ * @param networkService The [NetworkService] the converted CIM object will be added too.
+ * @return The converted [pb] as a CIM [Structure].
+ */
 fun toCim(pb: PBStructure, cim: Structure, networkService: NetworkService): Structure =
     cim.apply { toCim(pb.ac, this, networkService) }
 
+/**
+ * An extension to add a converted copy of the protobuf [PBAssetOwner] to the [NetworkService].
+ */
 fun NetworkService.addFromPb(pb: PBAssetOwner): AssetOwner? = tryAddOrNull(toCim(pb, this))
+
+/**
+ * An extension to add a converted copy of the protobuf [PBPole] to the [NetworkService].
+ */
 fun NetworkService.addFromPb(pb: PBPole): Pole? = tryAddOrNull(toCim(pb, this))
+
+/**
+ * An extension to add a converted copy of the protobuf [PBStreetlight] to the [NetworkService].
+ */
 fun NetworkService.addFromPb(pb: PBStreetlight): Streetlight? = tryAddOrNull(toCim(pb, this))
 
-/************ IEC61968 COMMON ************/
+// ####################
+// # IEC61968 COMMON #
+// ####################
 
+/**
+ * Convert the protobuf [PBLocation] into its CIM counterpart.
+ *
+ * @param pb The protobuf [PBLocation] to convert.
+ * @param networkService The [NetworkService] the converted CIM object will be added too.
+ * @return The converted [pb] as a CIM [Location].
+ */
 fun toCim(pb: PBLocation, networkService: NetworkService): Location =
     Location(pb.mRID()).apply {
         mainAddress = if (pb.hasMainAddress()) toCim(pb.mainAddress) else null
@@ -357,9 +567,21 @@ fun toCim(pb: PBLocation, networkService: NetworkService): Location =
         toCim(pb.io, this, networkService)
     }
 
+/**
+ * Convert the protobuf [PBPositionPoint] into its CIM counterpart.
+ *
+ * @param pb The protobuf [PBPositionPoint] to convert.
+ * @return The converted [pb] as a CIM [PositionPoint].
+ */
 fun toCim(pb: PBPositionPoint): PositionPoint =
     PositionPoint(pb.xPosition, pb.yPosition)
 
+/**
+ * Convert the protobuf [PBStreetAddress] into its CIM counterpart.
+ *
+ * @param pb The protobuf [PBStreetAddress] to convert.
+ * @return The converted [pb] as a CIM [StreetAddress].
+ */
 fun toCim(pb: PBStreetAddress): StreetAddress =
     StreetAddress(
         pb.postalCode.internEmpty(),
@@ -368,6 +590,12 @@ fun toCim(pb: PBStreetAddress): StreetAddress =
         if (pb.hasStreetDetail()) toCim(pb.streetDetail) else null
     )
 
+/**
+ * Convert the protobuf [PBStreetDetail] into its CIM counterpart.
+ *
+ * @param pb The protobuf [PBStreetDetail] to convert.
+ * @return The converted [pb] as a CIM [StreetDetail].
+ */
 fun toCim(pb: PBStreetDetail): StreetDetail =
     StreetDetail(
         pb.buildingName.internEmpty(),
@@ -379,14 +607,36 @@ fun toCim(pb: PBStreetDetail): StreetDetail =
         pb.displayAddress.internEmpty()
     )
 
+/**
+ * Convert the protobuf [PBPositionPoint] into its CIM counterpart.
+ *
+ * @param pb The protobuf [PBPositionPoint] to convert.
+ * @return The converted [pb] as a CIM [PositionPoint].
+ */
 fun toCim(pb: PBTownDetail): TownDetail =
     TownDetail(pb.name.internEmpty(), pb.stateOrProvince.internEmpty())
 
+/**
+ * An extension to add a converted copy of the protobuf [PBOrganisation] to the [NetworkService].
+ */
 fun NetworkService.addFromPb(pb: PBOrganisation): Organisation? = tryAddOrNull(toCim(pb, this))
+
+/**
+ * An extension to add a converted copy of the protobuf [PBLocation] to the [NetworkService].
+ */
 fun NetworkService.addFromPb(pb: PBLocation): Location? = tryAddOrNull(toCim(pb, this))
 
-/************ IEC61968 infIEC61968 InfAssetInfo ************/
+// #####################################
+// # IEC61968 infIEC61968 InfAssetInfo #
+// #####################################
 
+/**
+ * Convert the protobuf [PBRelayInfo] into its CIM counterpart.
+ *
+ * @param pb The protobuf [PBRelayInfo] to convert.
+ * @param networkService The [NetworkService] the converted CIM object will be added too.
+ * @return The converted [pb] as a CIM [RelayInfo].
+ */
 fun toCim(pb: PBRelayInfo, networkService: NetworkService): RelayInfo =
     RelayInfo(pb.mRID()).apply {
         curveSetting = pb.curveSetting.takeIf { it.isNotBlank() }
@@ -397,6 +647,13 @@ fun toCim(pb: PBRelayInfo, networkService: NetworkService): RelayInfo =
         toCim(pb.ai, this, networkService)
     }
 
+/**
+ * Convert the protobuf [PBCurrentTransformerInfo] into its CIM counterpart.
+ *
+ * @param pb The protobuf [PBCurrentTransformerInfo] to convert.
+ * @param networkService The [NetworkService] the converted CIM object will be added too.
+ * @return The converted [pb] as a CIM [CurrentTransformerInfo].
+ */
 fun toCim(pb: PBCurrentTransformerInfo, networkService: NetworkService): CurrentTransformerInfo =
     CurrentTransformerInfo(pb.mRID()).apply {
         accuracyClass = pb.accuracyClass.takeIf { it.isNotBlank() }
@@ -414,6 +671,13 @@ fun toCim(pb: PBCurrentTransformerInfo, networkService: NetworkService): Current
         toCim(pb.ai, this, networkService)
     }
 
+/**
+ * Convert the protobuf [PBPotentialTransformerInfo] into its CIM counterpart.
+ *
+ * @param pb The protobuf [PBPotentialTransformerInfo] to convert.
+ * @param networkService The [NetworkService] the converted CIM object will be added too.
+ * @return The converted [pb] as a CIM [PotentialTransformerInfo].
+ */
 fun toCim(pb: PBPotentialTransformerInfo, networkService: NetworkService): PotentialTransformerInfo =
     PotentialTransformerInfo(pb.mRID()).apply {
         accuracyClass = pb.accuracyClass.takeIf { it.isNotBlank() }
@@ -425,17 +689,46 @@ fun toCim(pb: PBPotentialTransformerInfo, networkService: NetworkService): Poten
         toCim(pb.ai, this, networkService)
     }
 
+/**
+ * An extension to add a converted copy of the protobuf [PBRelayInfo] to the [NetworkService].
+ */
 fun NetworkService.addFromPb(pb: PBRelayInfo): RelayInfo? = tryAddOrNull(toCim(pb, this))
+
+/**
+ * An extension to add a converted copy of the protobuf [PBCurrentTransformerInfo] to the [NetworkService].
+ */
 fun NetworkService.addFromPb(pb: PBCurrentTransformerInfo): CurrentTransformerInfo? = tryAddOrNull(toCim(pb, this))
+
+/**
+ * An extension to add a converted copy of the protobuf [PBPotentialTransformerInfo] to the [NetworkService].
+ */
 fun NetworkService.addFromPb(pb: PBPotentialTransformerInfo): PotentialTransformerInfo? = tryAddOrNull(toCim(pb, this))
 
-/************ IEC61968 infIEC61968 InfCommon ************/
+// ##################################
+// # IEC61968 infIEC61968 InfCommon #
+// ##################################
 
+/**
+ * Convert the protobuf [PBRatio] into its CIM counterpart.
+ *
+ * @param pb The protobuf [PBRatio] to convert.
+ * @return The converted [pb] as a CIM [Ratio].
+ */
 fun toCim(pb: PBRatio): Ratio =
     Ratio(pb.numerator, pb.denominator)
 
-/************ IEC61968 METERING ************/
+// #####################
+// # IEC61968 METERING #
+// #####################
 
+/**
+ * Convert the protobuf [PBEndDevice] into its CIM counterpart.
+ *
+ * @param pb The protobuf [PBEndDevice] to convert.
+ * @param cim The CIM [EndDevice] to populate.
+ * @param networkService The [NetworkService] the converted CIM object will be added too.
+ * @return The converted [pb] as a CIM [EndDevice].
+ */
 fun toCim(pb: PBEndDevice, cim: EndDevice, networkService: NetworkService): EndDevice =
     cim.apply {
         pb.usagePointMRIDsList.forEach { usagePointMRID ->
@@ -446,11 +739,25 @@ fun toCim(pb: PBEndDevice, cim: EndDevice, networkService: NetworkService): EndD
         toCim(pb.ac, this, networkService)
     }
 
+/**
+ * Convert the protobuf [PBMeter] into its CIM counterpart.
+ *
+ * @param pb The protobuf [PBMeter] to convert.
+ * @param networkService The [NetworkService] the converted CIM object will be added too.
+ * @return The converted [pb] as a CIM [Meter].
+ */
 fun toCim(pb: PBMeter, networkService: NetworkService): Meter =
     Meter(pb.mRID()).apply {
         toCim(pb.ed, this, networkService)
     }
 
+/**
+ * Convert the protobuf [PBUsagePoint] into its CIM counterpart.
+ *
+ * @param pb The protobuf [PBUsagePoint] to convert.
+ * @param networkService The [NetworkService] the converted CIM object will be added too.
+ * @return The converted [pb] as a CIM [UsagePoint].
+ */
 fun toCim(pb: PBUsagePoint, networkService: NetworkService): UsagePoint =
     UsagePoint(pb.mRID()).apply {
         networkService.resolveOrDeferReference(Resolvers.usagePointLocation(this), pb.usagePointLocationMRID)
@@ -471,26 +778,62 @@ fun toCim(pb: PBUsagePoint, networkService: NetworkService): UsagePoint =
         toCim(pb.io, this, networkService)
     }
 
+/**
+ * An extension to add a converted copy of the protobuf [PBMeter] to the [NetworkService].
+ */
 fun NetworkService.addFromPb(pb: PBMeter): Meter? = tryAddOrNull(toCim(pb, this))
+
+/**
+ * An extension to add a converted copy of the protobuf [PBUsagePoint] to the [NetworkService].
+ */
 fun NetworkService.addFromPb(pb: PBUsagePoint): UsagePoint? = tryAddOrNull(toCim(pb, this))
 
-/************ IEC61968 OPERATIONS ************/
+// #######################
+// # IEC61968 OPERATIONS #
+// #######################
 
+/**
+ * Convert the protobuf [PBOperationalRestriction] into its CIM counterpart.
+ *
+ * @param pb The protobuf [PBOperationalRestriction] to convert.
+ * @param networkService The [NetworkService] the converted CIM object will be added too.
+ * @return The converted [pb] as a CIM [OperationalRestriction].
+ */
 fun toCim(pb: PBOperationalRestriction, networkService: NetworkService): OperationalRestriction =
     OperationalRestriction(pb.mRID()).apply {
         toCim(pb.doc, this, networkService)
     }
 
+/**
+ * An extension to add a converted copy of the protobuf [PBOperationalRestriction] to the [NetworkService].
+ */
 fun NetworkService.addFromPb(pb: PBOperationalRestriction): OperationalRestriction? = tryAddOrNull(toCim(pb, this))
 
-/************ IEC61970 AUXILIARY EQUIPMENT ************/
+// #################################
+// # IEC61970 AUXILIARY EQUIPMENT #
+// #################################
 
+/**
+ * Convert the protobuf [PBAuxiliaryEquipment] into its CIM counterpart.
+ *
+ * @param pb The protobuf [PBAuxiliaryEquipment] to convert.
+ * @param cim The CIM [AuxiliaryEquipment] to populate.
+ * @param networkService The [NetworkService] the converted CIM object will be added too.
+ * @return The converted [pb] as a CIM [AuxiliaryEquipment].
+ */
 fun toCim(pb: PBAuxiliaryEquipment, cim: AuxiliaryEquipment, networkService: NetworkService): AuxiliaryEquipment =
     cim.apply {
         networkService.resolveOrDeferReference(Resolvers.terminal(this), pb.terminalMRID)
         toCim(pb.eq, this, networkService)
     }
 
+/**
+ * Convert the protobuf [PBCurrentTransformer] into its CIM counterpart.
+ *
+ * @param pb The protobuf [PBCurrentTransformer] to convert.
+ * @param networkService The [NetworkService] the converted CIM object will be added too.
+ * @return The converted [pb] as a CIM [CurrentTransformer].
+ */
 fun toCim(pb: PBCurrentTransformer, networkService: NetworkService): CurrentTransformer =
     CurrentTransformer(pb.mRID()).apply {
         networkService.resolveOrDeferReference(Resolvers.assetInfo(this), pb.assetInfoMRID())
@@ -498,11 +841,25 @@ fun toCim(pb: PBCurrentTransformer, networkService: NetworkService): CurrentTran
         toCim(pb.sn, this, networkService)
     }
 
+/**
+ * Convert the protobuf [PBFaultIndicator] into its CIM counterpart.
+ *
+ * @param pb The protobuf [PBFaultIndicator] to convert.
+ * @param networkService The [NetworkService] the converted CIM object will be added too.
+ * @return The converted [pb] as a CIM [FaultIndicator].
+ */
 fun toCim(pb: PBFaultIndicator, networkService: NetworkService): FaultIndicator =
     FaultIndicator(pb.mRID()).apply {
         toCim(pb.ae, this, networkService)
     }
 
+/**
+ * Convert the protobuf [PBPotentialTransformer] into its CIM counterpart.
+ *
+ * @param pb The protobuf [PBPotentialTransformer] to convert.
+ * @param networkService The [NetworkService] the converted CIM object will be added too.
+ * @return The converted [pb] as a CIM [PotentialTransformer].
+ */
 fun toCim(pb: PBPotentialTransformer, networkService: NetworkService): PotentialTransformer =
     PotentialTransformer(pb.mRID()).apply {
         networkService.resolveOrDeferReference(Resolvers.assetInfo(this), pb.assetInfoMRID())
@@ -510,6 +867,14 @@ fun toCim(pb: PBPotentialTransformer, networkService: NetworkService): Potential
         toCim(pb.sn, this, networkService)
     }
 
+/**
+ * Convert the protobuf [PBSensor] into its CIM counterpart.
+ *
+ * @param pb The protobuf [PBSensor] to convert.
+ * @param cim The CIM [Sensor] to populate.
+ * @param networkService The [NetworkService] the converted CIM object will be added too.
+ * @return The converted [pb] as a CIM [Sensor].
+ */
 fun toCim(pb: PBSensor, cim: Sensor, networkService: NetworkService): Sensor =
     cim.apply {
         pb.relayFunctionMRIDsList.forEach { relayFunctionMRID ->
@@ -518,21 +883,57 @@ fun toCim(pb: PBSensor, cim: Sensor, networkService: NetworkService): Sensor =
         toCim(pb.ae, this, networkService)
     }
 
+/**
+ * An extension to add a converted copy of the protobuf [PBCurrentTransformer] to the [NetworkService].
+ */
 fun NetworkService.addFromPb(pb: PBCurrentTransformer): CurrentTransformer? = tryAddOrNull(toCim(pb, this))
+
+/**
+ * An extension to add a converted copy of the protobuf [PBFaultIndicator] to the [NetworkService].
+ */
 fun NetworkService.addFromPb(pb: PBFaultIndicator): FaultIndicator? = tryAddOrNull(toCim(pb, this))
+
+/**
+ * An extension to add a converted copy of the protobuf [PBPotentialTransformer] to the [NetworkService].
+ */
 fun NetworkService.addFromPb(pb: PBPotentialTransformer): PotentialTransformer? = tryAddOrNull(toCim(pb, this))
 
-/************ IEC61970 CORE ************/
+// #################
+// # IEC61970 CORE #
+// #################
 
+/**
+ * Convert the protobuf [PBAcDcTerminal] into its CIM counterpart.
+ *
+ * @param pb The protobuf [PBAcDcTerminal] to convert.
+ * @param cim The CIM [AcDcTerminal] to populate.
+ * @param networkService The [NetworkService] the converted CIM object will be added too.
+ * @return The converted [pb] as a CIM [AcDcTerminal].
+ */
 fun toCim(pb: PBAcDcTerminal, cim: AcDcTerminal, networkService: NetworkService): AcDcTerminal =
     cim.apply { toCim(pb.io, this, networkService) }
 
+/**
+ * Convert the protobuf [PBBaseVoltage] into its CIM counterpart.
+ *
+ * @param pb The protobuf [PBBaseVoltage] to convert.
+ * @param networkService The [NetworkService] the converted CIM object will be added too.
+ * @return The converted [pb] as a CIM [BaseVoltage].
+ */
 fun toCim(pb: PBBaseVoltage, networkService: NetworkService): BaseVoltage =
     BaseVoltage(pb.mRID()).apply {
         nominalVoltage = pb.nominalVoltage
         toCim(pb.io, this, networkService)
     }
 
+/**
+ * Convert the protobuf [PBConductingEquipment] into its CIM counterpart.
+ *
+ * @param pb The protobuf [PBConductingEquipment] to convert.
+ * @param cim The CIM [ConductingEquipment] to populate.
+ * @param networkService The [NetworkService] the converted CIM object will be added too.
+ * @return The converted [pb] as a CIM [ConductingEquipment].
+ */
 fun toCim(pb: PBConductingEquipment, cim: ConductingEquipment, networkService: NetworkService): ConductingEquipment =
     cim.apply {
         networkService.resolveOrDeferReference(Resolvers.baseVoltage(this), pb.baseVoltageMRID)
@@ -542,20 +943,49 @@ fun toCim(pb: PBConductingEquipment, cim: ConductingEquipment, networkService: N
         toCim(pb.eq, this, networkService)
     }
 
+/**
+ * Convert the protobuf [PBConnectivityNode] into its CIM counterpart.
+ *
+ * @param pb The protobuf [PBConnectivityNode] to convert.
+ * @param networkService The [NetworkService] the converted CIM object will be added too.
+ * @return The converted [pb] as a CIM [ConnectivityNode].
+ */
 fun toCim(pb: PBConnectivityNode, networkService: NetworkService): ConnectivityNode =
     ConnectivityNode(pb.mRID()).apply {
         toCim(pb.io, this, networkService)
     }
 
+/**
+ * Convert the protobuf [PBConnectivityNodeContainer] into its CIM counterpart.
+ *
+ * @param pb The protobuf [PBConnectivityNodeContainer] to convert.
+ * @param cim The CIM [ConnectivityNodeContainer] to populate.
+ * @param networkService The [NetworkService] the converted CIM object will be added too.
+ * @return The converted [pb] as a CIM [ConnectivityNodeContainer].
+ */
 fun toCim(pb: PBConnectivityNodeContainer, cim: ConnectivityNodeContainer, networkService: NetworkService): ConnectivityNodeContainer =
     cim.apply { toCim(pb.psr, this, networkService) }
 
+/**
+ * Convert the protobuf [PBCurve] into its CIM counterpart.
+ *
+ * @param pb The protobuf [PBCurve] to convert.
+ * @param cim The CIM [Curve] to populate.
+ * @param networkService The [NetworkService] the converted CIM object will be added too.
+ * @return The converted [pb] as a CIM [Curve].
+ */
 fun toCim(pb: PBCurve, cim: Curve, networkService: NetworkService): Curve =
     cim.apply {
         pb.curveDataList.forEach { addData(toCim(it)) }
         toCim(pb.io, this, networkService)
     }
 
+/**
+ * Convert the protobuf [PBCurveData] into its CIM counterpart.
+ *
+ * @param pb The protobuf [PBCurveData] to convert.
+ * @return The converted [pb] as a CIM [CurveData].
+ */
 fun toCim(pb: PBCurveData): CurveData =
     CurveData(
         pb.xValue,
@@ -564,6 +994,14 @@ fun toCim(pb: PBCurveData): CurveData =
         pb.y3Value.takeUnless { it == UNKNOWN_FLOAT }
     )
 
+/**
+ * Convert the protobuf [PBEquipment] into its CIM counterpart.
+ *
+ * @param pb The protobuf [PBEquipment] to convert.
+ * @param cim The CIM [Equipment] to populate.
+ * @param networkService The [NetworkService] the converted CIM object will be added too.
+ * @return The converted [pb] as a CIM [Equipment].
+ */
 fun toCim(pb: PBEquipment, cim: Equipment, networkService: NetworkService): Equipment =
     cim.apply {
         inService = pb.inService
@@ -589,11 +1027,26 @@ fun toCim(pb: PBEquipment, cim: Equipment, networkService: NetworkService): Equi
         toCim(pb.psr, this, networkService)
     }
 
+/**
+ * Convert the protobuf [PBEquipmentContainer] into its CIM counterpart.
+ *
+ * @param pb The protobuf [PBEquipmentContainer] to convert.
+ * @param cim The CIM [EquipmentContainer] to populate.
+ * @param networkService The [NetworkService] the converted CIM object will be added too.
+ * @return The converted [pb] as a CIM [EquipmentContainer].
+ */
 fun toCim(pb: PBEquipmentContainer, cim: EquipmentContainer, networkService: NetworkService): EquipmentContainer =
     cim.apply {
         toCim(pb.cnc, this, networkService)
     }
 
+/**
+ * Convert the protobuf [PBFeeder] into its CIM counterpart.
+ *
+ * @param pb The protobuf [PBFeeder] to convert.
+ * @param networkService The [NetworkService] the converted CIM object will be added too.
+ * @return The converted [pb] as a CIM [Feeder].
+ */
 fun toCim(pb: PBFeeder, networkService: NetworkService): Feeder =
     Feeder(pb.mRID()).apply {
         networkService.resolveOrDeferReference(Resolvers.normalHeadTerminal(this), pb.normalHeadTerminalMRID)
@@ -606,6 +1059,13 @@ fun toCim(pb: PBFeeder, networkService: NetworkService): Feeder =
         toCim(pb.ec, this, networkService)
     }
 
+/**
+ * Convert the protobuf [PBGeographicalRegion] into its CIM counterpart.
+ *
+ * @param pb The protobuf [PBGeographicalRegion] to convert.
+ * @param networkService The [NetworkService] the converted CIM object will be added too.
+ * @return The converted [pb] as a CIM [GeographicalRegion].
+ */
 fun toCim(pb: PBGeographicalRegion, networkService: NetworkService): GeographicalRegion =
     GeographicalRegion(pb.mRID()).apply {
         pb.subGeographicalRegionMRIDsList.forEach { subGeographicalRegionMRID ->
@@ -614,6 +1074,14 @@ fun toCim(pb: PBGeographicalRegion, networkService: NetworkService): Geographica
         toCim(pb.io, this, networkService)
     }
 
+/**
+ * Convert the protobuf [PBPowerSystemResource] into its CIM counterpart.
+ *
+ * @param pb The protobuf [PBPowerSystemResource] to convert.
+ * @param cim The CIM [PowerSystemResource] to populate.
+ * @param networkService The [NetworkService] the converted CIM object will be added too.
+ * @return The converted [pb] as a CIM [PowerSystemResource].
+ */
 fun toCim(pb: PBPowerSystemResource, cim: PowerSystemResource, networkService: NetworkService): PowerSystemResource =
     cim.apply {
         // NOTE: assetInfoMRID will be handled by classes that use it with specific types.
@@ -623,11 +1091,25 @@ fun toCim(pb: PBPowerSystemResource, cim: PowerSystemResource, networkService: N
         toCim(pb.io, this, networkService)
     }
 
+/**
+ * Convert the protobuf [PBSite] into its CIM counterpart.
+ *
+ * @param pb The protobuf [PBSite] to convert.
+ * @param networkService The [NetworkService] the converted CIM object will be added too.
+ * @return The converted [pb] as a CIM [Site].
+ */
 fun toCim(pb: PBSite, networkService: NetworkService): Site =
     Site(pb.mRID()).apply {
         toCim(pb.ec, this, networkService)
     }
 
+/**
+ * Convert the protobuf [PBSubGeographicalRegion] into its CIM counterpart.
+ *
+ * @param pb The protobuf [PBSubGeographicalRegion] to convert.
+ * @param networkService The [NetworkService] the converted CIM object will be added too.
+ * @return The converted [pb] as a CIM [SubGeographicalRegion].
+ */
 fun toCim(pb: PBSubGeographicalRegion, networkService: NetworkService): SubGeographicalRegion =
     SubGeographicalRegion(pb.mRID()).apply {
         networkService.resolveOrDeferReference(Resolvers.geographicalRegion(this), pb.geographicalRegionMRID)
@@ -638,6 +1120,13 @@ fun toCim(pb: PBSubGeographicalRegion, networkService: NetworkService): SubGeogr
         toCim(pb.io, this, networkService)
     }
 
+/**
+ * Convert the protobuf [PBSubstation] into its CIM counterpart.
+ *
+ * @param pb The protobuf [PBSubstation] to convert.
+ * @param networkService The [NetworkService] the converted CIM object will be added too.
+ * @return The converted [pb] as a CIM [Substation].
+ */
 fun toCim(pb: PBSubstation, networkService: NetworkService): Substation =
     Substation(pb.mRID()).apply {
         networkService.resolveOrDeferReference(Resolvers.subGeographicalRegion(this), pb.subGeographicalRegionMRID)
@@ -656,6 +1145,13 @@ fun toCim(pb: PBSubstation, networkService: NetworkService): Substation =
         toCim(pb.ec, this, networkService)
     }
 
+/**
+ * Convert the protobuf [PBTerminal] into its CIM counterpart.
+ *
+ * @param pb The protobuf [PBTerminal] to convert.
+ * @param networkService The [NetworkService] the converted CIM object will be added too.
+ * @return The converted [pb] as a CIM [Terminal].
+ */
 fun toCim(pb: PBTerminal, networkService: NetworkService): Terminal =
     Terminal(pb.mRID()).apply {
 
@@ -672,18 +1168,62 @@ fun toCim(pb: PBTerminal, networkService: NetworkService): Terminal =
         toCim(pb.ad, this, networkService)
     }
 
+/**
+ * An extension to add a converted copy of the protobuf [PBBaseVoltage] to the [NetworkService].
+ */
 fun NetworkService.addFromPb(pb: PBBaseVoltage): BaseVoltage? = tryAddOrNull(toCim(pb, this))
+
+/**
+ * An extension to add a converted copy of the protobuf [PBConnectivityNode] to the [NetworkService].
+ */
 fun NetworkService.addFromPb(pb: PBConnectivityNode): ConnectivityNode? = tryAddOrNull(toCim(pb, this))
+
+/**
+ * An extension to add a converted copy of the protobuf [PBFeeder] to the [NetworkService].
+ */
 fun NetworkService.addFromPb(pb: PBFeeder): Feeder? = tryAddOrNull(toCim(pb, this))
+
+/**
+ * An extension to add a converted copy of the protobuf [PBGeographicalRegion] to the [NetworkService].
+ */
 fun NetworkService.addFromPb(pb: PBGeographicalRegion): GeographicalRegion? = tryAddOrNull(toCim(pb, this))
+
+/**
+ * An extension to add a converted copy of the protobuf [PBNameType] to the [NetworkService].
+ */
 fun NetworkService.addFromPb(pb: PBNameType): NameType = toCim(pb, this) // Special case
+
+/**
+ * An extension to add a converted copy of the protobuf [PBSite] to the [NetworkService].
+ */
 fun NetworkService.addFromPb(pb: PBSite): Site? = tryAddOrNull(toCim(pb, this))
+
+/**
+ * An extension to add a converted copy of the protobuf [PBSubGeographicalRegion] to the [NetworkService].
+ */
 fun NetworkService.addFromPb(pb: PBSubGeographicalRegion): SubGeographicalRegion? = tryAddOrNull(toCim(pb, this))
+
+/**
+ * An extension to add a converted copy of the protobuf [PBSubstation] to the [NetworkService].
+ */
 fun NetworkService.addFromPb(pb: PBSubstation): Substation? = tryAddOrNull(toCim(pb, this))
+
+/**
+ * An extension to add a converted copy of the protobuf [PBTerminal] to the [NetworkService].
+ */
 fun NetworkService.addFromPb(pb: PBTerminal): Terminal? = tryAddOrNull(toCim(pb, this))
 
-/************ IEC61970 BASE EQUIVALENTS ************/
+// #############################
+// # IEC61970 BASE EQUIVALENTS #
+// #############################
 
+/**
+ * Convert the protobuf [PBEquivalentBranch] into its CIM counterpart.
+ *
+ * @param pb The protobuf [PBEquivalentBranch] to convert.
+ * @param networkService The [NetworkService] the converted CIM object will be added too.
+ * @return The converted [pb] as a CIM [EquivalentBranch].
+ */
 fun toCim(pb: PBEquivalentBranch, networkService: NetworkService): EquivalentBranch =
     EquivalentBranch(pb.mRID()).apply {
         negativeR12 = pb.negativeR12.takeUnless { it == UNKNOWN_DOUBLE }
@@ -705,13 +1245,33 @@ fun toCim(pb: PBEquivalentBranch, networkService: NetworkService): EquivalentBra
         toCim(pb.ee, this, networkService)
     }
 
+/**
+ * Convert the protobuf [PBEquivalentEquipment] into its CIM counterpart.
+ *
+ * @param pb The protobuf [PBEquivalentEquipment] to convert.
+ * @param cim The CIM [EquivalentEquipment] to populate.
+ * @param networkService The [NetworkService] the converted CIM object will be added too.
+ * @return The converted [pb] as a CIM [EquivalentEquipment].
+ */
 fun toCim(pb: PBEquivalentEquipment, cim: EquivalentEquipment, networkService: NetworkService): EquivalentEquipment =
     cim.apply { toCim(pb.ce, this, networkService) }
 
+/**
+ * An extension to add a converted copy of the protobuf [PBEquivalentBranch] to the [NetworkService].
+ */
 fun NetworkService.addFromPb(pb: PBEquivalentBranch): EquivalentBranch? = tryAddOrNull(toCim(pb, this))
 
-/************ IEC61970 MEAS ************/
+// ##################
+// # IEC61970 MEAS #
+// ##################
 
+/**
+ * Convert the protobuf [PBControl] into its CIM counterpart.
+ *
+ * @param pb The protobuf [PBControl] to convert.
+ * @param networkService The [NetworkService] the converted CIM object will be added too.
+ * @return The converted [pb] as a CIM [Control].
+ */
 fun toCim(pb: PBControl, networkService: NetworkService): Control =
     Control(pb.mRID()).apply {
         powerSystemResourceMRID = pb.powerSystemResourceMRID.takeIf { it.isNotBlank() }
@@ -719,9 +1279,24 @@ fun toCim(pb: PBControl, networkService: NetworkService): Control =
         toCim(pb.ip, this, networkService)
     }
 
+/**
+ * Convert the protobuf [PBIoPoint] into its CIM counterpart.
+ *
+ * @param pb The protobuf [PBIoPoint] to convert.
+ * @param cim The CIM [IoPoint] to populate.
+ * @param networkService The [NetworkService] the converted CIM object will be added too.
+ * @return The converted [pb] as a CIM [IoPoint].
+ */
 fun toCim(pb: PBIoPoint, cim: IoPoint, networkService: NetworkService): IoPoint =
     cim.apply { toCim(pb.io, this, networkService) }
 
+/**
+ * Convert the protobuf [PBMeasurement] into its CIM counterpart.
+ *
+ * @param pb The protobuf [PBMeasurement] to convert.
+ * @param cim The [NetworkService] the converted CIM object will be added too.
+ * @param networkService The converted [pb] as a CIM [Measurement].
+ */
 fun toCim(pb: PBMeasurement, cim: Measurement, networkService: NetworkService) {
     cim.apply {
         powerSystemResourceMRID = pb.powerSystemResourceMRID.takeIf { it.isNotBlank() }
@@ -733,29 +1308,74 @@ fun toCim(pb: PBMeasurement, cim: Measurement, networkService: NetworkService) {
     }
 }
 
+/**
+ * Convert the protobuf [PBAccumulator] into its CIM counterpart.
+ *
+ * @param pb The protobuf [PBAccumulator] to convert.
+ * @param networkService The [NetworkService] the converted CIM object will be added too.
+ * @return The converted [pb] as a CIM [Accumulator].
+ */
 fun toCim(pb: PBAccumulator, networkService: NetworkService): Accumulator =
     Accumulator(pb.measurement.mRID()).apply {
         toCim(pb.measurement, this, networkService)
     }
 
+/**
+ * Convert the protobuf [PBAnalog] into its CIM counterpart.
+ *
+ * @param pb The protobuf [PBAnalog] to convert.
+ * @param networkService The [NetworkService] the converted CIM object will be added too.
+ * @return The converted [pb] as a CIM [Analog].
+ */
 fun toCim(pb: PBAnalog, networkService: NetworkService): Analog =
     Analog(pb.measurement.mRID()).apply {
         toCim(pb.measurement, this, networkService)
         positiveFlowIn = pb.positiveFlowIn
     }
 
+/**
+ * Convert the protobuf [PBDiscrete] into its CIM counterpart.
+ *
+ * @param pb The protobuf [PBDiscrete] to convert.
+ * @param networkService The [NetworkService] the converted CIM object will be added too.
+ * @return The converted [pb] as a CIM [Discrete].
+ */
 fun toCim(pb: PBDiscrete, networkService: NetworkService): Discrete =
     Discrete(pb.measurement.mRID()).apply {
         toCim(pb.measurement, this, networkService)
     }
 
+/**
+ * An extension to add a converted copy of the protobuf [PBControl] to the [NetworkService].
+ */
 fun NetworkService.addFromPb(pb: PBControl): Control? = tryAddOrNull(toCim(pb, this))
+
+/**
+ * An extension to add a converted copy of the protobuf [PBAnalog] to the [NetworkService].
+ */
 fun NetworkService.addFromPb(pb: PBAnalog): Analog? = tryAddOrNull(toCim(pb, this))
+
+/**
+ * An extension to add a converted copy of the protobuf [PBAccumulator] to the [NetworkService].
+ */
 fun NetworkService.addFromPb(pb: PBAccumulator): Accumulator? = tryAddOrNull(toCim(pb, this))
+
+/**
+ * An extension to add a converted copy of the protobuf [PBDiscrete] to the [NetworkService].
+ */
 fun NetworkService.addFromPb(pb: PBDiscrete): Discrete? = tryAddOrNull(toCim(pb, this))
 
-/************ IEC61970 Base Protection ************/
+// #############################
+// # IEC61970 Base Protection #
+// #############################
 
+/**
+ * Convert the protobuf [PBCurrentRelay] into its CIM counterpart.
+ *
+ * @param pb The protobuf [PBCurrentRelay] to convert.
+ * @param networkService The [NetworkService] the converted CIM object will be added too.
+ * @return The converted [pb] as a CIM [CurrentRelay].
+ */
 fun toCim(pb: PBCurrentRelay, networkService: NetworkService): CurrentRelay =
     CurrentRelay(pb.mRID()).apply {
         currentLimit1 = pb.currentLimit1.takeUnless { it == UNKNOWN_DOUBLE }
@@ -764,6 +1384,13 @@ fun toCim(pb: PBCurrentRelay, networkService: NetworkService): CurrentRelay =
         toCim(pb.prf, this, networkService)
     }
 
+/**
+ * Convert the protobuf [PBDistanceRelay] into its CIM counterpart.
+ *
+ * @param pb The protobuf [PBDistanceRelay] to convert.
+ * @param networkService The [NetworkService] the converted CIM object will be added too.
+ * @return The converted [pb] as a CIM [DistanceRelay].
+ */
 fun toCim(pb: PBDistanceRelay, networkService: NetworkService): DistanceRelay =
     DistanceRelay(pb.mRID()).apply {
         backwardBlind = pb.backwardBlind.takeUnless { it == UNKNOWN_DOUBLE }
@@ -778,6 +1405,14 @@ fun toCim(pb: PBDistanceRelay, networkService: NetworkService): DistanceRelay =
         toCim(pb.prf, this, networkService)
     }
 
+/**
+ * Convert the protobuf [PBProtectionRelayFunction] into its CIM counterpart.
+ *
+ * @param pb The protobuf [PBProtectionRelayFunction] to convert.
+ * @param cim The CIM [ProtectionRelayFunction] to populate.
+ * @param networkService The [NetworkService] the converted CIM object will be added too.
+ * @return The converted [pb] as a CIM [ProtectionRelayFunction].
+ */
 fun toCim(pb: PBProtectionRelayFunction, cim: ProtectionRelayFunction, networkService: NetworkService): ProtectionRelayFunction =
     cim.apply {
         pb.protectedSwitchMRIDsList.forEach { protectedSwitchMRID ->
@@ -803,6 +1438,13 @@ fun toCim(pb: PBProtectionRelayFunction, cim: ProtectionRelayFunction, networkSe
         toCim(pb.psr, this, networkService)
     }
 
+/**
+ * Convert the protobuf [PBProtectionRelayScheme] into its CIM counterpart.
+ *
+ * @param pb The protobuf [PBProtectionRelayScheme] to convert.
+ * @param networkService The [NetworkService] the converted CIM object will be added too.
+ * @return The converted [pb] as a CIM [ProtectionRelayScheme].
+ */
 fun toCim(pb: PBProtectionRelayScheme, networkService: NetworkService): ProtectionRelayScheme =
     ProtectionRelayScheme(pb.mRID()).apply {
         networkService.resolveOrDeferReference(Resolvers.system(this), pb.systemMRID)
@@ -812,6 +1454,13 @@ fun toCim(pb: PBProtectionRelayScheme, networkService: NetworkService): Protecti
         toCim(pb.io, this, networkService)
     }
 
+/**
+ * Convert the protobuf [PBProtectionRelaySystem] into its CIM counterpart.
+ *
+ * @param pb The protobuf [PBProtectionRelaySystem] to convert.
+ * @param networkService The [NetworkService] the converted CIM object will be added too.
+ * @return The converted [pb] as a CIM [ProtectionRelaySystem].
+ */
 fun toCim(pb: PBProtectionRelaySystem, networkService: NetworkService): ProtectionRelaySystem =
     ProtectionRelaySystem(pb.mRID()).apply {
         pb.schemeMRIDsList.forEach { schemeMRID ->
@@ -821,42 +1470,115 @@ fun toCim(pb: PBProtectionRelaySystem, networkService: NetworkService): Protecti
         toCim(pb.eq, this, networkService)
     }
 
+/**
+ * Convert the protobuf [PBRelaySetting] into its CIM counterpart.
+ *
+ * @param pb The protobuf [PBRelaySetting] to convert.
+ * @return The converted [pb] as a CIM [RelaySetting].
+ */
 fun toCim(pb: PBRelaySetting): RelaySetting =
     RelaySetting(UnitSymbol.valueOf(pb.unitSymbol.name), pb.value, pb.name.takeIf { it.isNotEmpty() })
 
+/**
+ * Convert the protobuf [PBVoltageRelay] into its CIM counterpart.
+ *
+ * @param pb The protobuf [PBVoltageRelay] to convert.
+ * @param networkService The [NetworkService] the converted CIM object will be added too.
+ * @return The converted [pb] as a CIM [VoltageRelay].
+ */
 fun toCim(pb: PBVoltageRelay, networkService: NetworkService): VoltageRelay =
     VoltageRelay(pb.mRID()).apply {
         toCim(pb.prf, this, networkService)
     }
 
+/**
+ * An extension to add a converted copy of the protobuf [PBCurrentRelay] to the [NetworkService].
+ */
 fun NetworkService.addFromPb(pb: PBCurrentRelay): CurrentRelay? = tryAddOrNull(toCim(pb, this))
+
+/**
+ * An extension to add a converted copy of the protobuf [PBDistanceRelay] to the [NetworkService].
+ */
 fun NetworkService.addFromPb(pb: PBDistanceRelay): DistanceRelay? = tryAddOrNull(toCim(pb, this))
+
+/**
+ * An extension to add a converted copy of the protobuf [PBProtectionRelayScheme] to the [NetworkService].
+ */
 fun NetworkService.addFromPb(pb: PBProtectionRelayScheme): ProtectionRelayScheme? = tryAddOrNull(toCim(pb, this))
+
+/**
+ * An extension to add a converted copy of the protobuf [PBProtectionRelaySystem] to the [NetworkService].
+ */
 fun NetworkService.addFromPb(pb: PBProtectionRelaySystem): ProtectionRelaySystem? = tryAddOrNull(toCim(pb, this))
+
+/**
+ * An extension to add a converted copy of the protobuf [PBVoltageRelay] to the [NetworkService].
+ */
 fun NetworkService.addFromPb(pb: PBVoltageRelay): VoltageRelay? = tryAddOrNull(toCim(pb, this))
 
-/************ IEC61970 SCADA ************/
+// ##################
+// # IEC61970 SCADA #
+// ##################
 
+/**
+ * Convert the protobuf [PBRemoteControl] into its CIM counterpart.
+ *
+ * @param pb The protobuf [PBRemoteControl] to convert.
+ * @param networkService The [NetworkService] the converted CIM object will be added too.
+ * @return The converted [pb] as a CIM [RemoteControl].
+ */
 fun toCim(pb: PBRemoteControl, networkService: NetworkService): RemoteControl =
     RemoteControl(pb.mRID()).apply {
         networkService.resolveOrDeferReference(Resolvers.control(this), pb.controlMRID)
         toCim(pb.rp, this, networkService)
     }
 
+/**
+ * Convert the protobuf [PBRemotePoint] into its CIM counterpart.
+ *
+ * @param pb The protobuf [PBRemotePoint] to convert.
+ * @param cim The CIM [RemotePoint] to populate.
+ * @param networkService The [NetworkService] the converted CIM object will be added too.
+ * @return The converted [pb] as a CIM [RemotePoint].
+ */
 fun toCim(pb: PBRemotePoint, cim: RemotePoint, networkService: NetworkService): RemotePoint =
     cim.apply { toCim(pb.io, this, networkService) }
 
+/**
+ * Convert the protobuf [PBRemoteSource] into its CIM counterpart.
+ *
+ * @param pb The protobuf [PBRemoteSource] to convert.
+ * @param networkService The [NetworkService] the converted CIM object will be added too.
+ * @return The converted [pb] as a CIM [RemoteSource].
+ */
 fun toCim(pb: PBRemoteSource, networkService: NetworkService): RemoteSource =
     RemoteSource(pb.mRID()).apply {
         networkService.resolveOrDeferReference(Resolvers.measurement(this), pb.measurementMRID)
         toCim(pb.rp, this, networkService)
     }
 
+/**
+ * An extension to add a converted copy of the protobuf [PBRemoteControl] to the [NetworkService].
+ */
 fun NetworkService.addFromPb(pb: PBRemoteControl): RemoteControl? = tryAddOrNull(toCim(pb, this))
+
+/**
+ * An extension to add a converted copy of the protobuf [PBRemoteSource] to the [NetworkService].
+ */
 fun NetworkService.addFromPb(pb: PBRemoteSource): RemoteSource? = tryAddOrNull(toCim(pb, this))
 
-/************ IEC61970 WIRES GENERATION PRODUCTION ************/
+// ########################################
+// # IEC61970 WIRES GENERATION PRODUCTION #
+// ########################################
 
+/**
+ * Convert the protobuf [PBPowerElectronicsUnit] into its CIM counterpart.
+ *
+ * @param pb The protobuf [PBPowerElectronicsUnit] to convert.
+ * @param cim The CIM [PowerElectronicsUnit] to populate.
+ * @param networkService The [NetworkService] the converted CIM object will be added too.
+ * @return The converted [pb] as a CIM [PowerElectronicsUnit].
+ */
 fun toCim(pb: PBPowerElectronicsUnit, cim: PowerElectronicsUnit, networkService: NetworkService): PowerElectronicsUnit =
     cim.apply {
         networkService.resolveOrDeferReference(Resolvers.powerElectronicsConnection(this), pb.powerElectronicsConnectionMRID)
@@ -865,6 +1587,13 @@ fun toCim(pb: PBPowerElectronicsUnit, cim: PowerElectronicsUnit, networkService:
         toCim(pb.eq, this, networkService)
     }
 
+/**
+ * Convert the protobuf [PBBatteryUnit] into its CIM counterpart.
+ *
+ * @param pb The protobuf [PBBatteryUnit] to convert.
+ * @param networkService The [NetworkService] the converted CIM object will be added too.
+ * @return The converted [pb] as a CIM [BatteryUnit].
+ */
 fun toCim(pb: PBBatteryUnit, networkService: NetworkService): BatteryUnit =
     BatteryUnit(pb.mRID()).apply {
         batteryState = BatteryStateKind.valueOf(pb.batteryState.name)
@@ -873,44 +1602,107 @@ fun toCim(pb: PBBatteryUnit, networkService: NetworkService): BatteryUnit =
         toCim(pb.peu, this, networkService)
     }
 
+/**
+ * Convert the protobuf [PBPhotoVoltaicUnit] into its CIM counterpart.
+ *
+ * @param pb The protobuf [PBPhotoVoltaicUnit] to convert.
+ * @param networkService The [NetworkService] the converted CIM object will be added too.
+ * @return The converted [pb] as a CIM [PhotoVoltaicUnit].
+ */
 fun toCim(pb: PBPhotoVoltaicUnit, networkService: NetworkService): PhotoVoltaicUnit =
     PhotoVoltaicUnit(pb.mRID()).apply {
         toCim(pb.peu, this, networkService)
     }
 
+/**
+ * Convert the protobuf [PBPowerElectronicsWindUnit] into its CIM counterpart.
+ *
+ * @param pb The protobuf [PBPowerElectronicsWindUnit] to convert.
+ * @param networkService The [NetworkService] the converted CIM object will be added too.
+ * @return The converted [pb] as a CIM [PowerElectronicsWindUnit].
+ */
 fun toCim(pb: PBPowerElectronicsWindUnit, networkService: NetworkService): PowerElectronicsWindUnit =
     PowerElectronicsWindUnit(pb.mRID()).apply {
         toCim(pb.peu, this, networkService)
     }
 
+/**
+ * An extension to add a converted copy of the protobuf [PBBatteryUnit] to the [NetworkService].
+ */
 fun NetworkService.addFromPb(pb: PBBatteryUnit): BatteryUnit? = tryAddOrNull(toCim(pb, this))
+
+/**
+ * An extension to add a converted copy of the protobuf [PBPhotoVoltaicUnit] to the [NetworkService].
+ */
 fun NetworkService.addFromPb(pb: PBPhotoVoltaicUnit): PhotoVoltaicUnit? = tryAddOrNull(toCim(pb, this))
+
+/**
+ * An extension to add a converted copy of the protobuf [PBPowerElectronicsWindUnit] to the [NetworkService].
+ */
 fun NetworkService.addFromPb(pb: PBPowerElectronicsWindUnit): PowerElectronicsWindUnit? = tryAddOrNull(toCim(pb, this))
 
-/************ IEC61970 WIRES ************/
+// ##################
+// # IEC61970 WIRES #
+// ##################
 
+/**
+ * Convert the protobuf [PBAcLineSegment] into its CIM counterpart.
+ *
+ * @param pb The protobuf [PBAcLineSegment] to convert.
+ * @param networkService The [NetworkService] the converted CIM object will be added too.
+ * @return The converted [pb] as a CIM [AcLineSegment].
+ */
 fun toCim(pb: PBAcLineSegment, networkService: NetworkService): AcLineSegment =
     AcLineSegment(pb.mRID()).apply {
         networkService.resolveOrDeferReference(Resolvers.perLengthSequenceImpedance(this), pb.perLengthSequenceImpedanceMRID)
         toCim(pb.cd, this, networkService)
     }
 
+/**
+ * Convert the protobuf [PBBreaker] into its CIM counterpart.
+ *
+ * @param pb The protobuf [PBBreaker] to convert.
+ * @param networkService The [NetworkService] the converted CIM object will be added too.
+ * @return The converted [pb] as a CIM [Breaker].
+ */
 fun toCim(pb: PBBreaker, networkService: NetworkService): Breaker =
     Breaker(pb.mRID()).apply {
         inTransitTime = pb.inTransitTime.takeUnless { it == UNKNOWN_DOUBLE }
         toCim(pb.sw, this, networkService)
     }
 
+/**
+ * Convert the protobuf [PBLoadBreakSwitch] into its CIM counterpart.
+ *
+ * @param pb The protobuf [PBLoadBreakSwitch] to convert.
+ * @param networkService The [NetworkService] the converted CIM object will be added too.
+ * @return The converted [pb] as a CIM [LoadBreakSwitch].
+ */
 fun toCim(pb: PBLoadBreakSwitch, networkService: NetworkService): LoadBreakSwitch =
     LoadBreakSwitch(pb.mRID()).apply {
         toCim(pb.ps, this, networkService)
     }
 
+/**
+ * Convert the protobuf [PBBusbarSection] into its CIM counterpart.
+ *
+ * @param pb The protobuf [PBBusbarSection] to convert.
+ * @param networkService The [NetworkService] the converted CIM object will be added too.
+ * @return The converted [pb] as a CIM [BusbarSection].
+ */
 fun toCim(pb: PBBusbarSection, networkService: NetworkService): BusbarSection =
     BusbarSection(pb.mRID()).apply {
         toCim(pb.cn, this, networkService)
     }
 
+/**
+ * Convert the protobuf [PBConductor] into its CIM counterpart.
+ *
+ * @param pb The protobuf [PBConductor] to convert.
+ * @param cim The CIM [Conductor] to populate.
+ * @param networkService The [NetworkService] the converted CIM object will be added too.
+ * @return The converted [pb] as a CIM [Conductor].
+ */
 fun toCim(pb: PBConductor, cim: Conductor, networkService: NetworkService): Conductor =
     cim.apply {
         length = pb.length.takeUnless { it == UNKNOWN_DOUBLE }
@@ -920,23 +1712,61 @@ fun toCim(pb: PBConductor, cim: Conductor, networkService: NetworkService): Cond
         toCim(pb.ce, this, networkService)
     }
 
+/**
+ * Convert the protobuf [PBConnector] into its CIM counterpart.
+ *
+ * @param pb The protobuf [PBConnector] to convert.
+ * @param cim The CIM [Connector] to populate.
+ * @param networkService The [NetworkService] the converted CIM object will be added too.
+ * @return The converted [pb] as a CIM [Connector].
+ */
 fun toCim(pb: PBConnector, cim: Connector, networkService: NetworkService): Connector =
     cim.apply { toCim(pb.ce, this, networkService) }
 
+/**
+ * Convert the protobuf [PBDisconnector] into its CIM counterpart.
+ *
+ * @param pb The protobuf [PBDisconnector] to convert.
+ * @param networkService The [NetworkService] the converted CIM object will be added too.
+ * @return The converted [pb] as a CIM [Disconnector].
+ */
 fun toCim(pb: PBDisconnector, networkService: NetworkService): Disconnector =
     Disconnector(pb.mRID()).apply {
         toCim(pb.sw, this, networkService)
     }
 
+/**
+ * Convert the protobuf [PBEarthFaultCompensator] into its CIM counterpart.
+ *
+ * @param pb The protobuf [PBEarthFaultCompensator] to convert.
+ * @param cim The CIM [EarthFaultCompensator] to populate.
+ * @param networkService The [NetworkService] the converted CIM object will be added too.
+ * @return The converted [pb] as a CIM [EarthFaultCompensator].
+ */
 fun toCim(pb: PBEarthFaultCompensator, cim: EarthFaultCompensator, networkService: NetworkService): EarthFaultCompensator =
     cim.apply {
         r = pb.r.takeUnless { it == UNKNOWN_DOUBLE }
         toCim(pb.ce, this, networkService)
     }
 
+/**
+ * Convert the protobuf [PBEnergyConnection] into its CIM counterpart.
+ *
+ * @param pb The protobuf [PBEnergyConnection] to convert.
+ * @param cim The CIM [EnergyConnection] to populate.
+ * @param networkService The [NetworkService] the converted CIM object will be added too.
+ * @return The converted [pb] as a CIM [EnergyConnection].
+ */
 fun toCim(pb: PBEnergyConnection, cim: EnergyConnection, networkService: NetworkService): EnergyConnection =
     cim.apply { toCim(pb.ce, this, networkService) }
 
+/**
+ * Convert the protobuf [PBEnergyConsumer] into its CIM counterpart.
+ *
+ * @param pb The protobuf [PBEnergyConsumer] to convert.
+ * @param networkService The [NetworkService] the converted CIM object will be added too.
+ * @return The converted [pb] as a CIM [EnergyConsumer].
+ */
 fun toCim(pb: PBEnergyConsumer, networkService: NetworkService): EnergyConsumer =
     EnergyConsumer(pb.mRID()).apply {
 
@@ -953,6 +1783,13 @@ fun toCim(pb: PBEnergyConsumer, networkService: NetworkService): EnergyConsumer 
         toCim(pb.ec, this, networkService)
     }
 
+/**
+ * Convert the protobuf [PBEnergyConsumerPhase] into its CIM counterpart.
+ *
+ * @param pb The protobuf [PBEnergyConsumerPhase] to convert.
+ * @param networkService The [NetworkService] the converted CIM object will be added too.
+ * @return The converted [pb] as a CIM [EnergyConsumerPhase].
+ */
 fun toCim(pb: PBEnergyConsumerPhase, networkService: NetworkService): EnergyConsumerPhase =
     EnergyConsumerPhase(pb.mRID()).apply {
         networkService.resolveOrDeferReference(Resolvers.energyConsumer(this), pb.energyConsumerMRID)
@@ -964,6 +1801,13 @@ fun toCim(pb: PBEnergyConsumerPhase, networkService: NetworkService): EnergyCons
         toCim(pb.psr, this, networkService)
     }
 
+/**
+ * Convert the protobuf [PBEnergySource] into its CIM counterpart.
+ *
+ * @param pb The protobuf [PBEnergySource] to convert.
+ * @param networkService The [NetworkService] the converted CIM object will be added too.
+ * @return The converted [pb] as a CIM [EnergySource].
+ */
 fun toCim(pb: PBEnergySource, networkService: NetworkService): EnergySource =
     EnergySource(pb.mRID()).apply {
         pb.energySourcePhasesMRIDsList.forEach { energySourcePhasesMRID ->
@@ -999,6 +1843,13 @@ fun toCim(pb: PBEnergySource, networkService: NetworkService): EnergySource =
         toCim(pb.ec, this, networkService)
     }
 
+/**
+ * Convert the protobuf [PBEnergySourcePhase] into its CIM counterpart.
+ *
+ * @param pb The protobuf [PBEnergySourcePhase] to convert.
+ * @param networkService The [NetworkService] the converted CIM object will be added too.
+ * @return The converted [pb] as a CIM [EnergySourcePhase].
+ */
 fun toCim(pb: PBEnergySourcePhase, networkService: NetworkService): EnergySourcePhase =
     EnergySourcePhase(pb.mRID()).apply {
         networkService.resolveOrDeferReference(Resolvers.energySource(this), pb.energySourceMRID)
@@ -1006,41 +1857,98 @@ fun toCim(pb: PBEnergySourcePhase, networkService: NetworkService): EnergySource
         toCim(pb.psr, this, networkService)
     }
 
+/**
+ * Convert the protobuf [PBFuse] into its CIM counterpart.
+ *
+ * @param pb The protobuf [PBFuse] to convert.
+ * @param networkService The [NetworkService] the converted CIM object will be added too.
+ * @return The converted [pb] as a CIM [Fuse].
+ */
 fun toCim(pb: PBFuse, networkService: NetworkService): Fuse =
     Fuse(pb.mRID()).apply {
         networkService.resolveOrDeferReference(Resolvers.function(this), pb.functionMRID)
         toCim(pb.sw, this, networkService)
     }
 
+/**
+ * Convert the protobuf [PBGround] into its CIM counterpart.
+ *
+ * @param pb The protobuf [PBGround] to convert.
+ * @param networkService The [NetworkService] the converted CIM object will be added too.
+ * @return The converted [pb] as a CIM [Ground].
+ */
 fun toCim(pb: PBGround, networkService: NetworkService): Ground =
     Ground(pb.mRID()).apply {
         toCim(pb.ce, this, networkService)
     }
 
+/**
+ * Convert the protobuf [PBGroundDisconnector] into its CIM counterpart.
+ *
+ * @param pb The protobuf [PBGroundDisconnector] to convert.
+ * @param networkService The [NetworkService] the converted CIM object will be added too.
+ * @return The converted [pb] as a CIM [GroundDisconnector].
+ */
 fun toCim(pb: PBGroundDisconnector, networkService: NetworkService): GroundDisconnector =
     GroundDisconnector(pb.mRID()).apply {
         toCim(pb.sw, this, networkService)
     }
 
+/**
+ * Convert the protobuf [PBGroundingImpedance] into its CIM counterpart.
+ *
+ * @param pb The protobuf [PBGroundingImpedance] to convert.
+ * @param networkService The [NetworkService] the converted CIM object will be added too.
+ * @return The converted [pb] as a CIM [GroundingImpedance].
+ */
 fun toCim(pb: PBGroundingImpedance, networkService: NetworkService): GroundingImpedance =
     GroundingImpedance(pb.mRID()).apply {
         x = pb.x.takeUnless { it == UNKNOWN_DOUBLE }
         toCim(pb.efc, this, networkService)
     }
 
+/**
+ * Convert the protobuf [PBJumper] into its CIM counterpart.
+ *
+ * @param pb The protobuf [PBJumper] to convert.
+ * @param networkService The [NetworkService] the converted CIM object will be added too.
+ * @return The converted [pb] as a CIM [Jumper].
+ */
 fun toCim(pb: PBJumper, networkService: NetworkService): Jumper =
     Jumper(pb.mRID()).apply {
         toCim(pb.sw, this, networkService)
     }
 
+/**
+ * Convert the protobuf [PBJunction] into its CIM counterpart.
+ *
+ * @param pb The protobuf [PBJunction] to convert.
+ * @param networkService The [NetworkService] the converted CIM object will be added too.
+ * @return The converted [pb] as a CIM [Junction].
+ */
 fun toCim(pb: PBJunction, networkService: NetworkService): Junction =
     Junction(pb.mRID()).apply {
         toCim(pb.cn, this, networkService)
     }
 
+/**
+ * Convert the protobuf [PBLine] into its CIM counterpart.
+ *
+ * @param pb The protobuf [PBLine] to convert.
+ * @param cim The CIM [Line] to populate.
+ * @param networkService The [NetworkService] the converted CIM object will be added too.
+ * @return The converted [pb] as a CIM [Line].
+ */
 fun toCim(pb: PBLine, cim: Line, networkService: NetworkService): Line =
     cim.apply { toCim(pb.ec, this, networkService) }
 
+/**
+ * Convert the protobuf [PBLinearShuntCompensator] into its CIM counterpart.
+ *
+ * @param pb The protobuf [PBLinearShuntCompensator] to convert.
+ * @param networkService The [NetworkService] the converted CIM object will be added too.
+ * @return The converted [pb] as a CIM [LinearShuntCompensator].
+ */
 fun toCim(pb: PBLinearShuntCompensator, networkService: NetworkService): LinearShuntCompensator =
     LinearShuntCompensator(pb.mRID()).apply {
         b0PerSection = pb.b0PerSection.takeUnless { it == UNKNOWN_DOUBLE }
@@ -1050,12 +1958,35 @@ fun toCim(pb: PBLinearShuntCompensator, networkService: NetworkService): LinearS
         toCim(pb.sc, this, networkService)
     }
 
+/**
+ * Convert the protobuf [PBPerLengthLineParameter] into its CIM counterpart.
+ *
+ * @param pb The protobuf [PBPerLengthLineParameter] to convert.
+ * @param cim The CIM [PerLengthLineParameter] to populate.
+ * @param networkService The [NetworkService] the converted CIM object will be added too.
+ * @return The converted [pb] as a CIM [PerLengthLineParameter].
+ */
 fun toCim(pb: PBPerLengthLineParameter, cim: PerLengthLineParameter, networkService: NetworkService): PerLengthLineParameter =
     cim.apply { toCim(pb.io, this, networkService) }
 
+/**
+ * Convert the protobuf [PBPerLengthImpedance] into its CIM counterpart.
+ *
+ * @param pb The protobuf [PBPerLengthImpedance] to convert.
+ * @param cim The CIM [PerLengthImpedance] to populate.
+ * @param networkService The [NetworkService] the converted CIM object will be added too.
+ * @return The converted [pb] as a CIM [PerLengthImpedance].
+ */
 fun toCim(pb: PBPerLengthImpedance, cim: PerLengthImpedance, networkService: NetworkService): PerLengthImpedance =
     cim.apply { toCim(pb.lp, cim, networkService) }
 
+/**
+ * Convert the protobuf [PBPerLengthSequenceImpedance] into its CIM counterpart.
+ *
+ * @param pb The protobuf [PBPerLengthSequenceImpedance] to convert.
+ * @param networkService The [NetworkService] the converted CIM object will be added too.
+ * @return The converted [pb] as a CIM [PerLengthSequenceImpedance].
+ */
 fun toCim(pb: PBPerLengthSequenceImpedance, networkService: NetworkService): PerLengthSequenceImpedance =
     PerLengthSequenceImpedance(pb.mRID()).apply {
         r = pb.r.takeUnless { it == UNKNOWN_DOUBLE }
@@ -1069,12 +2000,26 @@ fun toCim(pb: PBPerLengthSequenceImpedance, networkService: NetworkService): Per
         toCim(pb.pli, this, networkService)
     }
 
+/**
+ * Convert the protobuf [PBPetersenCoil] into its CIM counterpart.
+ *
+ * @param pb The protobuf [PBPetersenCoil] to convert.
+ * @param networkService The [NetworkService] the converted CIM object will be added too.
+ * @return The converted [pb] as a CIM [PetersenCoil].
+ */
 fun toCim(pb: PBPetersenCoil, networkService: NetworkService): PetersenCoil =
     PetersenCoil(pb.mRID()).apply {
         xGroundNominal = pb.xGroundNominal.takeUnless { it == UNKNOWN_DOUBLE }
         toCim(pb.efc, this, networkService)
     }
 
+/**
+ * Convert the protobuf [PBPowerElectronicsConnection] into its CIM counterpart.
+ *
+ * @param pb The protobuf [PBPowerElectronicsConnection] to convert.
+ * @param networkService The [NetworkService] the converted CIM object will be added too.
+ * @return The converted [pb] as a CIM [PowerElectronicsConnection].
+ */
 fun toCim(pb: PBPowerElectronicsConnection, networkService: NetworkService): PowerElectronicsConnection =
     PowerElectronicsConnection(pb.mRID()).apply {
         pb.powerElectronicsUnitMRIDsList.forEach { powerElectronicsUnitMRID ->
@@ -1117,6 +2062,13 @@ fun toCim(pb: PBPowerElectronicsConnection, networkService: NetworkService): Pow
         toCim(pb.rce, this, networkService)
     }
 
+/**
+ * Convert the protobuf [PBPowerElectronicsConnectionPhase] into its CIM counterpart.
+ *
+ * @param pb The protobuf [PBPowerElectronicsConnectionPhase] to convert.
+ * @param networkService The [NetworkService] the converted CIM object will be added too.
+ * @return The converted [pb] as a CIM [PowerElectronicsConnectionPhase].
+ */
 fun toCim(pb: PBPowerElectronicsConnectionPhase, networkService: NetworkService): PowerElectronicsConnectionPhase =
     PowerElectronicsConnectionPhase(pb.mRID()).apply {
         networkService.resolveOrDeferReference(Resolvers.powerElectronicsConnection(this), pb.powerElectronicsConnectionMRID)
@@ -1126,6 +2078,13 @@ fun toCim(pb: PBPowerElectronicsConnectionPhase, networkService: NetworkService)
         toCim(pb.psr, this, networkService)
     }
 
+/**
+ * Convert the protobuf [PBPowerTransformer] into its CIM counterpart.
+ *
+ * @param pb The protobuf [PBPowerTransformer] to convert.
+ * @param networkService The [NetworkService] the converted CIM object will be added too.
+ * @return The converted [pb] as a CIM [PowerTransformer].
+ */
 fun toCim(pb: PBPowerTransformer, networkService: NetworkService): PowerTransformer =
     PowerTransformer(pb.mRID()).apply {
         pb.powerTransformerEndMRIDsList.forEach { endMRID ->
@@ -1139,6 +2098,13 @@ fun toCim(pb: PBPowerTransformer, networkService: NetworkService): PowerTransfor
         toCim(pb.ce, this, networkService)
     }
 
+/**
+ * Convert the protobuf [PBPowerTransformerEnd] into its CIM counterpart.
+ *
+ * @param pb The protobuf [PBPowerTransformerEnd] to convert.
+ * @param networkService The [NetworkService] the converted CIM object will be added too.
+ * @return The converted [pb] as a CIM [PowerTransformerEnd].
+ */
 fun toCim(pb: PBPowerTransformerEnd, networkService: NetworkService): PowerTransformerEnd =
     PowerTransformerEnd(pb.mRID()).apply {
         networkService.resolveOrDeferReference(Resolvers.powerTransformer(this), pb.powerTransformerMRID)
@@ -1160,6 +2126,14 @@ fun toCim(pb: PBPowerTransformerEnd, networkService: NetworkService): PowerTrans
         toCim(pb.te, this, networkService)
     }
 
+/**
+ * Convert the protobuf [PBProtectedSwitch] into its CIM counterpart.
+ *
+ * @param pb The protobuf [PBProtectedSwitch] to convert.
+ * @param cim The CIM [ProtectedSwitch] to populate.
+ * @param networkService The [NetworkService] the converted CIM object will be added too.
+ * @return The converted [pb] as a CIM [ProtectedSwitch].
+ */
 fun toCim(pb: PBProtectedSwitch, cim: ProtectedSwitch, networkService: NetworkService): ProtectedSwitch =
     cim.apply {
         pb.relayFunctionMRIDsList.forEach { relayFunctionMRID ->
@@ -1169,6 +2143,13 @@ fun toCim(pb: PBProtectedSwitch, cim: ProtectedSwitch, networkService: NetworkSe
         toCim(pb.sw, this, networkService)
     }
 
+/**
+ * Convert the protobuf [PBRatioTapChanger] into its CIM counterpart.
+ *
+ * @param pb The protobuf [PBRatioTapChanger] to convert.
+ * @param networkService The [NetworkService] the converted CIM object will be added too.
+ * @return The converted [pb] as a CIM [RatioTapChanger].
+ */
 fun toCim(pb: PBRatioTapChanger, networkService: NetworkService): RatioTapChanger =
     RatioTapChanger(pb.mRID()).apply {
         networkService.resolveOrDeferReference(Resolvers.transformerEnd(this), pb.transformerEndMRID)
@@ -1176,16 +2157,38 @@ fun toCim(pb: PBRatioTapChanger, networkService: NetworkService): RatioTapChange
         toCim(pb.tc, this, networkService)
     }
 
+/**
+ * Convert the protobuf [PBReactiveCapabilityCurve] into its CIM counterpart.
+ *
+ * @param pb The protobuf [PBReactiveCapabilityCurve] to convert.
+ * @param networkService The [NetworkService] the converted CIM object will be added too.
+ * @return The converted [pb] as a CIM [ReactiveCapabilityCurve].
+ */
 fun toCim(pb: PBReactiveCapabilityCurve, networkService: NetworkService): ReactiveCapabilityCurve =
     ReactiveCapabilityCurve(pb.mRID()).apply {
         toCim(pb.c, this, networkService)
     }
 
+/**
+ * Convert the protobuf [PBRecloser] into its CIM counterpart.
+ *
+ * @param pb The protobuf [PBRecloser] to convert.
+ * @param networkService The [NetworkService] the converted CIM object will be added too.
+ * @return The converted [pb] as a CIM [Recloser].
+ */
 fun toCim(pb: PBRecloser, networkService: NetworkService): Recloser =
     Recloser(pb.mRID()).apply {
         toCim(pb.sw, this, networkService)
     }
 
+/**
+ * Convert the protobuf [PBRegulatingCondEq] into its CIM counterpart.
+ *
+ * @param pb The protobuf [PBRegulatingCondEq] to convert.
+ * @param cim The CIM [RegulatingCondEq] to populate.
+ * @param networkService The [NetworkService] the converted CIM object will be added too.
+ * @return The converted [pb] as a CIM [RegulatingCondEq].
+ */
 fun toCim(pb: PBRegulatingCondEq, cim: RegulatingCondEq, networkService: NetworkService): RegulatingCondEq =
     cim.apply {
         controlEnabled = pb.controlEnabled
@@ -1193,6 +2196,14 @@ fun toCim(pb: PBRegulatingCondEq, cim: RegulatingCondEq, networkService: Network
         toCim(pb.ec, this, networkService)
     }
 
+/**
+ * Convert the protobuf [PBRegulatingControl] into its CIM counterpart.
+ *
+ * @param pb The protobuf [PBRegulatingControl] to convert.
+ * @param cim The CIM [RegulatingControl] to populate.
+ * @param networkService The [NetworkService] the converted CIM object will be added too.
+ * @return The converted [pb] as a CIM [RegulatingControl].
+ */
 fun toCim(pb: PBRegulatingControl, cim: RegulatingControl, networkService: NetworkService): RegulatingControl =
     cim.apply {
         discrete = pb.discreteSet.takeUnless { pb.hasDiscreteNull() }
@@ -1212,6 +2223,14 @@ fun toCim(pb: PBRegulatingControl, cim: RegulatingControl, networkService: Netwo
         toCim(pb.psr, this, networkService)
     }
 
+/**
+ * Convert the protobuf [PBRotatingMachine] into its CIM counterpart.
+ *
+ * @param pb The protobuf [PBRotatingMachine] to convert.
+ * @param cim The CIM [RotatingMachine] to populate.
+ * @param networkService The [NetworkService] the converted CIM object will be added too.
+ * @return The converted [pb] as a CIM [RotatingMachine].
+ */
 fun toCim(pb: PBRotatingMachine, cim: RotatingMachine, networkService: NetworkService): RotatingMachine =
     cim.apply {
         ratedPowerFactor = pb.ratedPowerFactor.takeUnless { it == UNKNOWN_DOUBLE }
@@ -1222,6 +2241,13 @@ fun toCim(pb: PBRotatingMachine, cim: RotatingMachine, networkService: NetworkSe
         toCim(pb.rce, this, networkService)
     }
 
+/**
+ * Convert the protobuf [PBSeriesCompensator] into its CIM counterpart.
+ *
+ * @param pb The protobuf [PBSeriesCompensator] to convert.
+ * @param networkService The [NetworkService] the converted CIM object will be added too.
+ * @return The converted [pb] as a CIM [SeriesCompensator].
+ */
 fun toCim(pb: PBSeriesCompensator, networkService: NetworkService): SeriesCompensator =
     SeriesCompensator(pb.mRID()).apply {
         r = pb.r.takeUnless { it == UNKNOWN_DOUBLE }
@@ -1233,6 +2259,14 @@ fun toCim(pb: PBSeriesCompensator, networkService: NetworkService): SeriesCompen
         toCim(pb.ce, this, networkService)
     }
 
+/**
+ * Convert the protobuf [PBShuntCompensator] into its CIM counterpart.
+ *
+ * @param pb The protobuf [PBShuntCompensator] to convert.
+ * @param cim The CIM [ShuntCompensator] to populate.
+ * @param networkService The [NetworkService] the converted CIM object will be added too.
+ * @return The converted [pb] as a CIM [ShuntCompensator].
+ */
 fun toCim(pb: PBShuntCompensator, cim: ShuntCompensator, networkService: NetworkService): ShuntCompensator =
     cim.apply {
         networkService.resolveOrDeferReference(Resolvers.assetInfo(this), pb.assetInfoMRID())
@@ -1243,6 +2277,14 @@ fun toCim(pb: PBShuntCompensator, cim: ShuntCompensator, networkService: Network
         toCim(pb.rce, this, networkService)
     }
 
+/**
+ * Convert the protobuf [PBSwitch] into its CIM counterpart.
+ *
+ * @param pb The protobuf [PBSwitch] to convert.
+ * @param cim The CIM [Switch] to populate.
+ * @param networkService The [NetworkService] the converted CIM object will be added too.
+ * @return The converted [pb] as a CIM [Switch].
+ */
 fun toCim(pb: PBSwitch, cim: Switch, networkService: NetworkService): Switch =
     cim.apply {
         networkService.resolveOrDeferReference(Resolvers.assetInfo(this), pb.assetInfoMRID())
@@ -1255,6 +2297,13 @@ fun toCim(pb: PBSwitch, cim: Switch, networkService: NetworkService): Switch =
         toCim(pb.ce, this, networkService)
     }
 
+/**
+ * Convert the protobuf [PBSynchronousMachine] into its CIM counterpart.
+ *
+ * @param pb The protobuf [PBSynchronousMachine] to convert.
+ * @param networkService The [NetworkService] the converted CIM object will be added too.
+ * @return The converted [pb] as a CIM [SynchronousMachine].
+ */
 fun toCim(pb: PBSynchronousMachine, networkService: NetworkService): SynchronousMachine =
     SynchronousMachine(pb.mRID()).apply {
         pb.reactiveCapabilityCurveMRIDsList.forEach { reactiveCapabilityCurveMRID ->
@@ -1285,6 +2334,14 @@ fun toCim(pb: PBSynchronousMachine, networkService: NetworkService): Synchronous
         toCim(pb.rm, this, networkService)
     }
 
+/**
+ * Convert the protobuf [PBTapChanger] into its CIM counterpart.
+ *
+ * @param pb The protobuf [PBTapChanger] to convert.
+ * @param cim The CIM [TapChanger] to populate.
+ * @param networkService The [NetworkService] the converted CIM object will be added too.
+ * @return The converted [pb] as a CIM [TapChanger].
+ */
 fun toCim(pb: PBTapChanger, cim: TapChanger, networkService: NetworkService): TapChanger =
     cim.apply {
         highStep = pb.highStep.takeUnless { it == UNKNOWN_INT }
@@ -1298,6 +2355,13 @@ fun toCim(pb: PBTapChanger, cim: TapChanger, networkService: NetworkService): Ta
         toCim(pb.psr, this, networkService)
     }
 
+/**
+ * Convert the protobuf [PBTapChangerControl] into its CIM counterpart.
+ *
+ * @param pb The protobuf [PBTapChangerControl] to convert.
+ * @param networkService The [NetworkService] the converted CIM object will be added too.
+ * @return The converted [pb] as a CIM [TapChangerControl].
+ */
 fun toCim(pb: PBTapChangerControl, networkService: NetworkService): TapChangerControl =
     TapChangerControl(pb.mRID()).apply {
         limitVoltage = pb.limitVoltage.takeUnless { it == UNKNOWN_INT }
@@ -1316,6 +2380,14 @@ fun toCim(pb: PBTapChangerControl, networkService: NetworkService): TapChangerCo
         toCim(pb.rc, this, networkService)
     }
 
+/**
+ * Convert the protobuf [PBTransformerEnd] into its CIM counterpart.
+ *
+ * @param pb The protobuf [PBTransformerEnd] to convert.
+ * @param cim The CIM [TransformerEnd] to populate.
+ * @param networkService The [NetworkService] the converted CIM object will be added too.
+ * @return The converted [pb] as a CIM [TransformerEnd].
+ */
 fun toCim(pb: PBTransformerEnd, cim: TransformerEnd, networkService: NetworkService): TransformerEnd =
     cim.apply {
         networkService.resolveOrDeferReference(Resolvers.terminal(this), pb.terminalMRID)
@@ -1329,9 +2401,22 @@ fun toCim(pb: PBTransformerEnd, cim: TransformerEnd, networkService: NetworkServ
         toCim(pb.io, this, networkService)
     }
 
+/**
+ * Convert the protobuf [PBTransformerEndRatedS] into its CIM counterpart.
+ *
+ * @param pb The protobuf [PBTransformerEndRatedS] to convert.
+ * @return The converted [pb] as a CIM [TransformerEndRatedS].
+ */
 fun toCim(pb: PBTransformerEndRatedS): TransformerEndRatedS =
     TransformerEndRatedS(TransformerCoolingType.valueOf(pb.coolingType.name), pb.ratedS)
 
+/**
+ * Convert the protobuf [PBTransformerStarImpedance] into its CIM counterpart.
+ *
+ * @param pb The protobuf [PBTransformerStarImpedance] to convert.
+ * @param networkService The [NetworkService] the converted CIM object will be added too.
+ * @return The converted [pb] as a CIM [TransformerStarImpedance].
+ */
 fun toCim(pb: PBTransformerStarImpedance, networkService: NetworkService): TransformerStarImpedance =
     TransformerStarImpedance(pb.mRID()).apply {
         networkService.resolveOrDeferReference(Resolvers.transformerEndInfo(this), pb.transformerEndInfoMRID)
@@ -1342,38 +2427,162 @@ fun toCim(pb: PBTransformerStarImpedance, networkService: NetworkService): Trans
         toCim(pb.io, this, networkService)
     }
 
+/**
+ * An extension to add a converted copy of the protobuf [PBAcLineSegment] to the [NetworkService].
+ */
 fun NetworkService.addFromPb(pb: PBAcLineSegment): AcLineSegment? = tryAddOrNull(toCim(pb, this))
+
+/**
+ * An extension to add a converted copy of the protobuf [PBBreaker] to the [NetworkService].
+ */
 fun NetworkService.addFromPb(pb: PBBreaker): Breaker? = tryAddOrNull(toCim(pb, this))
+
+/**
+ * An extension to add a converted copy of the protobuf [PBBusbarSection] to the [NetworkService].
+ */
 fun NetworkService.addFromPb(pb: PBBusbarSection): BusbarSection? = tryAddOrNull(toCim(pb, this))
+
+/**
+ * An extension to add a converted copy of the protobuf [PBDisconnector] to the [NetworkService].
+ */
 fun NetworkService.addFromPb(pb: PBDisconnector): Disconnector? = tryAddOrNull(toCim(pb, this))
+
+/**
+ * An extension to add a converted copy of the protobuf [PBEnergyConsumer] to the [NetworkService].
+ */
 fun NetworkService.addFromPb(pb: PBEnergyConsumer): EnergyConsumer? = tryAddOrNull(toCim(pb, this))
+
+/**
+ * An extension to add a converted copy of the protobuf [PBEnergyConsumerPhase] to the [NetworkService].
+ */
 fun NetworkService.addFromPb(pb: PBEnergyConsumerPhase): EnergyConsumerPhase? = tryAddOrNull(toCim(pb, this))
+
+/**
+ * An extension to add a converted copy of the protobuf [PBEnergySource] to the [NetworkService].
+ */
 fun NetworkService.addFromPb(pb: PBEnergySource): EnergySource? = tryAddOrNull(toCim(pb, this))
+
+/**
+ * An extension to add a converted copy of the protobuf [PBEnergySourcePhase] to the [NetworkService].
+ */
 fun NetworkService.addFromPb(pb: PBEnergySourcePhase): EnergySourcePhase? = tryAddOrNull(toCim(pb, this))
+
+/**
+ * An extension to add a converted copy of the protobuf [PBFuse] to the [NetworkService].
+ */
 fun NetworkService.addFromPb(pb: PBFuse): Fuse? = tryAddOrNull(toCim(pb, this))
+
+/**
+ * An extension to add a converted copy of the protobuf [PBGround] to the [NetworkService].
+ */
 fun NetworkService.addFromPb(pb: PBGround): Ground? = tryAddOrNull(toCim(pb, this))
+
+/**
+ * An extension to add a converted copy of the protobuf [PBGroundDisconnector] to the [NetworkService].
+ */
 fun NetworkService.addFromPb(pb: PBGroundDisconnector): GroundDisconnector? = tryAddOrNull(toCim(pb, this))
+
+/**
+ * An extension to add a converted copy of the protobuf [PBGroundingImpedance] to the [NetworkService].
+ */
 fun NetworkService.addFromPb(pb: PBGroundingImpedance): GroundingImpedance? = tryAddOrNull(toCim(pb, this))
+
+/**
+ * An extension to add a converted copy of the protobuf [PBJumper] to the [NetworkService].
+ */
 fun NetworkService.addFromPb(pb: PBJumper): Jumper? = tryAddOrNull(toCim(pb, this))
+
+/**
+ * An extension to add a converted copy of the protobuf [PBJunction] to the [NetworkService].
+ */
 fun NetworkService.addFromPb(pb: PBJunction): Junction? = tryAddOrNull(toCim(pb, this))
+
+/**
+ * An extension to add a converted copy of the protobuf [PBLinearShuntCompensator] to the [NetworkService].
+ */
 fun NetworkService.addFromPb(pb: PBLinearShuntCompensator): LinearShuntCompensator? = tryAddOrNull(toCim(pb, this))
+
+/**
+ * An extension to add a converted copy of the protobuf [PBLoadBreakSwitch] to the [NetworkService].
+ */
 fun NetworkService.addFromPb(pb: PBLoadBreakSwitch): LoadBreakSwitch? = tryAddOrNull(toCim(pb, this))
+
+/**
+ * An extension to add a converted copy of the protobuf [PBPerLengthSequenceImpedance] to the [NetworkService].
+ */
 fun NetworkService.addFromPb(pb: PBPerLengthSequenceImpedance): PerLengthSequenceImpedance? = tryAddOrNull(toCim(pb, this))
+
+/**
+ * An extension to add a converted copy of the protobuf [PBPetersenCoil] to the [NetworkService].
+ */
 fun NetworkService.addFromPb(pb: PBPetersenCoil): PetersenCoil? = tryAddOrNull(toCim(pb, this))
+
+/**
+ * An extension to add a converted copy of the protobuf [PBPowerElectronicsConnection] to the [NetworkService].
+ */
 fun NetworkService.addFromPb(pb: PBPowerElectronicsConnection): PowerElectronicsConnection? = tryAddOrNull(toCim(pb, this))
+
+/**
+ * An extension to add a converted copy of the protobuf [PBPowerElectronicsConnectionPhase] to the [NetworkService].
+ */
 fun NetworkService.addFromPb(pb: PBPowerElectronicsConnectionPhase): PowerElectronicsConnectionPhase? = tryAddOrNull(toCim(pb, this))
+
+/**
+ * An extension to add a converted copy of the protobuf [PBPowerTransformer] to the [NetworkService].
+ */
 fun NetworkService.addFromPb(pb: PBPowerTransformer): PowerTransformer? = tryAddOrNull(toCim(pb, this))
+
+/**
+ * An extension to add a converted copy of the protobuf [PBPowerTransformerEnd] to the [NetworkService].
+ */
 fun NetworkService.addFromPb(pb: PBPowerTransformerEnd): PowerTransformerEnd? = tryAddOrNull(toCim(pb, this))
+
+/**
+ * An extension to add a converted copy of the protobuf [PBRatioTapChanger] to the [NetworkService].
+ */
 fun NetworkService.addFromPb(pb: PBRatioTapChanger): RatioTapChanger? = tryAddOrNull(toCim(pb, this))
+
+/**
+ * An extension to add a converted copy of the protobuf [PBReactiveCapabilityCurve] to the [NetworkService].
+ */
 fun NetworkService.addFromPb(pb: PBReactiveCapabilityCurve): ReactiveCapabilityCurve? = tryAddOrNull(toCim(pb, this))
+
+/**
+ * An extension to add a converted copy of the protobuf [PBRecloser] to the [NetworkService].
+ */
 fun NetworkService.addFromPb(pb: PBRecloser): Recloser? = tryAddOrNull(toCim(pb, this))
+
+/**
+ * An extension to add a converted copy of the protobuf [PBSeriesCompensator] to the [NetworkService].
+ */
 fun NetworkService.addFromPb(pb: PBSeriesCompensator): SeriesCompensator? = tryAddOrNull(toCim(pb, this))
+
+/**
+ * An extension to add a converted copy of the protobuf [PBSynchronousMachine] to the [NetworkService].
+ */
 fun NetworkService.addFromPb(pb: PBSynchronousMachine): SynchronousMachine? = tryAddOrNull(toCim(pb, this))
+
+/**
+ * An extension to add a converted copy of the protobuf [PBTapChangerControl] to the [NetworkService].
+ */
 fun NetworkService.addFromPb(pb: PBTapChangerControl): TapChangerControl? = tryAddOrNull(toCim(pb, this))
+
+/**
+ * An extension to add a converted copy of the protobuf [PBTransformerStarImpedance] to the [NetworkService].
+ */
 fun NetworkService.addFromPb(pb: PBTransformerStarImpedance): TransformerStarImpedance? = tryAddOrNull(toCim(pb, this))
 
-/************ IEC61970 InfIEC61970 Feeder ************/
+// ################################
+// # IEC61970 InfIEC61970 Feeder #
+// ################################
 
+/**
+ * Convert the protobuf [PBCircuit] into its CIM counterpart.
+ *
+ * @param pb The protobuf [PBCircuit] to convert.
+ * @param networkService The [NetworkService] the converted CIM object will be added too.
+ * @return The converted [pb] as a CIM [Circuit].
+ */
 fun toCim(pb: PBCircuit, networkService: NetworkService): Circuit =
     Circuit(pb.mRID()).apply {
         networkService.resolveOrDeferReference(Resolvers.loop(this), pb.loopMRID)
@@ -1387,6 +2596,13 @@ fun toCim(pb: PBCircuit, networkService: NetworkService): Circuit =
         toCim(pb.l, this, networkService)
     }
 
+/**
+ * Convert the protobuf [PBLoop] into its CIM counterpart.
+ *
+ * @param pb The protobuf [PBLoop] to convert.
+ * @param networkService The [NetworkService] the converted CIM object will be added too.
+ * @return The converted [pb] as a CIM [Loop].
+ */
 fun toCim(pb: PBLoop, networkService: NetworkService): Loop =
     Loop(pb.mRID()).apply {
         pb.circuitMRIDsList.forEach { circuitMRID ->
@@ -1402,6 +2618,13 @@ fun toCim(pb: PBLoop, networkService: NetworkService): Loop =
         toCim(pb.io, this, networkService)
     }
 
+/**
+ * Convert the protobuf [PBLvFeeder] into its CIM counterpart.
+ *
+ * @param pb The protobuf [PBLvFeeder] to convert.
+ * @param networkService The [NetworkService] the converted CIM object will be added too.
+ * @return The converted [pb] as a CIM [LvFeeder].
+ */
 fun toCim(pb: PBLvFeeder, networkService: NetworkService): LvFeeder =
     LvFeeder(pb.mRID()).apply {
         networkService.resolveOrDeferReference(Resolvers.normalHeadTerminal(this), pb.normalHeadTerminalMRID)
@@ -1411,134 +2634,763 @@ fun toCim(pb: PBLvFeeder, networkService: NetworkService): LvFeeder =
         toCim(pb.ec, this, networkService)
     }
 
+/**
+ * An extension to add a converted copy of the protobuf [PBCircuit] to the [NetworkService].
+ */
 fun NetworkService.addFromPb(pb: PBCircuit): Circuit? = tryAddOrNull(toCim(pb, this))
+
+/**
+ * An extension to add a converted copy of the protobuf [PBLoop] to the [NetworkService].
+ */
 fun NetworkService.addFromPb(pb: PBLoop): Loop? = tryAddOrNull(toCim(pb, this))
+
+/**
+ * An extension to add a converted copy of the protobuf [PBLvFeeder] to the [NetworkService].
+ */
 fun NetworkService.addFromPb(pb: PBLvFeeder): LvFeeder? = tryAddOrNull(toCim(pb, this))
 
-/************ IEC61970 InfIEC61970 Wires.Generation.Production ************/
+// ####################################################
+// # IEC61970 InfIEC61970 Wires.Generation.Production #
+// ####################################################
 
+/**
+ * Convert the protobuf [PBEvChargingUnit] into its CIM counterpart.
+ *
+ * @param pb The protobuf [PBEvChargingUnit] to convert.
+ * @param networkService The [NetworkService] the converted CIM object will be added too.
+ * @return The converted [pb] as a CIM [EvChargingUnit].
+ */
 fun toCim(pb: PBEvChargingUnit, networkService: NetworkService): EvChargingUnit =
     EvChargingUnit(pb.mRID()).apply {
         toCim(pb.peu, this, networkService)
     }
 
+/**
+ * An extension to add a converted copy of the protobuf [PBEvChargingUnit] to the [NetworkService].
+ */
 fun NetworkService.addFromPb(pb: PBEvChargingUnit): EvChargingUnit? = tryAddOrNull(toCim(pb, this))
 
-/************ Class for Java friendly usage ************/
+// #################################
+// # Class for Java friendly usage #
+// #################################
 
+/**
+ * A helper class for Java friendly convertion from protobuf objects to their CIM counterparts.
+ *
+ * @property networkService The [NetworkService] all converted objects should be added to.
+ */
 class NetworkProtoToCim(val networkService: NetworkService) : BaseProtoToCim() {
 
-    // IEC61968 ASSET INFO
+    // #######################
+    // # IEC61968 ASSET INFO #
+    // #######################
+
+    /**
+     * Add a converted copy of the protobuf [PBCableInfo] to the [NetworkService].
+     *
+     * @param pb The [PBCableInfo] to convert.
+     * @return The converted [CableInfo]
+     */
     fun addFromPb(pb: PBCableInfo): CableInfo? = networkService.addFromPb(pb)
+
+    /**
+     * Add a converted copy of the protobuf [PBNoLoadTest] to the [NetworkService].
+     *
+     * @param pb The [PBNoLoadTest] to convert.
+     * @return The converted [NoLoadTest]
+     */
     fun addFromPb(pb: PBNoLoadTest): NoLoadTest? = networkService.addFromPb(pb)
+
+    /**
+     * Add a converted copy of the protobuf [PBOpenCircuitTest] to the [NetworkService].
+     *
+     * @param pb The [PBOpenCircuitTest] to convert.
+     * @return The converted [OpenCircuitTest]
+     */
     fun addFromPb(pb: PBOpenCircuitTest): OpenCircuitTest? = networkService.addFromPb(pb)
+
+    /**
+     * Add a converted copy of the protobuf [PBOverheadWireInfo] to the [NetworkService].
+     *
+     * @param pb The [PBOverheadWireInfo] to convert.
+     * @return The converted [OverheadWireInfo]
+     */
     fun addFromPb(pb: PBOverheadWireInfo): OverheadWireInfo? = networkService.addFromPb(pb)
+
+    /**
+     * Add a converted copy of the protobuf [PBPowerTransformerInfo] to the [NetworkService].
+     *
+     * @param pb The [PBPowerTransformerInfo] to convert.
+     * @return The converted [PowerTransformerInfo]
+     */
     fun addFromPb(pb: PBPowerTransformerInfo): PowerTransformerInfo? = networkService.addFromPb(pb)
+
+    /**
+     * Add a converted copy of the protobuf [PBShortCircuitTest] to the [NetworkService].
+     *
+     * @param pb The [PBShortCircuitTest] to convert.
+     * @return The converted [ShortCircuitTest]
+     */
     fun addFromPb(pb: PBShortCircuitTest): ShortCircuitTest? = networkService.addFromPb(pb)
+
+    /**
+     * Add a converted copy of the protobuf [PBShuntCompensatorInfo] to the [NetworkService].
+     *
+     * @param pb The [PBShuntCompensatorInfo] to convert.
+     * @return The converted [ShuntCompensatorInfo]
+     */
     fun addFromPb(pb: PBShuntCompensatorInfo): ShuntCompensatorInfo? = networkService.addFromPb(pb)
+
+    /**
+     * Add a converted copy of the protobuf [PBSwitchInfo] to the [NetworkService].
+     *
+     * @param pb The [PBSwitchInfo] to convert.
+     * @return The converted [SwitchInfo]
+     */
     fun addFromPb(pb: PBSwitchInfo): SwitchInfo? = networkService.addFromPb(pb)
+
+    /**
+     * Add a converted copy of the protobuf [PBTransformerEndInfo] to the [NetworkService].
+     *
+     * @param pb The [PBTransformerEndInfo] to convert.
+     * @return The converted [TransformerEndInfo]
+     */
     fun addFromPb(pb: PBTransformerEndInfo): TransformerEndInfo? = networkService.addFromPb(pb)
+
+    /**
+     * Add a converted copy of the protobuf [PBTransformerTankInfo] to the [NetworkService].
+     *
+     * @param pb The [PBTransformerTankInfo] to convert.
+     * @return The converted [TransformerTankInfo]
+     */
     fun addFromPb(pb: PBTransformerTankInfo): TransformerTankInfo? = networkService.addFromPb(pb)
 
-    // IEC61968 ASSETS
+    // ###################
+    // # IEC61968 ASSETS #
+    // ###################
+
+    /**
+     * Add a converted copy of the protobuf [PBAssetOwner] to the [NetworkService].
+     *
+     * @param pb The [PBAssetOwner] to convert.
+     * @return The converted [AssetOwner]
+     */
     fun addFromPb(pb: PBAssetOwner): AssetOwner? = networkService.addFromPb(pb)
+
+    /**
+     * Add a converted copy of the protobuf [PBPole] to the [NetworkService].
+     *
+     * @param pb The [PBPole] to convert.
+     * @return The converted [Pole]
+     */
     fun addFromPb(pb: PBPole): Pole? = networkService.addFromPb(pb)
+
+    /**
+     * Add a converted copy of the protobuf [PBStreetlight] to the [NetworkService].
+     *
+     * @param pb The [PBStreetlight] to convert.
+     * @return The converted [Streetlight]
+     */
     fun addFromPb(pb: PBStreetlight): Streetlight? = networkService.addFromPb(pb)
 
-    // IEC61968 COMMON
+    // ###################
+    // # IEC61968 COMMON #
+    // ###################
+
+    /**
+     * Add a converted copy of the protobuf [PBOrganisation] to the [NetworkService].
+     *
+     * @param pb The [PBOrganisation] to convert.
+     * @return The converted [Organisation]
+     */
     fun addFromPb(pb: PBOrganisation): Organisation? = networkService.addFromPb(pb)
+
+    /**
+     * Add a converted copy of the protobuf [PBLocation] to the [NetworkService].
+     *
+     * @param pb The [PBLocation] to convert.
+     * @return The converted [Location]
+     */
     fun addFromPb(pb: PBLocation): Location? = networkService.addFromPb(pb)
 
-    // IEC61968 infIEC61968 InfAssetInfo
+    // #####################################
+    // # IEC61968 infIEC61968 InfAssetInfo #
+    // #####################################
+
+    /**
+     * Add a converted copy of the protobuf [PBRelayInfo] to the [NetworkService].
+     *
+     * @param pb The [PBRelayInfo] to convert.
+     * @return The converted [RelayInfo]
+     */
     fun addFromPb(pb: PBRelayInfo): RelayInfo? = networkService.addFromPb(pb)
+
+    /**
+     * Add a converted copy of the protobuf [PBCurrentTransformerInfo] to the [NetworkService].
+     *
+     * @param pb The [PBCurrentTransformerInfo] to convert.
+     * @return The converted [CurrentTransformerInfo]
+     */
     fun addFromPb(pb: PBCurrentTransformerInfo): CurrentTransformerInfo? = networkService.addFromPb(pb)
+
+    /**
+     * Add a converted copy of the protobuf [PBPotentialTransformerInfo] to the [NetworkService].
+     *
+     * @param pb The [PBPotentialTransformerInfo] to convert.
+     * @return The converted [PotentialTransformerInfo]
+     */
     fun addFromPb(pb: PBPotentialTransformerInfo): PotentialTransformerInfo? = networkService.addFromPb(pb)
 
-    // IEC61968 METERING
+    // #####################
+    // # IEC61968 METERING #
+    // #####################
+
+    /**
+     * Add a converted copy of the protobuf [PBMeter] to the [NetworkService].
+     *
+     * @param pb The [PBMeter] to convert.
+     * @return The converted [Meter]
+     */
     fun addFromPb(pb: PBMeter): Meter? = networkService.addFromPb(pb)
+
+    /**
+     * Add a converted copy of the protobuf [PBUsagePoint] to the [NetworkService].
+     *
+     * @param pb The [PBUsagePoint] to convert.
+     * @return The converted [UsagePoint]
+     */
     fun addFromPb(pb: PBUsagePoint): UsagePoint? = networkService.addFromPb(pb)
 
-    // IEC61968 OPERATIONS
+    // #######################
+    // # IEC61968 OPERATIONS #
+    // #######################
+
+    /**
+     * Add a converted copy of the protobuf [PBOperationalRestriction] to the [NetworkService].
+     *
+     * @param pb The [PBOperationalRestriction] to convert.
+     * @return The converted [OperationalRestriction]
+     */
     fun addFromPb(pb: PBOperationalRestriction): OperationalRestriction? = networkService.addFromPb(pb)
 
-    // IEC61970 BASE AUXILIARY EQUIPMENT
+    // #####################################
+    // # IEC61970 BASE AUXILIARY EQUIPMENT #
+    // #####################################
+
+    /**
+     * Add a converted copy of the protobuf [PBCurrentTransformer] to the [NetworkService].
+     *
+     * @param pb The [PBCurrentTransformer] to convert.
+     * @return The converted [CurrentTransformer]
+     */
     fun addFromPb(pb: PBCurrentTransformer): CurrentTransformer? = networkService.addFromPb(pb)
+
+    /**
+     * Add a converted copy of the protobuf [PBFaultIndicator] to the [NetworkService].
+     *
+     * @param pb The [PBFaultIndicator] to convert.
+     * @return The converted [FaultIndicator]
+     */
     fun addFromPb(pb: PBFaultIndicator): FaultIndicator? = networkService.addFromPb(pb)
+
+    /**
+     * Add a converted copy of the protobuf [PBPotentialTransformer] to the [NetworkService].
+     *
+     * @param pb The [PBPotentialTransformer] to convert.
+     * @return The converted [PotentialTransformer]
+     */
     fun addFromPb(pb: PBPotentialTransformer): PotentialTransformer? = networkService.addFromPb(pb)
 
-    // IEC61970 BASE CORE
+    // ######################
+    // # IEC61970 BASE CORE #
+    // ######################
+
+    /**
+     * Add a converted copy of the protobuf [PBBaseVoltage] to the [NetworkService].
+     *
+     * @param pb The [PBBaseVoltage] to convert.
+     * @return The converted [BaseVoltage]
+     */
     fun addFromPb(pb: PBBaseVoltage): BaseVoltage? = networkService.addFromPb(pb)
+
+    /**
+     * Add a converted copy of the protobuf [PBConnectivityNode] to the [NetworkService].
+     *
+     * @param pb The [PBConnectivityNode] to convert.
+     * @return The converted [ConnectivityNode]
+     */
     fun addFromPb(pb: PBConnectivityNode): ConnectivityNode? = networkService.addFromPb(pb)
+
+    /**
+     * Add a converted copy of the protobuf [PBFeeder] to the [NetworkService].
+     *
+     * @param pb The [PBFeeder] to convert.
+     * @return The converted [Feeder]
+     */
     fun addFromPb(pb: PBFeeder): Feeder? = networkService.addFromPb(pb)
+
+    /**
+     * Add a converted copy of the protobuf [PBGeographicalRegion] to the [NetworkService].
+     *
+     * @param pb The [PBGeographicalRegion] to convert.
+     * @return The converted [GeographicalRegion]
+     */
     fun addFromPb(pb: PBGeographicalRegion): GeographicalRegion? = networkService.addFromPb(pb)
+
+    /**
+     * Add a converted copy of the protobuf [PBNameType] to the [NetworkService].
+     *
+     * @param pb The [PBNameType] to convert.
+     * @return The converted [NameType]
+     */
     fun addFromPb(pb: PBNameType): NameType = networkService.addFromPb(pb)
+
+    /**
+     * Add a converted copy of the protobuf [PBSite] to the [NetworkService].
+     *
+     * @param pb The [PBSite] to convert.
+     * @return The converted [Site]
+     */
     fun addFromPb(pb: PBSite): Site? = networkService.addFromPb(pb)
+
+    /**
+     * Add a converted copy of the protobuf [PBSubGeographicalRegion] to the [NetworkService].
+     *
+     * @param pb The [PBSubGeographicalRegion] to convert.
+     * @return The converted [SubGeographicalRegion]
+     */
     fun addFromPb(pb: PBSubGeographicalRegion): SubGeographicalRegion? = networkService.addFromPb(pb)
+
+    /**
+     * Add a converted copy of the protobuf [PBSubstation] to the [NetworkService].
+     *
+     * @param pb The [PBSubstation] to convert.
+     * @return The converted [Substation]
+     */
     fun addFromPb(pb: PBSubstation): Substation? = networkService.addFromPb(pb)
+
+    /**
+     * Add a converted copy of the protobuf [PBTerminal] to the [NetworkService].
+     *
+     * @param pb The [PBTerminal] to convert.
+     * @return The converted [Terminal]
+     */
     fun addFromPb(pb: PBTerminal): Terminal? = networkService.addFromPb(pb)
 
-    // IEC61970 BASE BASE EQUIVALENTS
+    // ##################################
+    // # IEC61970 BASE BASE EQUIVALENTS #
+    // ##################################
+
+    /**
+     * Add a converted copy of the protobuf [PBEquivalentBranch] to the [NetworkService].
+     *
+     * @param pb The [PBEquivalentBranch] to convert.
+     * @return The converted [EquivalentBranch]
+     */
     fun addFromPb(pb: PBEquivalentBranch): EquivalentBranch? = networkService.addFromPb(pb)
 
-    // IEC61970 BASE MEAS
+    // ######################
+    // # IEC61970 BASE MEAS #
+    // ######################
+
+    /**
+     * Add a converted copy of the protobuf [PBControl] to the [NetworkService].
+     *
+     * @param pb The [PBControl] to convert.
+     * @return The converted [Control]
+     */
     fun addFromPb(pb: PBControl): Control? = networkService.addFromPb(pb)
+
+    /**
+     * Add a converted copy of the protobuf [PBAnalog] to the [NetworkService].
+     *
+     * @param pb The [PBAnalog] to convert.
+     * @return The converted [Analog]
+     */
     fun addFromPb(pb: PBAnalog): Analog? = networkService.addFromPb(pb)
+
+    /**
+     * Add a converted copy of the protobuf [PBAccumulator] to the [NetworkService].
+     *
+     * @param pb The [PBAccumulator] to convert.
+     * @return The converted [Accumulator]
+     */
     fun addFromPb(pb: PBAccumulator): Accumulator? = networkService.addFromPb(pb)
+
+    /**
+     * Add a converted copy of the protobuf [PBDiscrete] to the [NetworkService].
+     *
+     * @param pb The [PBDiscrete] to convert.
+     * @return The converted [Discrete]
+     */
     fun addFromPb(pb: PBDiscrete): Discrete? = networkService.addFromPb(pb)
 
-    // IEC61970 Base Protection
+    // ########################
+// IEC6# 1970 Base Protection #
+    // ########################
+
+    /**
+     * Add a converted copy of the protobuf [PBCurrentRelay] to the [NetworkService].
+     *
+     * @param pb The [PBCurrentRelay] to convert.
+     * @return The converted [CurrentRelay]
+     */
     fun addFromPb(pb: PBCurrentRelay): CurrentRelay? = networkService.addFromPb(pb)
+
+    /**
+     * Add a converted copy of the protobuf [PBDistanceRelay] to the [NetworkService].
+     *
+     * @param pb The [PBDistanceRelay] to convert.
+     * @return The converted [DistanceRelay]
+     */
     fun addFromPb(pb: PBDistanceRelay): DistanceRelay? = networkService.addFromPb(pb)
+
+    /**
+     * Add a converted copy of the protobuf [PBProtectionRelayScheme] to the [NetworkService].
+     *
+     * @param pb The [PBProtectionRelayScheme] to convert.
+     * @return The converted [ProtectionRelayScheme]
+     */
     fun addFromPb(pb: PBProtectionRelayScheme): ProtectionRelayScheme? = networkService.addFromPb(pb)
+
+    /**
+     * Add a converted copy of the protobuf [PBProtectionRelaySystem] to the [NetworkService].
+     *
+     * @param pb The [PBProtectionRelaySystem] to convert.
+     * @return The converted [ProtectionRelaySystem]
+     */
     fun addFromPb(pb: PBProtectionRelaySystem): ProtectionRelaySystem? = networkService.addFromPb(pb)
+
+    /**
+     * Add a converted copy of the protobuf [PBVoltageRelay] to the [NetworkService].
+     *
+     * @param pb The [PBVoltageRelay] to convert.
+     * @return The converted [VoltageRelay]
+     */
     fun addFromPb(pb: PBVoltageRelay): VoltageRelay? = networkService.addFromPb(pb)
 
-    // IEC61970 BASE SCADA
+    // #######################
+    // # IEC61970 BASE SCADA #
+    // #######################
+
+    /**
+     * Add a converted copy of the protobuf [PBRemoteControl] to the [NetworkService].
+     *
+     * @param pb The [PBRemoteControl] to convert.
+     * @return The converted [RemoteControl]
+     */
     fun addFromPb(pb: PBRemoteControl): RemoteControl? = networkService.addFromPb(pb)
+
+    /**
+     * Add a converted copy of the protobuf [PBRemoteSource] to the [NetworkService].
+     *
+     * @param pb The [PBRemoteSource] to convert.
+     * @return The converted [RemoteSource]
+     */
     fun addFromPb(pb: PBRemoteSource): RemoteSource? = networkService.addFromPb(pb)
 
-    // IEC61970 BASE WIRES GENERATION PRODUCTION
+    // #############################################
+    // # IEC61970 BASE WIRES GENERATION PRODUCTION #
+    // #############################################
+
+    /**
+     * Add a converted copy of the protobuf [PBBatteryUnit] to the [NetworkService].
+     *
+     * @param pb The [PBBatteryUnit] to convert.
+     * @return The converted [BatteryUnit]
+     */
     fun addFromPb(pb: PBBatteryUnit): BatteryUnit? = networkService.addFromPb(pb)
+
+    /**
+     * Add a converted copy of the protobuf [PBPhotoVoltaicUnit] to the [NetworkService].
+     *
+     * @param pb The [PBPhotoVoltaicUnit] to convert.
+     * @return The converted [PhotoVoltaicUnit]
+     */
     fun addFromPb(pb: PBPhotoVoltaicUnit): PhotoVoltaicUnit? = networkService.addFromPb(pb)
+
+    /**
+     * Add a converted copy of the protobuf [PBPowerElectronicsWindUnit] to the [NetworkService].
+     *
+     * @param pb The [PBPowerElectronicsWindUnit] to convert.
+     * @return The converted [PowerElectronicsWindUnit]
+     */
     fun addFromPb(pb: PBPowerElectronicsWindUnit): PowerElectronicsWindUnit? = networkService.addFromPb(pb)
 
-    // IEC61970 BASE WIRES
+    // #######################
+    // # IEC61970 BASE WIRES #
+    // #######################
+
+    /**
+     * Add a converted copy of the protobuf [PBAcLineSegment] to the [NetworkService].
+     *
+     * @param pb The [PBAcLineSegment] to convert.
+     * @return The converted [AcLineSegment]
+     */
     fun addFromPb(pb: PBAcLineSegment): AcLineSegment? = networkService.addFromPb(pb)
+
+    /**
+     * Add a converted copy of the protobuf [PBBreaker] to the [NetworkService].
+     *
+     * @param pb The [PBBreaker] to convert.
+     * @return The converted [Breaker]
+     */
     fun addFromPb(pb: PBBreaker): Breaker? = networkService.addFromPb(pb)
+
+    /**
+     * Add a converted copy of the protobuf [PBBusbarSection] to the [NetworkService].
+     *
+     * @param pb The [PBBusbarSection] to convert.
+     * @return The converted [BusbarSection]
+     */
     fun addFromPb(pb: PBBusbarSection): BusbarSection? = networkService.addFromPb(pb)
+
+    /**
+     * Add a converted copy of the protobuf [PBDisconnector] to the [NetworkService].
+     *
+     * @param pb The [PBDisconnector] to convert.
+     * @return The converted [Disconnector]
+     */
     fun addFromPb(pb: PBDisconnector): Disconnector? = networkService.addFromPb(pb)
+
+    /**
+     * Add a converted copy of the protobuf [PBEnergyConsumer] to the [NetworkService].
+     *
+     * @param pb The [PBEnergyConsumer] to convert.
+     * @return The converted [EnergyConsumer]
+     */
     fun addFromPb(pb: PBEnergyConsumer): EnergyConsumer? = networkService.addFromPb(pb)
+
+    /**
+     * Add a converted copy of the protobuf [PBEnergyConsumerPhase] to the [NetworkService].
+     *
+     * @param pb The [PBEnergyConsumerPhase] to convert.
+     * @return The converted [EnergyConsumerPhase]
+     */
     fun addFromPb(pb: PBEnergyConsumerPhase): EnergyConsumerPhase? = networkService.addFromPb(pb)
+
+    /**
+     * Add a converted copy of the protobuf [PBEnergySource] to the [NetworkService].
+     *
+     * @param pb The [PBEnergySource] to convert.
+     * @return The converted [EnergySource]
+     */
     fun addFromPb(pb: PBEnergySource): EnergySource? = networkService.addFromPb(pb)
+
+    /**
+     * Add a converted copy of the protobuf [PBEnergySourcePhase] to the [NetworkService].
+     *
+     * @param pb The [PBEnergySourcePhase] to convert.
+     * @return The converted [EnergySourcePhase]
+     */
     fun addFromPb(pb: PBEnergySourcePhase): EnergySourcePhase? = networkService.addFromPb(pb)
+
+    /**
+     * Add a converted copy of the protobuf [PBFuse] to the [NetworkService].
+     *
+     * @param pb The [PBFuse] to convert.
+     * @return The converted [Fuse]
+     */
     fun addFromPb(pb: PBFuse): Fuse? = networkService.addFromPb(pb)
+
+    /**
+     * Add a converted copy of the protobuf [PBGround] to the [NetworkService].
+     *
+     * @param pb The [PBGround] to convert.
+     * @return The converted [Ground]
+     */
     fun addFromPb(pb: PBGround): Ground? = networkService.addFromPb(pb)
+
+    /**
+     * Add a converted copy of the protobuf [PBGroundDisconnector] to the [NetworkService].
+     *
+     * @param pb The [PBGroundDisconnector] to convert.
+     * @return The converted [GroundDisconnector]
+     */
     fun addFromPb(pb: PBGroundDisconnector): GroundDisconnector? = networkService.addFromPb(pb)
+
+    /**
+     * Add a converted copy of the protobuf [PBGroundingImpedance] to the [NetworkService].
+     *
+     * @param pb The [PBGroundingImpedance] to convert.
+     * @return The converted [GroundingImpedance]
+     */
     fun addFromPb(pb: PBGroundingImpedance): GroundingImpedance? = networkService.addFromPb(pb)
+
+    /**
+     * Add a converted copy of the protobuf [PBJumper] to the [NetworkService].
+     *
+     * @param pb The [PBJumper] to convert.
+     * @return The converted [Jumper]
+     */
     fun addFromPb(pb: PBJumper): Jumper? = networkService.addFromPb(pb)
+
+    /**
+     * Add a converted copy of the protobuf [PBJunction] to the [NetworkService].
+     *
+     * @param pb The [PBJunction] to convert.
+     * @return The converted [Junction]
+     */
     fun addFromPb(pb: PBJunction): Junction? = networkService.addFromPb(pb)
+
+    /**
+     * Add a converted copy of the protobuf [PBLinearShuntCompensator] to the [NetworkService].
+     *
+     * @param pb The [PBLinearShuntCompensator] to convert.
+     * @return The converted [LinearShuntCompensator]
+     */
     fun addFromPb(pb: PBLinearShuntCompensator): LinearShuntCompensator? = networkService.addFromPb(pb)
+
+    /**
+     * Add a converted copy of the protobuf [PBLoadBreakSwitch] to the [NetworkService].
+     *
+     * @param pb The [PBLoadBreakSwitch] to convert.
+     * @return The converted [LoadBreakSwitch]
+     */
     fun addFromPb(pb: PBLoadBreakSwitch): LoadBreakSwitch? = networkService.addFromPb(pb)
+
+    /**
+     * Add a converted copy of the protobuf [PBPerLengthSequenceImpedance] to the [NetworkService].
+     *
+     * @param pb The [PBPerLengthSequenceImpedance] to convert.
+     * @return The converted [PerLengthSequenceImpedance]
+     */
     fun addFromPb(pb: PBPerLengthSequenceImpedance): PerLengthSequenceImpedance? = networkService.addFromPb(pb)
+
+    /**
+     * Add a converted copy of the protobuf [PBPetersenCoil] to the [NetworkService].
+     *
+     * @param pb The [PBPetersenCoil] to convert.
+     * @return The converted [PetersenCoil]
+     */
     fun addFromPb(pb: PBPetersenCoil): PetersenCoil? = networkService.addFromPb(pb)
+
+    /**
+     * Add a converted copy of the protobuf [PBPowerElectronicsConnection] to the [NetworkService].
+     *
+     * @param pb The [PBPowerElectronicsConnection] to convert.
+     * @return The converted [PowerElectronicsConnection]
+     */
     fun addFromPb(pb: PBPowerElectronicsConnection): PowerElectronicsConnection? = networkService.addFromPb(pb)
+
+    /**
+     * Add a converted copy of the protobuf [PBPowerElectronicsConnectionPhase] to the [NetworkService].
+     *
+     * @param pb The [PBPowerElectronicsConnectionPhase] to convert.
+     * @return The converted [PowerElectronicsConnectionPhase]
+     */
     fun addFromPb(pb: PBPowerElectronicsConnectionPhase): PowerElectronicsConnectionPhase? = networkService.addFromPb(pb)
+
+    /**
+     * Add a converted copy of the protobuf [PBPowerTransformer] to the [NetworkService].
+     *
+     * @param pb The [PBPowerTransformer] to convert.
+     * @return The converted [PowerTransformer]
+     */
     fun addFromPb(pb: PBPowerTransformer): PowerTransformer? = networkService.addFromPb(pb)
+
+    /**
+     * Add a converted copy of the protobuf [PBPowerTransformerEnd] to the [NetworkService].
+     *
+     * @param pb The [PBPowerTransformerEnd] to convert.
+     * @return The converted [PowerTransformerEnd]
+     */
     fun addFromPb(pb: PBPowerTransformerEnd): PowerTransformerEnd? = networkService.addFromPb(pb)
+
+    /**
+     * Add a converted copy of the protobuf [PBRatioTapChanger] to the [NetworkService].
+     *
+     * @param pb The [PBRatioTapChanger] to convert.
+     * @return The converted [RatioTapChanger]
+     */
     fun addFromPb(pb: PBRatioTapChanger): RatioTapChanger? = networkService.addFromPb(pb)
+
+    /**
+     * Add a converted copy of the protobuf [PBReactiveCapabilityCurve] to the [NetworkService].
+     *
+     * @param pb The [PBReactiveCapabilityCurve] to convert.
+     * @return The converted [ReactiveCapabilityCurve]
+     */
     fun addFromPb(pb: PBReactiveCapabilityCurve): ReactiveCapabilityCurve? = networkService.addFromPb(pb)
+
+    /**
+     * Add a converted copy of the protobuf [PBRecloser] to the [NetworkService].
+     *
+     * @param pb The [PBRecloser] to convert.
+     * @return The converted [Recloser]
+     */
     fun addFromPb(pb: PBRecloser): Recloser? = networkService.addFromPb(pb)
+
+    /**
+     * Add a converted copy of the protobuf [PBSeriesCompensator] to the [NetworkService].
+     *
+     * @param pb The [PBSeriesCompensator] to convert.
+     * @return The converted [SeriesCompensator]
+     */
     fun addFromPb(pb: PBSeriesCompensator): SeriesCompensator? = networkService.addFromPb(pb)
+
+    /**
+     * Add a converted copy of the protobuf [PBSynchronousMachine] to the [NetworkService].
+     *
+     * @param pb The [PBSynchronousMachine] to convert.
+     * @return The converted [SynchronousMachine]
+     */
     fun addFromPb(pb: PBSynchronousMachine): SynchronousMachine? = networkService.addFromPb(pb)
+
+    /**
+     * Add a converted copy of the protobuf [PBTapChangerControl] to the [NetworkService].
+     *
+     * @param pb The [PBTapChangerControl] to convert.
+     * @return The converted [TapChangerControl]
+     */
     fun addFromPb(pb: PBTapChangerControl): TapChangerControl? = networkService.addFromPb(pb)
+
+    /**
+     * Add a converted copy of the protobuf [PBTransformerStarImpedance] to the [NetworkService].
+     *
+     * @param pb The [PBTransformerStarImpedance] to convert.
+     * @return The converted [TransformerStarImpedance]
+     */
     fun addFromPb(pb: PBTransformerStarImpedance): TransformerStarImpedance? = networkService.addFromPb(pb)
 
-    // IEC61970 InfIEC61970 Base Wires Generation Production
+    // #########################################################
+    // # IEC61970 InfIEC61970 Base Wires Generation Production #
+    // #########################################################
+
+    /**
+     * Add a converted copy of the protobuf [PBEvChargingUnit] to the [NetworkService].
+     *
+     * @param pb The [PBEvChargingUnit] to convert.
+     * @return The converted [EvChargingUnit]
+     */
     fun addFromPb(pb: PBEvChargingUnit): EvChargingUnit? = networkService.addFromPb(pb)
 
-    // IEC61970 InfIEC61970 Feeder
+    // ###############################
+    // # IEC61970 InfIEC61970 Feeder #
+    // ###############################
+
+    /**
+     * Add a converted copy of the protobuf [PBCircuit] to the [NetworkService].
+     *
+     * @param pb The [PBCircuit] to convert.
+     * @return The converted [Circuit]
+     */
     fun addFromPb(pb: PBCircuit): Circuit? = networkService.addFromPb(pb)
+
+    /**
+     * Add a converted copy of the protobuf [PBLoop] to the [NetworkService].
+     *
+     * @param pb The [PBLoop] to convert.
+     * @return The converted [Loop]
+     */
     fun addFromPb(pb: PBLoop): Loop? = networkService.addFromPb(pb)
+
+    /**
+     * Add a converted copy of the protobuf [PBLvFeeder] to the [NetworkService].
+     *
+     * @param pb The [PBLvFeeder] to convert.
+     * @return The converted [LvFeeder]
+     */
     fun addFromPb(pb: PBLvFeeder): LvFeeder? = networkService.addFromPb(pb)
 
 }

--- a/src/main/kotlin/com/zepben/evolve/services/network/translator/NetworkProtoToCim.kt
+++ b/src/main/kotlin/com/zepben/evolve/services/network/translator/NetworkProtoToCim.kt
@@ -1246,7 +1246,7 @@ fun toCim(pb: PBShuntCompensator, cim: ShuntCompensator, networkService: Network
 fun toCim(pb: PBSwitch, cim: Switch, networkService: NetworkService): Switch =
     cim.apply {
         networkService.resolveOrDeferReference(Resolvers.assetInfo(this), pb.assetInfoMRID())
-        ratedCurrent = pb.ratedCurrent.takeUnless { it == UNKNOWN_UINT }
+        ratedCurrent = pb.ratedCurrent.takeUnless { it == UNKNOWN_DOUBLE }
         setNormallyOpen(pb.normalOpen)
         setOpen(pb.open)
         // when unganged support is added to protobuf
@@ -1258,7 +1258,7 @@ fun toCim(pb: PBSwitch, cim: Switch, networkService: NetworkService): Switch =
 fun toCim(pb: PBSynchronousMachine, networkService: NetworkService): SynchronousMachine =
     SynchronousMachine(pb.mRID()).apply {
         pb.reactiveCapabilityCurveMRIDsList.forEach { reactiveCapabilityCurveMRID ->
-            networkService.resolveOrDeferReference(Resolvers.reactiveCapabilityCurve(this), reactiveCapabilityCurveMRID.mRID())
+            networkService.resolveOrDeferReference(Resolvers.reactiveCapabilityCurve(this), reactiveCapabilityCurveMRID)
         }
         baseQ = pb.baseQ.takeUnless { it == UNKNOWN_DOUBLE }
         condenserP = pb.condenserP.takeUnless { it == UNKNOWN_INT }

--- a/src/test/kotlin/com/zepben/evolve/database/sqlite/cim/upgrade/ChangeSetTest.kt
+++ b/src/test/kotlin/com/zepben/evolve/database/sqlite/cim/upgrade/ChangeSetTest.kt
@@ -55,7 +55,8 @@ internal class ChangeSetTest {
         NoChanges(DatabaseType.CUSTOMER, 52),
         NoChanges(DatabaseType.CUSTOMER, 53),
         ChangeSet54CustomerValidator,
-        NoChanges(DatabaseType.CUSTOMER, 55)
+        NoChanges(DatabaseType.CUSTOMER, 55),
+        NoChanges(DatabaseType.CUSTOMER, 56)
     ).associateBy { it.version }
 
     private val diagramChangeSetValidators = listOf(
@@ -64,7 +65,8 @@ internal class ChangeSetTest {
         ChangeSet52DiagramValidator,
         NoChanges(DatabaseType.DIAGRAM, 53),
         NoChanges(DatabaseType.DIAGRAM, 54),
-        NoChanges(DatabaseType.DIAGRAM, 55)
+        NoChanges(DatabaseType.DIAGRAM, 55),
+        NoChanges(DatabaseType.DIAGRAM, 56)
     ).associateBy { it.version }
 
     private val networkChangeSetValidators = listOf(
@@ -73,7 +75,8 @@ internal class ChangeSetTest {
         ChangeSet52NetworkValidator,
         ChangeSet53NetworkValidator,
         NoChanges(DatabaseType.NETWORK_MODEL, 54),
-        ChangeSet55NetworkValidator
+        ChangeSet55NetworkValidator,
+        ChangeSet56NetworkValidator
     ).associateBy { it.version }
 
     @Test

--- a/src/test/kotlin/com/zepben/evolve/database/sqlite/cim/upgrade/changesets/network/ChangeSet56NetworkValidator.kt
+++ b/src/test/kotlin/com/zepben/evolve/database/sqlite/cim/upgrade/changesets/network/ChangeSet56NetworkValidator.kt
@@ -1,0 +1,110 @@
+/*
+ * Copyright 2024 Zeppelin Bend Pty Ltd
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+package com.zepben.evolve.database.sqlite.cim.upgrade.changesets.network
+
+import com.zepben.evolve.database.getNullableDouble
+import com.zepben.evolve.database.paths.DatabaseType
+import com.zepben.evolve.database.sqlite.cim.upgrade.changesets.ChangeSetValidator
+import org.hamcrest.MatcherAssert.assertThat
+import org.hamcrest.Matchers.equalTo
+import org.hamcrest.Matchers.nullValue
+import java.sql.Statement
+
+object ChangeSet56NetworkValidator : ChangeSetValidator(DatabaseType.NETWORK_MODEL, 56) {
+
+    //
+    // NOTE: In the validators we are only checking a subset of common columns including the one that was actually changed.
+    //
+
+    private val tables = listOf(
+        "breakers",
+        "disconnectors",
+        "fuses",
+        "ground_disconnectors",
+        "jumpers",
+        "load_break_switches",
+        "reclosers",
+    )
+
+    override fun setUpStatements(): List<String> = tables.flatMap { table ->
+        listOf(
+            // Rated current of 11.
+            "INSERT INTO $table (mrid, name, description, num_diagram_objects, location_mrid, num_controls, normally_in_service, in_service, commissioned_date, base_voltage_mrid, normal_open, open, rated_current, switch_info_mrid) VALUES ('1', '', '', 1, 'loc1', 10, true, true, 'comm1', 'bv1', 100, 1000, 11, 'si1');",
+
+            // Rated current of null
+            "INSERT INTO $table (mrid, name, description, num_diagram_objects, location_mrid, num_controls, normally_in_service, in_service, commissioned_date, base_voltage_mrid, normal_open, open, rated_current, switch_info_mrid) VALUES ('2', '', '', 2, 'loc2', 20, true, true, 'comm2', 'bv2', 200, 2000, null, 'si2');"
+        )
+    }
+
+    override fun populateStatements(): List<String> = tables.map { table ->
+        // Rated current of 33.3.
+        "INSERT INTO $table (mrid, name, description, num_diagram_objects, location_mrid, num_controls, normally_in_service, in_service, commissioned_date, base_voltage_mrid, normal_open, open, rated_current, switch_info_mrid) VALUES ('3', '', '', 3, 'loc3', 30, true, true, 'comm3', 'bv3', 300, 3000, 33.3, 'si3');"
+    }
+
+    override fun validateChanges(statement: Statement) {
+        tables.forEach { ensureModifiedRatedCurrent(statement, it) }
+    }
+
+    override fun tearDownStatements(): List<String> =
+        tables.map { "DELETE FROM $it;" }
+
+    private fun ensureModifiedRatedCurrent(statement: Statement, table: String) {
+        validateRows(statement, "SELECT * FROM $table",
+            { rs ->
+                assertThat(rs.getString("mrid"), equalTo("1"))
+                assertThat(rs.getString("name"), equalTo(""))
+                assertThat(rs.getString("description"), equalTo(""))
+                assertThat(rs.getInt("num_diagram_objects"), equalTo(1))
+                assertThat(rs.getString("location_mrid"), equalTo("loc1"))
+                assertThat(rs.getInt("num_controls"), equalTo(10))
+                assertThat(rs.getBoolean("normally_in_service"), equalTo(true))
+                assertThat(rs.getBoolean("in_service"), equalTo(true))
+                assertThat(rs.getString("commissioned_date"), equalTo("comm1"))
+                assertThat(rs.getString("base_voltage_mrid"), equalTo("bv1"))
+                assertThat(rs.getInt("normal_open"), equalTo(100))
+                assertThat(rs.getInt("open"), equalTo(1000))
+                assertThat(rs.getNullableDouble("rated_current"), equalTo(11.0))
+                assertThat(rs.getString("switch_info_mrid"), equalTo("si1"))
+            },
+            { rs ->
+                assertThat(rs.getString("mrid"), equalTo("2"))
+                assertThat(rs.getString("name"), equalTo(""))
+                assertThat(rs.getString("description"), equalTo(""))
+                assertThat(rs.getInt("num_diagram_objects"), equalTo(2))
+                assertThat(rs.getString("location_mrid"), equalTo("loc2"))
+                assertThat(rs.getInt("num_controls"), equalTo(20))
+                assertThat(rs.getBoolean("normally_in_service"), equalTo(true))
+                assertThat(rs.getBoolean("in_service"), equalTo(true))
+                assertThat(rs.getString("commissioned_date"), equalTo("comm2"))
+                assertThat(rs.getString("base_voltage_mrid"), equalTo("bv2"))
+                assertThat(rs.getInt("normal_open"), equalTo(200))
+                assertThat(rs.getInt("open"), equalTo(2000))
+                assertThat(rs.getNullableDouble("rated_current"), nullValue())
+                assertThat(rs.getString("switch_info_mrid"), equalTo("si2"))
+            },
+            { rs ->
+                assertThat(rs.getString("mrid"), equalTo("3"))
+                assertThat(rs.getString("name"), equalTo(""))
+                assertThat(rs.getString("description"), equalTo(""))
+                assertThat(rs.getInt("num_diagram_objects"), equalTo(3))
+                assertThat(rs.getString("location_mrid"), equalTo("loc3"))
+                assertThat(rs.getInt("num_controls"), equalTo(30))
+                assertThat(rs.getBoolean("normally_in_service"), equalTo(true))
+                assertThat(rs.getBoolean("in_service"), equalTo(true))
+                assertThat(rs.getString("commissioned_date"), equalTo("comm3"))
+                assertThat(rs.getString("base_voltage_mrid"), equalTo("bv3"))
+                assertThat(rs.getInt("normal_open"), equalTo(300))
+                assertThat(rs.getInt("open"), equalTo(3000))
+                assertThat(rs.getNullableDouble("rated_current"), equalTo(33.3))
+                assertThat(rs.getString("switch_info_mrid"), equalTo("si3"))
+            }
+        )
+    }
+
+}

--- a/src/test/kotlin/com/zepben/evolve/services/network/NetworkServiceComparatorTest.kt
+++ b/src/test/kotlin/com/zepben/evolve/services/network/NetworkServiceComparatorTest.kt
@@ -1302,7 +1302,7 @@ internal class NetworkServiceComparatorTest : BaseServiceComparatorTest() {
         compareConductingEquipment(createSwitch)
 
         comparatorValidator.validateProperty(Switch::assetInfo, createSwitch, { SwitchInfo("si1") }, { SwitchInfo("si2") })
-        comparatorValidator.validateProperty(Switch::ratedCurrent, createSwitch, { 1 }, { 2 })
+        comparatorValidator.validateProperty(Switch::ratedCurrent, createSwitch, { 1.0 }, { 2.0 })
 
         val closedSwitch = createSwitch("mRID").apply { setNormallyOpen(false); setOpen(true) }
         val openSwitch = createSwitch("mRID").apply { setNormallyOpen(true); setOpen(false) }

--- a/src/test/kotlin/com/zepben/evolve/services/network/testdata/FillFields.kt
+++ b/src/test/kotlin/com/zepben/evolve/services/network/testdata/FillFields.kt
@@ -1326,7 +1326,7 @@ fun Switch.fillFields(service: NetworkService, includeRuntime: Boolean = true): 
     (this as ConductingEquipment).fillFields(service, includeRuntime)
 
     assetInfo = SwitchInfo().also { service.add(it) }
-    ratedCurrent = 1
+    ratedCurrent = 1.1
 
     setNormallyOpen(true)
     setOpen(true)


### PR DESCRIPTION
# Description

Made the following changes:
* Changed `Switch.ratedCurrent` to a float to support milli-amp ratings of fuses.
* `SynchronousMachine.reactiveCapabilityCurveMRIDs` is now a list of strings. This is what it should have always been (missed in the PR review of the initial change).
* Added docstrings.

# Associated tasks

- https://github.com/zepben/ewb-grpc/pull/111
- https://github.com/zepben/ewb-network-routes/pull/149
- https://github.com/zepben/network-verifier-lib/pull/47

# Test Steps

1. Update a database and make sure the sqlite file has updated the `rated_current` column of all switch tables to be a float, and your values are still there.
2. Request a `SynchronousMachine` via gRPC and ensure the curves collection is a list of mRID's rather than the curves themselves.

or 

rely on the extensive checks in the unit tests that cover this for you.

# Checklist

If any of these are not applicable, strikethrough the line `~like this~`. **Do not delete it!**. Let the reviewer decide if you should have done it.

### Code
- [x] I have performed a self review of my own code (including checking issues raised when creating the PR).
- [x] I have added/updated unit tests for these changes, and if not I have explained why they are not necessary.
- [x] I have commented my code in any hard-to-understand or hacky areas.
- [x] I have handled all new warnings generated by the compiler or IDE.
- [ ] I have rebased onto the target branch (usually main).

### Documentation
- [x] I have updated the changelog.
~- [ ] I have updated any documentation required for these changes.~

# Breaking Changes
- [x] I have considered if this is a breaking change and will communicate it with other team members if so.

Both changes are breaking.
