### PR TITLE
DEV-1573 Traced phases optimisation

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -23,6 +23,8 @@
   * A new class, `LocalEwbDataFilePaths`, has been introduced to specifically handle the resolution of database paths for the local file system.
 * `Switch.ratedCurrent` has been converted to a `double` (used to be an `integer`). Type safe languages will need to be updated to support floating point
   arithmatic/syntax.
+* Deprecated `TracedPhases`, however the internal constructor property has been removed. `Terminal.normalPhases`
+  and `Terminal.currentPhases` should be used instead of `Terminal.tracedPhases` going forward.
 
 ### New Features
 * A file named after the ID of an ingestion job is now created when running `MetricsDatabaseWriter.save()`. For this feature to take effect, a `modelPath` must

--- a/docs/docs/datamodel.mdx
+++ b/docs/docs/datamodel.mdx
@@ -248,8 +248,8 @@ switch.setOpen(false)
 Phases in CIM are set on a [Terminal](https://zepben.github.io/evolve/docs/cim/evolve/IEC61970/Base/Core/Terminal). The `phases`
 property on the terminal should be considered as the terminal's 'nominal' phases. The vast majority of the time, this will
 be the actual active phases at that terminal. However, due to the dynamic nature of the network, it's possible that when
-tracing connectivity that the active phase at the terminal is different. The phase can be tracked using the `tracedPhases`
-property on the terminal. 
+tracing connectivity that the active phase at the terminal is different. The phase can be tracked using the `normalPhases`
+and `currentPhases` properties on the terminal.
 
 :::tip
 There are a number of helpful functions for tracing phases based on connectivity. See [tracing](./sdk-tracing) for more details.

--- a/docs/docs/phases.mdx
+++ b/docs/docs/phases.mdx
@@ -10,11 +10,11 @@ import TabItem from '@theme/TabItem';
 
 There are three different types of phases stored/calculated by the SDK:
 
-| Phase Type | SDK Field                                                   | Field Type  | Description                                                                                                                                                                                                                |
-|------------|-------------------------------------------------------------|-------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| Nominal    | `Terminal.phases`                                           | `PhaseCode` | The nominal phases of the network indicate how the network is connected. The nominal phases can include the "unknown" phases `X` and `Y`. <br/><br/>This is the phase field that you are most likely to be interested in.  |
-| Normal     | `Terminal.normalPhases` or `Terminal.tracedPhases.normal`   | `Traced`    | The normal phases indicate the energised phases of the network in its normal state. There will not be any unknown phases in the normal phases, however; any de-energised areas of the network will not have normal phases. |
-| Current    | `Terminal.currentPhases` or `Terminal.tracedPhases.current` | `Traced`    | The current phases indicate the energised phases of the network in the current state. It has the same caveats as the normal phases.                                                                                        |
+| Phase Type | SDK Field                                                   | Field Type    | Description                                                                                                                                                                                                                |
+|------------|-------------------------------------------------------------|---------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| Nominal    | `Terminal.phases`                                           | `PhaseCode`   | The nominal phases of the network indicate how the network is connected. The nominal phases can include the "unknown" phases `X` and `Y`. <br/><br/>This is the phase field that you are most likely to be interested in.  |
+| Normal     | `Terminal.normalPhases`                                     | `PhaseStatus` | The normal phases indicate the energised phases of the network in its normal state. There will not be any unknown phases in the normal phases, however; any de-energised areas of the network will not have normal phases. |
+| Current    | `Terminal.currentPhases`                                    | `PhaseStatus` | The current phases indicate the energised phases of the network in the current state. It has the same caveats as the normal phases.                                                                                        |
 
 There are two different feeder directions calculated by the SDK:
 

--- a/src/main/kotlin/com/zepben/evolve/cim/iec61970/base/core/Terminal.kt
+++ b/src/main/kotlin/com/zepben/evolve/cim/iec61970/base/core/Terminal.kt
@@ -9,7 +9,6 @@
 package com.zepben.evolve.cim.iec61970.base.core
 
 import com.zepben.evolve.services.network.tracing.feeder.FeederDirection
-import com.zepben.evolve.services.network.tracing.phases.PhaseSelector
 import com.zepben.evolve.services.network.tracing.phases.PhaseStatus
 import com.zepben.evolve.services.network.tracing.phases.TracedPhases
 import java.lang.ref.WeakReference
@@ -43,7 +42,11 @@ class Terminal @JvmOverloads constructor(mRID: String = "") : AcDcTerminal(mRID)
     var normalFeederDirection: FeederDirection = FeederDirection.NONE
     var currentFeederDirection: FeederDirection = FeederDirection.NONE
 
-    val tracedPhases: TracedPhases = TracedPhases(terminal = this)
+    @Deprecated(
+        message = "Replaced by direct use of `normalPhases` and `currentPhases`.",
+        replaceWith = ReplaceWith("/* See [TracedPhases.normal] and [TracedPhases.current] for direct replacement suggestions */"),
+    )
+    val tracedPhases: TracedPhases get() = TracedPhases(terminal = this)
 
     // The reference to the connectivity node is weak so if a Network object goes out of scope, holding a single conducting equipment
     // reference does not cause everything connected to it in the network to stay in memory.
@@ -68,18 +71,18 @@ class Terminal @JvmOverloads constructor(mRID: String = "") : AcDcTerminal(mRID)
     val isConnected: Boolean; get() = connectivityNode != null
 
     /**
-     * Convenience method for accessing the normal phases.
+     * The status of phases as traced for the normal state of the network
      *
      * @return the [PhaseStatus] for the terminal in the normal state of the network.
      */
-    val normalPhases: PhaseStatus = PhaseSelector.NORMAL_PHASES.phases(this)
+    val normalPhases: PhaseStatus = PhaseStatus(this)
 
     /**
-     * Convenience method for accessing the current phases.
+     * The status of phases as traced for the current state of the network
      *
-     * @return the [PhaseStatus] for the terminal in the normal state of the network.
+     * @return the [PhaseStatus] for the terminal in the current state of the network.
      */
-    val currentPhases: PhaseStatus = PhaseSelector.CURRENT_PHASES.phases(this)
+    val currentPhases: PhaseStatus = PhaseStatus(this)
 
     /**
      * Get the terminals that are connected to this [Terminal].

--- a/src/main/kotlin/com/zepben/evolve/services/network/NetworkServiceComparator.kt
+++ b/src/main/kotlin/com/zepben/evolve/services/network/NetworkServiceComparator.kt
@@ -463,8 +463,8 @@ class NetworkServiceComparator @JvmOverloads constructor(
             compareIdReferences(Terminal::conductingEquipment, Terminal::connectivityNode)
             compareValues(Terminal::phases, Terminal::sequenceNumber, Terminal::normalFeederDirection, Terminal::currentFeederDirection)
 
-            // TracedPhases is not comparable directly
-            addIfDifferent(Terminal::tracedPhases.name, Terminal::tracedPhases.compareValues(source, target) { it.phaseStatusInternal })
+            addIfDifferent(Terminal::normalPhases.name, Terminal::normalPhases.compareValues(source, target) { it.phaseStatusInternal })
+            addIfDifferent(Terminal::currentPhases.name, Terminal::currentPhases.compareValues(source, target) { it.phaseStatusInternal })
         }
 
     /************ IEC61970 BASE EQUIVALENTS ************/

--- a/src/main/kotlin/com/zepben/evolve/services/network/tracing/connectivity/TerminalConnectivityConnected.kt
+++ b/src/main/kotlin/com/zepben/evolve/services/network/tracing/connectivity/TerminalConnectivityConnected.kt
@@ -128,15 +128,13 @@ class TerminalConnectivityConnected @JvmOverloads constructor(
 
     private fun checkTracedPhases(step: XyPhaseStep, candidatePhases: XyCandidatePhasePaths): Boolean {
         var foundTraced = false
-        step.terminal.tracedPhases.apply {
-            normal[SPK.X].takeIf { it != SPK.NONE }?.also {
-                candidatePhases.addKnown(SPK.X, it)
-                foundTraced = true
-            }
-            normal[SPK.Y].takeIf { it != SPK.NONE }?.also {
-                candidatePhases.addKnown(SPK.Y, it)
-                foundTraced = true
-            }
+        step.terminal.normalPhases[SPK.X].takeIf { it != SPK.NONE }?.also {
+            candidatePhases.addKnown(SPK.X, it)
+            foundTraced = true
+        }
+        step.terminal.normalPhases[SPK.Y].takeIf { it != SPK.NONE }?.also {
+            candidatePhases.addKnown(SPK.Y, it)
+            foundTraced = true
         }
         return foundTraced
     }

--- a/src/main/kotlin/com/zepben/evolve/services/network/tracing/phases/PhaseSelector.kt
+++ b/src/main/kotlin/com/zepben/evolve/services/network/tracing/phases/PhaseSelector.kt
@@ -22,10 +22,10 @@ fun interface PhaseSelector {
     companion object {
 
         @JvmField
-        val NORMAL_PHASES: PhaseSelector = PhaseSelector { terminal -> terminal.tracedPhases.normal }
+        val NORMAL_PHASES: PhaseSelector = PhaseSelector { it.normalPhases }
 
         @JvmField
-        val CURRENT_PHASES: PhaseSelector = PhaseSelector { terminal -> terminal.tracedPhases.current }
+        val CURRENT_PHASES: PhaseSelector = PhaseSelector { it.currentPhases }
 
     }
 

--- a/src/main/kotlin/com/zepben/evolve/services/network/tracing/phases/RemovePhases.kt
+++ b/src/main/kotlin/com/zepben/evolve/services/network/tracing/phases/RemovePhases.kt
@@ -60,7 +60,8 @@ class RemovePhases {
      */
     fun run(networkService: NetworkService) {
         networkService.sequenceOf<Terminal>().forEach {
-            it.tracedPhases.phaseStatusInternal = 0u
+            it.normalPhases.phaseStatusInternal = 0u
+            it.currentPhases.phaseStatusInternal = 0u
         }
     }
 

--- a/src/main/kotlin/com/zepben/evolve/services/network/tracing/phases/TracedPhases.kt
+++ b/src/main/kotlin/com/zepben/evolve/services/network/tracing/phases/TracedPhases.kt
@@ -10,75 +10,45 @@ package com.zepben.evolve.services.network.tracing.phases
 
 import com.zepben.evolve.cim.iec61970.base.core.PhaseCode
 import com.zepben.evolve.cim.iec61970.base.core.Terminal
-import com.zepben.evolve.services.network.tracing.phases.TracedPhasesBitManipulation.get
-import com.zepben.evolve.services.network.tracing.phases.TracedPhasesBitManipulation.set
 import com.zepben.evolve.cim.iec61970.base.wires.SinglePhaseKind as SPK
 
-/**
- * Class that holds the traced phase statuses for the current and normal state of the network.
- *
- * Traced phase status:
- * |     integer      |
- * | 16 bits |16 bits |
- * | current | normal |
- *
- * See [TracedPhasesBitManipulation] for details on bit representation for normal and current status.
- *
- * @property phaseStatusInternal The underlying implementation value tracking the phase statuses for the current and normal state of the network.
- *                               It is primarily used for data serialisation and debugging within official evolve libraries and utilities.
- *
- *                               NOTE: This property should be considered evolve internal and not for public use as the underlying
- *                               data structure to store the status could change at any time (and thus be a breaking change).
- *                               Use at your own risk.
- */
-class TracedPhases(
-    internal var phaseStatusInternal: UInt = 0u,
-    terminal: Terminal
-) {
-
-    private val normalMask: UInt = 0x0000ffff.toUInt()
-    private val currentMask: UInt = 0xffff0000.toUInt()
-    private val currentShift = 16
+@Deprecated(
+    "Traced phases are now stored directly as PhaseStatus on the terminal",
+    replaceWith = ReplaceWith("/* `Terminal.normalPhases` for the normal traced phase status, `Terminal.currentPhases` for the current trace phase status */")
+)
+class TracedPhases(private val terminal: Terminal) {
 
     /**
      * The traced phases in the normal state of the network.
      */
-    val normal: PhaseStatus = object : PhaseStatus(terminal) {
-        override operator fun get(nominalPhase: SPK): SPK = normal(nominalPhase)
-        override operator fun set(nominalPhase: SPK, singlePhaseKind: SPK): Boolean = setNormal(nominalPhase, singlePhaseKind)
-    }
+    @Deprecated(
+        message = "Use normalPhases directly on the terminal.",
+        replaceWith = ReplaceWith("terminal.normalPhases"),
+    )
+    val normal: PhaseStatus get() = terminal.normalPhases
 
     /**
      * The traced phases in the current state of the network.
      */
-    val current: PhaseStatus = object : PhaseStatus(terminal) {
-        override operator fun get(nominalPhase: SPK): SPK = current(nominalPhase)
-        override operator fun set(nominalPhase: SPK, singlePhaseKind: SPK): Boolean = setCurrent(nominalPhase, singlePhaseKind)
-    }
+    @Deprecated(
+        message = "Use currentPhases directly on the terminal.",
+        replaceWith = ReplaceWith("terminal.currentPhases"),
+    )
+    val current: PhaseStatus get() = terminal.currentPhases
 
-
+    @Deprecated(
+        message = "Use normalPhases directly on the terminal.",
+        replaceWith = ReplaceWith("terminal.normalPhases.set"),
+    )
     fun setNormal(nominalPhase: SPK, singlePhaseKind: SPK): Boolean =
-        normal(nominalPhase).let {
-            if (it == singlePhaseKind)
-                false
-            else if ((it == SPK.NONE) || (singlePhaseKind == SPK.NONE)) {
-                phaseStatusInternal = (phaseStatusInternal and currentMask) or set(phaseStatusInternal, nominalPhase, singlePhaseKind)
-                true
-            } else
-                throw UnsupportedOperationException("Crossing Phases.")
-        }
+        normal.set(nominalPhase, singlePhaseKind)
 
+    @Deprecated(
+        message = "Use currentPhases directly on the terminal.",
+        replaceWith = ReplaceWith("terminal.currentPhases.set"),
+    )
     fun setCurrent(nominalPhase: SPK, singlePhaseKind: SPK): Boolean =
-        current(nominalPhase).let {
-            if (it == singlePhaseKind)
-                false
-            else if ((it == SPK.NONE) || (singlePhaseKind == SPK.NONE)) {
-                phaseStatusInternal =
-                    (phaseStatusInternal and normalMask) or (set(phaseStatusInternal shr currentShift, nominalPhase, singlePhaseKind) shl currentShift)
-                true
-            } else
-                throw UnsupportedOperationException("Crossing Phases.")
-        }
+        current.set(nominalPhase, singlePhaseKind)
 
     override fun toString(): String {
         val normal = PhaseCode.ABCN.singlePhases.joinToString(prefix = "{", postfix = "}") { "${normal(it)}" }
@@ -87,14 +57,16 @@ class TracedPhases(
     }
 
     // Java interop
-    fun normal(nominalPhase: SPK): SPK = get(phaseStatusInternal, nominalPhase.validate())
-    fun current(nominalPhase: SPK): SPK = get(phaseStatusInternal shr currentShift, nominalPhase.validate())
+    @Deprecated(
+        message = "Use normalPhases directly on the terminal.",
+        replaceWith = ReplaceWith("terminal.normalPhases.get"),
+    )
+    fun normal(nominalPhase: SPK): SPK = normal[nominalPhase]
 
-    private fun SPK.validate(): SPK {
-        when (this) {
-            SPK.A, SPK.B, SPK.C, SPK.N, SPK.X, SPK.Y, SPK.s1, SPK.s2 -> return this
-            SPK.NONE, SPK.INVALID -> throw IllegalArgumentException("INTERNAL ERROR: Phase $this is invalid.")
-        }
-    }
+    @Deprecated(
+        message = "Use currentPhases directly on the terminal.",
+        replaceWith = ReplaceWith("terminal.currentPhases.get"),
+    )
+    fun current(nominalPhase: SPK): SPK = current[nominalPhase]
 
 }

--- a/src/main/kotlin/com/zepben/evolve/services/network/tracing/phases/TracedPhasesBitManipulation.kt
+++ b/src/main/kotlin/com/zepben/evolve/services/network/tracing/phases/TracedPhasesBitManipulation.kt
@@ -27,7 +27,7 @@ import com.zepben.evolve.cim.iec61970.base.wires.SinglePhaseKind
  *               |  1 bit  |  1 bit  |  1 bit  |  1 bit  |
  * Actual Phase: |    N    |    C    |    B    |    A    |
  */
-object TracedPhasesBitManipulation {
+internal object TracedPhasesBitManipulation {
 
     /**
      * Bitwise mask for selecting the actual phases from a nominal phase A/B/C/N, X/Y/N or s1/s2/N

--- a/src/main/kotlin/com/zepben/evolve/services/network/tracing/phases/TracedPhasesBitManipulation.kt
+++ b/src/main/kotlin/com/zepben/evolve/services/network/tracing/phases/TracedPhasesBitManipulation.kt
@@ -40,8 +40,8 @@ object TracedPhasesBitManipulation {
     private val phaseMasks = listOf(1u, 2u, 4u, 8u)
 
     @JvmStatic
-    fun get(status: UInt, nominalPhase: SinglePhaseKind): SinglePhaseKind {
-        return when ((status shr nominalPhase.byteSelector()) and 15u) {
+    fun get(status: UShort, nominalPhase: SinglePhaseKind): SinglePhaseKind {
+        return when ((status.toUInt() shr nominalPhase.byteSelector()) and 15u) {
             1u -> SinglePhaseKind.A
             2u -> SinglePhaseKind.B
             4u -> SinglePhaseKind.C
@@ -51,11 +51,14 @@ object TracedPhasesBitManipulation {
     }
 
     @JvmStatic
-    fun set(status: UInt, nominalPhase: SinglePhaseKind, singlePhaseKind: SinglePhaseKind): UInt =
-        if (singlePhaseKind == SinglePhaseKind.NONE)
-            (status and nominalPhaseMasks[nominalPhase.maskIndex].inv())
+    fun set(status: UShort, nominalPhase: SinglePhaseKind, singlePhaseKind: SinglePhaseKind): UShort {
+        val newStatus = if (singlePhaseKind == SinglePhaseKind.NONE)
+            (status.toUInt() and nominalPhaseMasks[nominalPhase.maskIndex].inv())
         else
-            (status and nominalPhaseMasks[nominalPhase.maskIndex].inv()) or singlePhaseKind.shiftedValue(nominalPhase)
+            (status.toUInt() and nominalPhaseMasks[nominalPhase.maskIndex].inv()) or singlePhaseKind.shiftedValue(nominalPhase)
+
+        return newStatus.toUShort()
+    }
 
     private fun SinglePhaseKind.byteSelector() = maskIndex * 4
 

--- a/src/main/kotlin/com/zepben/evolve/services/network/translator/NetworkCimToProto.kt
+++ b/src/main/kotlin/com/zepben/evolve/services/network/translator/NetworkCimToProto.kt
@@ -1126,7 +1126,7 @@ fun toPb(cim: Terminal, pb: PBTerminal.Builder): PBTerminal.Builder =
         sequenceNumber = cim.sequenceNumber
         normalFeederDirection = FeederDirection.valueOf(cim.normalFeederDirection.name)
         currentFeederDirection = FeederDirection.valueOf(cim.currentFeederDirection.name)
-        tracedPhases = cim.tracedPhases.phaseStatusInternal.toInt()
+        tracedPhases = (cim.currentPhases.phaseStatusInternal.toInt() shl 16) + cim.normalPhases.phaseStatusInternal.toInt()
         toPb(cim, adBuilder)
     }
 

--- a/src/main/kotlin/com/zepben/evolve/services/network/translator/NetworkProtoToCim.kt
+++ b/src/main/kotlin/com/zepben/evolve/services/network/translator/NetworkProtoToCim.kt
@@ -1159,7 +1159,8 @@ fun toCim(pb: PBTerminal, networkService: NetworkService): Terminal =
         sequenceNumber = pb.sequenceNumber
         normalFeederDirection = FeederDirection.valueOf(pb.normalFeederDirection.name)
         currentFeederDirection = FeederDirection.valueOf(pb.currentFeederDirection.name)
-        tracedPhases.phaseStatusInternal = pb.tracedPhases.toUInt()
+        normalPhases.phaseStatusInternal = (pb.tracedPhases and 0xFFFF).toUShort()
+        currentPhases.phaseStatusInternal = ((pb.tracedPhases shr 16) and 0xFFFF).toUShort()
 
         // Sequence number must be set before adding the terminal to the conducting equipment to prevent it from being auto set
         networkService.resolveOrDeferReference(Resolvers.conductingEquipment(this), pb.conductingEquipmentMRID)

--- a/src/test/kotlin/com/zepben/evolve/cim/iec61970/base/core/TerminalTest.kt
+++ b/src/test/kotlin/com/zepben/evolve/cim/iec61970/base/core/TerminalTest.kt
@@ -9,7 +9,6 @@
 package com.zepben.evolve.cim.iec61970.base.core
 
 import com.zepben.evolve.cim.iec61970.base.wires.Junction
-import com.zepben.evolve.cim.iec61970.base.wires.SinglePhaseKind
 import com.zepben.evolve.services.network.NetworkService
 import com.zepben.evolve.services.network.testdata.fillFields
 import com.zepben.evolve.services.network.tracing.feeder.FeederDirection
@@ -39,7 +38,8 @@ internal class TerminalTest {
         assertThat(terminal.phases, equalTo(PhaseCode.ABC))
         assertThat(terminal.sequenceNumber, equalTo(0))
         assertThat(terminal.connectivityNode, nullValue())
-        assertThat(terminal.tracedPhases.phaseStatusInternal, equalTo(0u))
+        assertThat(terminal.normalPhases.phaseStatusInternal, equalTo(0u))
+        assertThat(terminal.currentPhases.phaseStatusInternal, equalTo(0u))
         assertThat(terminal.normalFeederDirection, equalTo(FeederDirection.NONE))
         assertThat(terminal.currentFeederDirection, equalTo(FeederDirection.NONE))
 
@@ -49,7 +49,8 @@ internal class TerminalTest {
         assertThat(terminal.phases, equalTo(PhaseCode.X))
         assertThat(terminal.sequenceNumber, equalTo(1))
         assertThat(terminal.connectivityNode, notNullValue())
-        assertThat(terminal.tracedPhases.phaseStatusInternal, equalTo(2u))
+        assertThat(terminal.normalPhases.phaseStatusInternal, equalTo(1u))
+        assertThat(terminal.currentPhases.phaseStatusInternal, equalTo(2u))
         assertThat(terminal.normalFeederDirection, equalTo(FeederDirection.UPSTREAM))
         assertThat(terminal.currentFeederDirection, equalTo(FeederDirection.DOWNSTREAM))
     }
@@ -115,43 +116,9 @@ internal class TerminalTest {
     }
 
     @Test
-    internal fun tracedPhases() {
+    internal fun normalAndCurrentPhasesAreDifferentStatuses() {
         val terminal = Terminal()
-
-        validatePhases(terminal, SinglePhaseKind.NONE, SinglePhaseKind.NONE)
-
-        terminal.tracedPhases.setNormal(SinglePhaseKind.A, SinglePhaseKind.B)
-        validatePhases(terminal, SinglePhaseKind.B, SinglePhaseKind.NONE)
-
-        terminal.tracedPhases.setCurrent(SinglePhaseKind.A, SinglePhaseKind.A)
-        validatePhases(terminal, SinglePhaseKind.B, SinglePhaseKind.A)
-    }
-
-    @Test
-    internal fun tracedPhasesOperators() {
-        val terminal = Terminal()
-
-        validatePhases(terminal, SinglePhaseKind.NONE, SinglePhaseKind.NONE)
-
-        terminal.tracedPhases.normal[SinglePhaseKind.A] = SinglePhaseKind.B
-        validatePhases(terminal, SinglePhaseKind.B, SinglePhaseKind.NONE)
-
-        terminal.tracedPhases.current[SinglePhaseKind.A] = SinglePhaseKind.A
-        validatePhases(terminal, SinglePhaseKind.B, SinglePhaseKind.A)
-    }
-
-    private fun validatePhases(
-        terminal: Terminal,
-        normalPhase: SinglePhaseKind,
-        currentPhase: SinglePhaseKind,
-    ) {
-        assertThat(terminal.normalPhases[SinglePhaseKind.A], equalTo(normalPhase))
-        assertThat(terminal.tracedPhases.normal[SinglePhaseKind.A], equalTo(normalPhase))
-        assertThat(terminal.tracedPhases.normal(SinglePhaseKind.A), equalTo(normalPhase))
-
-        assertThat(terminal.currentPhases[SinglePhaseKind.A], equalTo(currentPhase))
-        assertThat(terminal.tracedPhases.current[SinglePhaseKind.A], equalTo(currentPhase))
-        assertThat(terminal.tracedPhases.current(SinglePhaseKind.A), equalTo(currentPhase))
+        assertThat(terminal.normalPhases, not(sameInstance(terminal.currentPhases)))
     }
 
 }

--- a/src/test/kotlin/com/zepben/evolve/services/network/NetworkServiceComparatorTest.kt
+++ b/src/test/kotlin/com/zepben/evolve/services/network/NetworkServiceComparatorTest.kt
@@ -579,19 +579,28 @@ internal class NetworkServiceComparatorTest : BaseServiceComparatorTest() {
             0x00000010 to 0x00000020,
             0x00000100 to 0x00000200,
             0x00001000 to 0x00002000,
-            0x00010000 to 0x00020000,
-            0x00100000 to 0x00200000,
-            0x01000000 to 0x02000000,
-            0x10000000 to 0x20000000,
         ).forEach { (first, second) ->
             comparatorValidator.validateValProperty(
-                Terminal::tracedPhases,
+                Terminal::normalPhases,
                 { Terminal(it) },
-                { _, tracedPhases -> tracedPhases.phaseStatusInternal = first.toUInt() },
-                { _, tracedPhases -> tracedPhases.phaseStatusInternal = second.toUInt() }
+                { _, phaseStatus -> phaseStatus.phaseStatusInternal = first.toUShort() },
+                { _, phaseStatus -> phaseStatus.phaseStatusInternal = second.toUShort() },
             )
         }
 
+        sequenceOf(
+            0x00000001 to 0x00000002,
+            0x00000010 to 0x00000020,
+            0x00000100 to 0x00000200,
+            0x00001000 to 0x00002000,
+        ).forEach { (first, second) ->
+            comparatorValidator.validateValProperty(
+                Terminal::currentPhases,
+                { Terminal(it) },
+                { _, phaseStatus -> phaseStatus.phaseStatusInternal = first.toUShort() },
+                { _, phaseStatus -> phaseStatus.phaseStatusInternal = second.toUShort() },
+            )
+        }
     }
 
     /************ IEC61970 BASE EQUIVALENTS ************/

--- a/src/test/kotlin/com/zepben/evolve/services/network/testdata/FillFields.kt
+++ b/src/test/kotlin/com/zepben/evolve/services/network/testdata/FillFields.kt
@@ -625,7 +625,8 @@ fun Terminal.fillFields(service: NetworkService, includeRuntime: Boolean = true)
     }
 
     if (includeRuntime) {
-        tracedPhases.phaseStatusInternal = 2u
+        normalPhases.phaseStatusInternal = 1u
+        currentPhases.phaseStatusInternal = 2u
         normalFeederDirection = FeederDirection.UPSTREAM
         currentFeederDirection = FeederDirection.DOWNSTREAM
     }

--- a/src/test/kotlin/com/zepben/evolve/services/network/tracing/connectivity/TerminalConnectivityConnectedTest.kt
+++ b/src/test/kotlin/com/zepben/evolve/services/network/tracing/connectivity/TerminalConnectivityConnectedTest.kt
@@ -289,8 +289,8 @@ internal class TerminalConnectivityConnectedTest {
 
     private fun Terminal.replaceNormalPhases(normalPhases: PhaseCode) {
         phases.singlePhases.filterIndexed { index, phase ->
-            tracedPhases.setNormal(phase, SPK.NONE)
-            tracedPhases.setNormal(phase, normalPhases.singlePhases[index])
+            this.normalPhases[phase] = SPK.NONE
+            this.normalPhases.set(phase, normalPhases.singlePhases[index])
         }
     }
 

--- a/src/test/kotlin/com/zepben/evolve/services/network/tracing/phases/PhaseSelectorTest.kt
+++ b/src/test/kotlin/com/zepben/evolve/services/network/tracing/phases/PhaseSelectorTest.kt
@@ -8,191 +8,25 @@
 
 package com.zepben.evolve.services.network.tracing.phases
 
-import com.zepben.evolve.cim.iec61970.base.core.PhaseCode
 import com.zepben.evolve.cim.iec61970.base.core.Terminal
-import com.zepben.evolve.cim.iec61970.base.wires.SinglePhaseKind
 import org.hamcrest.MatcherAssert.assertThat
-import org.hamcrest.Matchers.equalTo
-import org.hamcrest.Matchers.nullValue
+import org.hamcrest.Matchers.sameInstance
 import org.junit.jupiter.api.Test
-import org.mockito.kotlin.doReturn
-import org.mockito.kotlin.mock
-import org.mockito.kotlin.verify
-import org.mockito.kotlin.verifyNoMoreInteractions
 
 internal class PhaseSelectorTest {
 
-    private val normal = mock<PhaseStatus>()
-    private val current = mock<PhaseStatus>()
-    private val tracedPhases = mock<TracedPhases>().also {
-        doReturn(normal).`when`(it).normal
-        doReturn(current).`when`(it).current
-    }
-    private val terminal = mock<Terminal>().also { doReturn(tracedPhases).`when`(it).tracedPhases }
+    private val terminal = Terminal()
 
     @Test
-    internal fun testNormalPhaseSelectorGet() {
+    internal fun testNormal() {
         val ps = PhaseSelector.NORMAL_PHASES.phases(terminal)
-
-        ps[SinglePhaseKind.A]
-
-        verify(terminal).tracedPhases
-        verify(tracedPhases).normal
-        verify(normal)[SinglePhaseKind.A]
-
-        verifyDone()
+        assertThat(ps, sameInstance(terminal.normalPhases))
     }
 
     @Test
-    internal fun testNormalPhaseSelectorSet() {
-        val ps = PhaseSelector.NORMAL_PHASES.phases(terminal)
-
-        ps[SinglePhaseKind.B] = SinglePhaseKind.C
-
-        verify(terminal).tracedPhases
-        verify(tracedPhases).normal
-        verify(normal)[SinglePhaseKind.B] = SinglePhaseKind.C
-
-        verifyDone()
-    }
-
-    @Test
-    internal fun testCurrentPhaseSelectorGet() {
+    internal fun testCurrent() {
         val ps = PhaseSelector.CURRENT_PHASES.phases(terminal)
-
-        ps[SinglePhaseKind.X]
-
-        verify(terminal).tracedPhases
-        verify(tracedPhases).current
-        verify(current)[SinglePhaseKind.X]
-
-        verifyDone()
-    }
-
-    @Test
-    internal fun testCurrentPhaseSelectorSet() {
-        val ps = PhaseSelector.CURRENT_PHASES.phases(terminal)
-
-        ps[SinglePhaseKind.Y] = SinglePhaseKind.N
-
-        verify(terminal).tracedPhases
-        verify(tracedPhases).current
-        verify(current)[SinglePhaseKind.Y] = SinglePhaseKind.N
-
-        verifyDone()
-    }
-
-    @Test
-    internal fun testAsPhaseCodeThree() {
-        val terminal = Terminal().apply { phases = PhaseCode.ABCN }
-        val normalPhases = terminal.normalPhases
-        val currentPhases = terminal.currentPhases
-
-        assertThat(normalPhases.asPhaseCode(), equalTo(PhaseCode.NONE))
-        assertThat(currentPhases.asPhaseCode(), equalTo(PhaseCode.NONE))
-
-        normalPhases[SinglePhaseKind.A] = SinglePhaseKind.A
-
-        assertThat(normalPhases.asPhaseCode(), nullValue())
-        assertThat(currentPhases.asPhaseCode(), equalTo(PhaseCode.NONE))
-
-        currentPhases[SinglePhaseKind.A] = SinglePhaseKind.A
-
-        assertThat(normalPhases.asPhaseCode(), nullValue())
-        assertThat(currentPhases.asPhaseCode(), nullValue())
-
-        normalPhases[SinglePhaseKind.B] = SinglePhaseKind.B
-        normalPhases[SinglePhaseKind.C] = SinglePhaseKind.C
-        normalPhases[SinglePhaseKind.N] = SinglePhaseKind.N
-
-        assertThat(normalPhases.asPhaseCode(), equalTo(PhaseCode.ABCN))
-        assertThat(currentPhases.asPhaseCode(), nullValue())
-
-        currentPhases[SinglePhaseKind.B] = SinglePhaseKind.B
-        currentPhases[SinglePhaseKind.C] = SinglePhaseKind.C
-        currentPhases[SinglePhaseKind.N] = SinglePhaseKind.N
-
-        assertThat(normalPhases.asPhaseCode(), equalTo(PhaseCode.ABCN))
-        assertThat(currentPhases.asPhaseCode(), equalTo(PhaseCode.ABCN))
-    }
-
-    @Test
-    internal fun testAsPhaseCodeSingle() {
-        val terminal = Terminal().apply { phases = PhaseCode.BC }
-        val normalPhases = terminal.normalPhases
-        val currentPhases = terminal.currentPhases
-
-        assertThat(normalPhases.asPhaseCode(), equalTo(PhaseCode.NONE))
-        assertThat(currentPhases.asPhaseCode(), equalTo(PhaseCode.NONE))
-
-        normalPhases[SinglePhaseKind.A] = SinglePhaseKind.A
-        currentPhases[SinglePhaseKind.A] = SinglePhaseKind.A
-
-        assertThat(normalPhases.asPhaseCode(), equalTo(PhaseCode.NONE))
-        assertThat(currentPhases.asPhaseCode(), equalTo(PhaseCode.NONE))
-
-        normalPhases[SinglePhaseKind.B] = SinglePhaseKind.B
-        currentPhases[SinglePhaseKind.B] = SinglePhaseKind.B
-
-        assertThat(normalPhases.asPhaseCode(), nullValue())
-        assertThat(currentPhases.asPhaseCode(), nullValue())
-
-        normalPhases[SinglePhaseKind.C] = SinglePhaseKind.C
-        currentPhases[SinglePhaseKind.C] = SinglePhaseKind.C
-
-        assertThat(normalPhases.asPhaseCode(), equalTo(PhaseCode.BC))
-        assertThat(currentPhases.asPhaseCode(), equalTo(PhaseCode.BC))
-    }
-
-    @Test
-    internal fun testAsPhaseCodeNone() {
-        val terminal = Terminal().apply { phases = PhaseCode.NONE }
-        val normalPhases = terminal.normalPhases
-        val currentPhases = terminal.currentPhases
-
-        assertThat(normalPhases.asPhaseCode(), equalTo(PhaseCode.NONE))
-        assertThat(currentPhases.asPhaseCode(), equalTo(PhaseCode.NONE))
-
-        PhaseCode.ABCN.singlePhases.forEach {
-            normalPhases[it] = it
-            currentPhases[it] = it
-        }
-
-        assertThat(normalPhases.asPhaseCode(), equalTo(PhaseCode.NONE))
-        assertThat(currentPhases.asPhaseCode(), equalTo(PhaseCode.NONE))
-    }
-
-    @Test
-    internal fun asPhaseCodeHandlesChangingTerminalPhases() {
-        val terminal = Terminal().apply { phases = PhaseCode.BC }
-        val normalPhases = terminal.normalPhases
-
-        normalPhases[SinglePhaseKind.A] = SinglePhaseKind.A
-        normalPhases[SinglePhaseKind.B] = SinglePhaseKind.B
-        normalPhases[SinglePhaseKind.C] = SinglePhaseKind.C
-
-        assertThat(normalPhases.asPhaseCode(), equalTo(PhaseCode.BC))
-
-        terminal.phases = PhaseCode.AC
-        assertThat(normalPhases.asPhaseCode(), equalTo(PhaseCode.AC))
-    }
-
-    @Test
-    internal fun asPhaseCodeDoesNotDropPhases() {
-        val terminal = Terminal().apply { phases = PhaseCode.BC }
-        val normalPhases = terminal.normalPhases
-
-        normalPhases[SinglePhaseKind.B] = SinglePhaseKind.A
-        normalPhases[SinglePhaseKind.C] = SinglePhaseKind.A
-
-        assertThat(normalPhases.asPhaseCode(), nullValue())
-    }
-
-    private fun verifyDone() {
-        verifyNoMoreInteractions(terminal)
-        verifyNoMoreInteractions(tracedPhases)
-        verifyNoMoreInteractions(normal)
-        verifyNoMoreInteractions(current)
+        assertThat(ps, sameInstance(terminal.currentPhases))
     }
 
 }

--- a/src/test/kotlin/com/zepben/evolve/services/network/tracing/phases/PhaseStatusTest.kt
+++ b/src/test/kotlin/com/zepben/evolve/services/network/tracing/phases/PhaseStatusTest.kt
@@ -1,0 +1,189 @@
+/*
+ * Copyright 2024 Zeppelin Bend Pty Ltd
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+package com.zepben.evolve.services.network.tracing.phases
+
+import com.zepben.evolve.cim.iec61970.base.core.PhaseCode
+import com.zepben.evolve.cim.iec61970.base.core.Terminal
+import com.zepben.evolve.cim.iec61970.base.wires.SinglePhaseKind
+import com.zepben.testutils.exception.ExpectException
+import com.zepben.testutils.junit.SystemLogExtension
+import org.hamcrest.MatcherAssert.assertThat
+import org.hamcrest.Matchers.equalTo
+import org.hamcrest.Matchers.nullValue
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.RegisterExtension
+import com.zepben.evolve.cim.iec61970.base.wires.SinglePhaseKind as SPK
+
+internal class PhaseStatusTest {
+
+    @JvmField
+    @RegisterExtension
+    var systemErr: SystemLogExtension = SystemLogExtension.SYSTEM_ERR.captureLog().muteOnSuccess()
+
+    @Test
+    internal fun setAndGetNominalMatchesTraced() {
+        val terminal = Terminal().apply { phases = PhaseCode.ABCN }
+        val phaseStatus = PhaseStatus(terminal)
+
+        /* -- Setting -- */
+        assertThat("Should return true when setting traced phase of A to A", phaseStatus.set(SPK.A, SPK.A))
+        assertThat("Should return true when setting traced phase of B to B", phaseStatus.set(SPK.B, SPK.B))
+        assertThat("Should return true when setting traced phase of C to C", phaseStatus.set(SPK.C, SPK.C))
+        assertThat("Should return true when setting traced phase of N to N", phaseStatus.set(SPK.N, SPK.N))
+
+        /* -- Getting -- */
+        assertThat(phaseStatus[SPK.A], equalTo(SPK.A))
+        assertThat(phaseStatus[SPK.B], equalTo(SPK.B))
+        assertThat(phaseStatus[SPK.C], equalTo(SPK.C))
+        assertThat(phaseStatus[SPK.N], equalTo(SPK.N))
+
+        /* -- Setting Unchanged -- */
+        assertThat("Should return false when attempting to set already-set current traced phase of A", !phaseStatus.set(SPK.A, SPK.A))
+        assertThat("Should return false when attempting to set already-set current traced phase of B", !phaseStatus.set(SPK.B, SPK.B))
+        assertThat("Should return false when attempting to set already-set current traced phase of C", !phaseStatus.set(SPK.C, SPK.C))
+        assertThat("Should return false when attempting to set already-set current traced phase of N", !phaseStatus.set(SPK.N, SPK.N))
+    }
+
+    @Test
+    internal fun setAndGetNominalDoesNotMatchTraced() {
+        val terminal = Terminal().apply { phases = PhaseCode.ABCN }
+        val phaseStatus = PhaseStatus(terminal)
+
+        /* -- Setting -- */
+        assertThat("Should return true when setting traced phase of A to N", phaseStatus.set(SPK.A, SPK.N))
+        assertThat("Should return true when setting traced phase of B to C", phaseStatus.set(SPK.B, SPK.C))
+        assertThat("Should return true when setting traced phase of C to B", phaseStatus.set(SPK.C, SPK.B))
+        assertThat("Should return true when setting traced phase of N to A", phaseStatus.set(SPK.N, SPK.A))
+
+        /* -- Getting -- */
+        assertThat(phaseStatus[SPK.A], equalTo(SPK.N))
+        assertThat(phaseStatus[SPK.B], equalTo(SPK.C))
+        assertThat(phaseStatus[SPK.C], equalTo(SPK.B))
+        assertThat(phaseStatus[SPK.N], equalTo(SPK.A))
+
+        /* -- Setting Unchanged -- */
+        assertThat("Should return false when attempting to set already-set normal traced phase of A", !phaseStatus.set(SPK.A, SPK.N))
+        assertThat("Should return false when attempting to set already-set normal traced phase of B", !phaseStatus.set(SPK.B, SPK.C))
+        assertThat("Should return false when attempting to set already-set normal traced phase of C", !phaseStatus.set(SPK.C, SPK.B))
+        assertThat("Should return false when attempting to set already-set normal traced phase of N", !phaseStatus.set(SPK.N, SPK.A))
+    }
+
+    @Test
+    internal fun phaseCodeThree() {
+        val terminal = Terminal().apply { phases = PhaseCode.ABCN }
+        val phaseStatus = PhaseStatus(terminal)
+
+        assertThat(phaseStatus.asPhaseCode(), equalTo(PhaseCode.NONE))
+
+        phaseStatus[SPK.A] = SPK.A
+        assertThat(phaseStatus.asPhaseCode(), nullValue())
+
+        phaseStatus[SPK.B] = SPK.B
+        phaseStatus[SPK.C] = SPK.C
+        phaseStatus[SPK.N] = SPK.N
+        assertThat(phaseStatus.asPhaseCode(), equalTo(PhaseCode.ABCN))
+    }
+
+    @Test
+    internal fun phaseCodeSingle() {
+        val terminal = Terminal().apply { phases = PhaseCode.BC }
+        val phaseStatus = PhaseStatus(terminal)
+
+        assertThat(phaseStatus.asPhaseCode(), equalTo(PhaseCode.NONE))
+
+        phaseStatus[SPK.B] = SPK.B
+        assertThat(phaseStatus.asPhaseCode(), nullValue())
+
+        phaseStatus[SPK.C] = SPK.C
+        assertThat(phaseStatus.asPhaseCode(), equalTo(PhaseCode.BC))
+    }
+
+    @Test
+    internal fun phaseCodeNone() {
+        val terminal = Terminal().apply { phases = PhaseCode.ABCN }
+        val phaseStatus = PhaseStatus(terminal)
+
+        assertThat(phaseStatus.asPhaseCode(), equalTo(PhaseCode.NONE))
+
+        phaseStatus[SPK.A] = SPK.A
+        assertThat(phaseStatus.asPhaseCode(), nullValue())
+
+        phaseStatus[SPK.B] = SPK.B
+        assertThat(phaseStatus.asPhaseCode(), nullValue())
+
+        phaseStatus[SPK.C] = SPK.C
+        assertThat(phaseStatus.asPhaseCode(), nullValue())
+
+        phaseStatus[SPK.N] = SPK.N
+        assertThat(phaseStatus.asPhaseCode(), equalTo(PhaseCode.ABCN))
+    }
+
+    @Test
+    internal fun asPhaseCodeHandlesChangingTerminalPhases() {
+        val terminal = Terminal().apply { phases = PhaseCode.ABN }
+        val phaseStatus = PhaseStatus(terminal)
+
+        phaseStatus[SPK.A] = SPK.A
+        phaseStatus[SPK.B] = SPK.B
+        phaseStatus[SPK.C] = SPK.C
+        phaseStatus[SPK.N] = SPK.N
+
+        assertThat(phaseStatus[SinglePhaseKind.A], equalTo(SPK.A))
+        assertThat(phaseStatus[SinglePhaseKind.B], equalTo(SPK.B))
+        assertThat(phaseStatus[SinglePhaseKind.C], equalTo(SPK.C))
+        assertThat(phaseStatus[SinglePhaseKind.N], equalTo(SPK.N))
+        assertThat(phaseStatus.asPhaseCode(), equalTo(PhaseCode.ABN))
+
+        terminal.phases = PhaseCode.AC
+
+        assertThat(phaseStatus[SinglePhaseKind.A], equalTo(SPK.A))
+        assertThat(phaseStatus[SinglePhaseKind.B], equalTo(SPK.B))
+        assertThat(phaseStatus[SinglePhaseKind.C], equalTo(SPK.C))
+        assertThat(phaseStatus[SinglePhaseKind.N], equalTo(SPK.N))
+        assertThat(phaseStatus.asPhaseCode(), equalTo(PhaseCode.AC))
+
+        terminal.phases = PhaseCode.ABN
+
+        assertThat(phaseStatus.asPhaseCode(), equalTo(PhaseCode.ABN))
+    }
+
+    @Test
+    internal fun asPhaseCodeDoesNotDropPhases() {
+        val terminal = Terminal().apply { phases = PhaseCode.ABCN }
+        val phaseStatus = PhaseStatus(terminal)
+
+        phaseStatus[SPK.B] = SPK.A
+        phaseStatus[SPK.C] = SPK.A
+
+        assertThat(phaseStatus.asPhaseCode(), nullValue())
+    }
+
+    @Test
+    internal fun testInvalidNominalPhase() {
+        val terminal = Terminal().apply { phases = PhaseCode.ABCN }
+        val phaseStatus = PhaseStatus(terminal)
+
+        ExpectException.expect { phaseStatus[SPK.INVALID] }
+            .toThrow<IllegalArgumentException>()
+            .withMessage("INTERNAL ERROR: Phase INVALID is invalid.")
+    }
+
+    @Test
+    internal fun testCrossingPhasesException() {
+        val terminal = Terminal().apply { phases = PhaseCode.ABCN }
+        val phaseStatus = PhaseStatus(terminal)
+
+        ExpectException.expect {
+            phaseStatus[SPK.A] = SPK.A
+            phaseStatus[SPK.A] = SPK.B
+        }.toThrow<UnsupportedOperationException>()
+            .withMessage("Crossing Phases.")
+    }
+
+}

--- a/src/test/kotlin/com/zepben/evolve/services/network/tracing/phases/TracedPhasesBitManipulationTest.kt
+++ b/src/test/kotlin/com/zepben/evolve/services/network/tracing/phases/TracedPhasesBitManipulationTest.kt
@@ -23,52 +23,52 @@ internal class TracedPhasesBitManipulationTest {
 
     @Test
     internal fun get() {
-        assertThat(TracedPhasesBitManipulation.get(0x0001.toUInt(), SPK.A), equalTo(SPK.A))
-        assertThat(TracedPhasesBitManipulation.get(0x0002.toUInt(), SPK.A), equalTo(SPK.B))
-        assertThat(TracedPhasesBitManipulation.get(0x0004.toUInt(), SPK.A), equalTo(SPK.C))
-        assertThat(TracedPhasesBitManipulation.get(0x0008.toUInt(), SPK.A), equalTo(SPK.N))
+        assertThat(TracedPhasesBitManipulation.get(0x0001.toUShort(), SPK.A), equalTo(SPK.A))
+        assertThat(TracedPhasesBitManipulation.get(0x0002.toUShort(), SPK.A), equalTo(SPK.B))
+        assertThat(TracedPhasesBitManipulation.get(0x0004.toUShort(), SPK.A), equalTo(SPK.C))
+        assertThat(TracedPhasesBitManipulation.get(0x0008.toUShort(), SPK.A), equalTo(SPK.N))
 
-        assertThat(TracedPhasesBitManipulation.get(0x0010.toUInt(), SPK.B), equalTo(SPK.A))
-        assertThat(TracedPhasesBitManipulation.get(0x0020.toUInt(), SPK.B), equalTo(SPK.B))
-        assertThat(TracedPhasesBitManipulation.get(0x0040.toUInt(), SPK.B), equalTo(SPK.C))
-        assertThat(TracedPhasesBitManipulation.get(0x0080.toUInt(), SPK.B), equalTo(SPK.N))
+        assertThat(TracedPhasesBitManipulation.get(0x0010.toUShort(), SPK.B), equalTo(SPK.A))
+        assertThat(TracedPhasesBitManipulation.get(0x0020.toUShort(), SPK.B), equalTo(SPK.B))
+        assertThat(TracedPhasesBitManipulation.get(0x0040.toUShort(), SPK.B), equalTo(SPK.C))
+        assertThat(TracedPhasesBitManipulation.get(0x0080.toUShort(), SPK.B), equalTo(SPK.N))
 
-        assertThat(TracedPhasesBitManipulation.get(0x0100.toUInt(), SPK.C), equalTo(SPK.A))
-        assertThat(TracedPhasesBitManipulation.get(0x0200.toUInt(), SPK.C), equalTo(SPK.B))
-        assertThat(TracedPhasesBitManipulation.get(0x0400.toUInt(), SPK.C), equalTo(SPK.C))
-        assertThat(TracedPhasesBitManipulation.get(0x0800.toUInt(), SPK.C), equalTo(SPK.N))
+        assertThat(TracedPhasesBitManipulation.get(0x0100.toUShort(), SPK.C), equalTo(SPK.A))
+        assertThat(TracedPhasesBitManipulation.get(0x0200.toUShort(), SPK.C), equalTo(SPK.B))
+        assertThat(TracedPhasesBitManipulation.get(0x0400.toUShort(), SPK.C), equalTo(SPK.C))
+        assertThat(TracedPhasesBitManipulation.get(0x0800.toUShort(), SPK.C), equalTo(SPK.N))
 
-        assertThat(TracedPhasesBitManipulation.get(0x1000.toUInt(), SPK.N), equalTo(SPK.A))
-        assertThat(TracedPhasesBitManipulation.get(0x2000.toUInt(), SPK.N), equalTo(SPK.B))
-        assertThat(TracedPhasesBitManipulation.get(0x4000.toUInt(), SPK.N), equalTo(SPK.C))
-        assertThat(TracedPhasesBitManipulation.get(0x8000.toUInt(), SPK.N), equalTo(SPK.N))
+        assertThat(TracedPhasesBitManipulation.get(0x1000.toUShort(), SPK.N), equalTo(SPK.A))
+        assertThat(TracedPhasesBitManipulation.get(0x2000.toUShort(), SPK.N), equalTo(SPK.B))
+        assertThat(TracedPhasesBitManipulation.get(0x4000.toUShort(), SPK.N), equalTo(SPK.C))
+        assertThat(TracedPhasesBitManipulation.get(0x8000.toUShort(), SPK.N), equalTo(SPK.N))
     }
 
     @Test
     internal fun set() {
-        assertThat(TracedPhasesBitManipulation.set(0x0000.toUInt(), SPK.A, SPK.A), equalTo(0x0001.toUInt()))
-        assertThat(TracedPhasesBitManipulation.set(0x0000.toUInt(), SPK.A, SPK.B), equalTo(0x0002.toUInt()))
-        assertThat(TracedPhasesBitManipulation.set(0x0000.toUInt(), SPK.A, SPK.C), equalTo(0x0004.toUInt()))
-        assertThat(TracedPhasesBitManipulation.set(0x0000.toUInt(), SPK.A, SPK.N), equalTo(0x0008.toUInt()))
-        assertThat(TracedPhasesBitManipulation.set(0xffff.toUInt(), SPK.A, SPK.NONE), equalTo(0xfff0.toUInt()))
+        assertThat(TracedPhasesBitManipulation.set(0x0000.toUShort(), SPK.A, SPK.A), equalTo(0x0001.toUShort()))
+        assertThat(TracedPhasesBitManipulation.set(0x0000.toUShort(), SPK.A, SPK.B), equalTo(0x0002.toUShort()))
+        assertThat(TracedPhasesBitManipulation.set(0x0000.toUShort(), SPK.A, SPK.C), equalTo(0x0004.toUShort()))
+        assertThat(TracedPhasesBitManipulation.set(0x0000.toUShort(), SPK.A, SPK.N), equalTo(0x0008.toUShort()))
+        assertThat(TracedPhasesBitManipulation.set(0xffff.toUShort(), SPK.A, SPK.NONE), equalTo(0xfff0.toUShort()))
 
-        assertThat(TracedPhasesBitManipulation.set(0x0000.toUInt(), SPK.B, SPK.A), equalTo(0x0010.toUInt()))
-        assertThat(TracedPhasesBitManipulation.set(0x0000.toUInt(), SPK.B, SPK.B), equalTo(0x0020.toUInt()))
-        assertThat(TracedPhasesBitManipulation.set(0x0000.toUInt(), SPK.B, SPK.C), equalTo(0x0040.toUInt()))
-        assertThat(TracedPhasesBitManipulation.set(0x0000.toUInt(), SPK.B, SPK.N), equalTo(0x0080.toUInt()))
-        assertThat(TracedPhasesBitManipulation.set(0xffff.toUInt(), SPK.B, SPK.NONE), equalTo(0xff0f.toUInt()))
+        assertThat(TracedPhasesBitManipulation.set(0x0000.toUShort(), SPK.B, SPK.A), equalTo(0x0010.toUShort()))
+        assertThat(TracedPhasesBitManipulation.set(0x0000.toUShort(), SPK.B, SPK.B), equalTo(0x0020.toUShort()))
+        assertThat(TracedPhasesBitManipulation.set(0x0000.toUShort(), SPK.B, SPK.C), equalTo(0x0040.toUShort()))
+        assertThat(TracedPhasesBitManipulation.set(0x0000.toUShort(), SPK.B, SPK.N), equalTo(0x0080.toUShort()))
+        assertThat(TracedPhasesBitManipulation.set(0xffff.toUShort(), SPK.B, SPK.NONE), equalTo(0xff0f.toUShort()))
 
-        assertThat(TracedPhasesBitManipulation.set(0x0000.toUInt(), SPK.C, SPK.A), equalTo(0x0100.toUInt()))
-        assertThat(TracedPhasesBitManipulation.set(0x0000.toUInt(), SPK.C, SPK.B), equalTo(0x0200.toUInt()))
-        assertThat(TracedPhasesBitManipulation.set(0x0000.toUInt(), SPK.C, SPK.C), equalTo(0x0400.toUInt()))
-        assertThat(TracedPhasesBitManipulation.set(0x0000.toUInt(), SPK.C, SPK.N), equalTo(0x0800.toUInt()))
-        assertThat(TracedPhasesBitManipulation.set(0xffff.toUInt(), SPK.C, SPK.NONE), equalTo(0xf0ff.toUInt()))
+        assertThat(TracedPhasesBitManipulation.set(0x0000.toUShort(), SPK.C, SPK.A), equalTo(0x0100.toUShort()))
+        assertThat(TracedPhasesBitManipulation.set(0x0000.toUShort(), SPK.C, SPK.B), equalTo(0x0200.toUShort()))
+        assertThat(TracedPhasesBitManipulation.set(0x0000.toUShort(), SPK.C, SPK.C), equalTo(0x0400.toUShort()))
+        assertThat(TracedPhasesBitManipulation.set(0x0000.toUShort(), SPK.C, SPK.N), equalTo(0x0800.toUShort()))
+        assertThat(TracedPhasesBitManipulation.set(0xffff.toUShort(), SPK.C, SPK.NONE), equalTo(0xf0ff.toUShort()))
 
-        assertThat(TracedPhasesBitManipulation.set(0x0000.toUInt(), SPK.N, SPK.A), equalTo(0x1000.toUInt()))
-        assertThat(TracedPhasesBitManipulation.set(0x0000.toUInt(), SPK.N, SPK.B), equalTo(0x2000.toUInt()))
-        assertThat(TracedPhasesBitManipulation.set(0x0000.toUInt(), SPK.N, SPK.C), equalTo(0x4000.toUInt()))
-        assertThat(TracedPhasesBitManipulation.set(0x0000.toUInt(), SPK.N, SPK.N), equalTo(0x8000.toUInt()))
-        assertThat(TracedPhasesBitManipulation.set(0xffff.toUInt(), SPK.N, SPK.NONE), equalTo(0x0fff.toUInt()))
+        assertThat(TracedPhasesBitManipulation.set(0x0000.toUShort(), SPK.N, SPK.A), equalTo(0x1000.toUShort()))
+        assertThat(TracedPhasesBitManipulation.set(0x0000.toUShort(), SPK.N, SPK.B), equalTo(0x2000.toUShort()))
+        assertThat(TracedPhasesBitManipulation.set(0x0000.toUShort(), SPK.N, SPK.C), equalTo(0x4000.toUShort()))
+        assertThat(TracedPhasesBitManipulation.set(0x0000.toUShort(), SPK.N, SPK.N), equalTo(0x8000.toUShort()))
+        assertThat(TracedPhasesBitManipulation.set(0xffff.toUShort(), SPK.N, SPK.NONE), equalTo(0x0fff.toUShort()))
     }
 
 }

--- a/src/test/kotlin/com/zepben/evolve/services/network/tracing/phases/TracedPhasesTest.kt
+++ b/src/test/kotlin/com/zepben/evolve/services/network/tracing/phases/TracedPhasesTest.kt
@@ -8,15 +8,12 @@
 
 package com.zepben.evolve.services.network.tracing.phases
 
-import com.zepben.evolve.cim.iec61970.base.core.PhaseCode
 import com.zepben.evolve.cim.iec61970.base.core.Terminal
-import com.zepben.testutils.exception.ExpectException.Companion.expect
 import com.zepben.testutils.junit.SystemLogExtension
 import org.hamcrest.MatcherAssert.assertThat
-import org.hamcrest.Matchers.equalTo
+import org.hamcrest.Matchers.sameInstance
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.RegisterExtension
-import com.zepben.evolve.cim.iec61970.base.wires.SinglePhaseKind as SPK
 
 internal class TracedPhasesTest {
 
@@ -24,72 +21,11 @@ internal class TracedPhasesTest {
     @RegisterExtension
     var systemErr: SystemLogExtension = SystemLogExtension.SYSTEM_ERR.captureLog().muteOnSuccess()
 
-    private val tracedPhases = TracedPhases(terminal = Terminal().apply { phases = PhaseCode.ABCN })
-
     @Test
-    internal fun testSetAndGet() {
-        /* -- Setting -- */
-        assertThat("Should return true when setting normal traced phase of A to N", tracedPhases.setNormal(SPK.A, SPK.N))
-        assertThat("Should return true when setting normal traced phase of B to C", tracedPhases.setNormal(SPK.B, SPK.C))
-        assertThat("Should return true when setting normal traced phase of C to B", tracedPhases.setNormal(SPK.C, SPK.B))
-        assertThat("Should return true when setting normal traced phase of N to A", tracedPhases.setNormal(SPK.N, SPK.A))
-
-        assertThat("Should return true when setting current traced phase of A to A", tracedPhases.setCurrent(SPK.A, SPK.A))
-        assertThat("Should return true when setting current traced phase of B to B", tracedPhases.setCurrent(SPK.B, SPK.B))
-        assertThat("Should return true when setting current traced phase of C to C", tracedPhases.setCurrent(SPK.C, SPK.C))
-        assertThat("Should return true when setting current traced phase of N to N", tracedPhases.setCurrent(SPK.N, SPK.N))
-
-        /* -- Getting Phase-- */
-        assertThat(tracedPhases.normal[SPK.A], equalTo(SPK.N))
-        assertThat(tracedPhases.normal[SPK.B], equalTo(SPK.C))
-        assertThat(tracedPhases.normal[SPK.C], equalTo(SPK.B))
-        assertThat(tracedPhases.normal[SPK.N], equalTo(SPK.A))
-
-        assertThat(tracedPhases.current[SPK.A], equalTo(SPK.A))
-        assertThat(tracedPhases.current[SPK.B], equalTo(SPK.B))
-        assertThat(tracedPhases.current[SPK.C], equalTo(SPK.C))
-        assertThat(tracedPhases.current[SPK.N], equalTo(SPK.N))
-
-        /* -- Setting Unchanged -- */
-        assertThat("Should return false when attempting to set already-set normal traced phase of A", !tracedPhases.setNormal(SPK.A, SPK.N))
-        assertThat("Should return false when attempting to set already-set normal traced phase of B", !tracedPhases.setNormal(SPK.B, SPK.C))
-        assertThat("Should return false when attempting to set already-set normal traced phase of C", !tracedPhases.setNormal(SPK.C, SPK.B))
-        assertThat("Should return false when attempting to set already-set normal traced phase of N", !tracedPhases.setNormal(SPK.N, SPK.A))
-
-        assertThat("Should return false when attempting to set already-set current traced phase of A", !tracedPhases.setCurrent(SPK.A, SPK.A))
-        assertThat("Should return false when attempting to set already-set current traced phase of B", !tracedPhases.setCurrent(SPK.B, SPK.B))
-        assertThat("Should return false when attempting to set already-set current traced phase of C", !tracedPhases.setCurrent(SPK.C, SPK.C))
-        assertThat("Should return false when attempting to set already-set current traced phase of N", !tracedPhases.setCurrent(SPK.N, SPK.N))
-    }
-
-    @Test
-    internal fun testInvalidNominalPhaseNormal() {
-        expect { tracedPhases.normal[SPK.INVALID] }
-            .toThrow<IllegalArgumentException>()
-            .withMessage("INTERNAL ERROR: Phase INVALID is invalid.")
-    }
-
-    @Test
-    internal fun testCrossingPhasesExceptionNormal() {
-        expect {
-            tracedPhases.setNormal(SPK.A, SPK.A)
-            tracedPhases.setNormal(SPK.A, SPK.B)
-        }.toThrow<UnsupportedOperationException>()
-            .withMessage("Crossing Phases.")
-    }
-
-    @Test
-    internal fun testInvalidNominalPhaseCurrent() {
-        expect { tracedPhases.current[SPK.INVALID] }
-            .toThrow<IllegalArgumentException>()
-    }
-
-    @Test
-    internal fun testCrossingPhasesExceptionCurrent() {
-        expect {
-            tracedPhases.setCurrent(SPK.A, SPK.A)
-            tracedPhases.setCurrent(SPK.A, SPK.B)
-        }.toThrow<UnsupportedOperationException>()
+    internal fun tracedPhases() {
+        val terminal = Terminal()
+        assertThat(terminal.tracedPhases.normal, sameInstance(terminal.normalPhases))
+        assertThat(terminal.tracedPhases.current, sameInstance(terminal.currentPhases))
     }
 
 }


### PR DESCRIPTION
# Description

When looking at setting/removing phases as part of a trace rework, we noticed 3 objects were being created for traced phases per terminal (`TracedPhases`, `normal: PhaseStatus`, `current: PhaseStatus`) and the `TracedPhases` was backed by a `UInt`. However, if we got rid of `TracedPhases` and just had `Terminal.normalPhases: PhaseStatus` and `Terminal.currentPhases: PhaseStatus` and backed `PhaseStatus` by a `UShort` we would only have 2 objects created to track phases, the same amount of memory to store the status (2 `UShort` vs 1 `UInt`) and less references being stored. 

If my calculations are right, this is about a 24-byte saving with compressed object pointers or a 48-byte saving without compressed object pointers (which we will have on very large networks with lots of terminals ➝ JVM heaps > 32GB). This calculation was also made noting that the bit masks and bit shift values were not static on TracedPhases and were duplicated on every instance (though this could have been easily negated by using a companion object, taking the saving of the proposed implementation to only a 12/36-byte saving).

Even though this isn't a huge memory saving, chipping away at this kind of stuff can add up to long term benefits. Endeavour's whole network (including LV) has over 4M terminals, which is about a 200MB saving. It's also 4M extra objects that aren't created and managed in old generation storage by the GC in the EWB server, which is a win. 

One can argue this also simplifies our API as we no longer have `Terminal.tracedPhases` and `Terminal.normalPhases` and `Terminal.currentPhases` and a `TracedPhases` and a `PhaseStatus`. We end up with just `PhaseStatus` and `Terminal.normalPhases` and `Terminal.currentPhases`.

The biggest impact of removing `TracedPhases` is that we no longer have a specific object that encapsulates just the normal and current phases statues. The encapsulating object becomes the terminal. However, I have searched our codebase, and I cannot see anywhere a `TracedPhases` instance is being passed around. That is, it is always being accessed directly off a Terminal anyway, so it seems that this use case is unlikely a common occurrence. 

In an effort to make transitioning easier, this implementation deprecates `TracedPhases` but still gains the memory benefits (TracedPhases now delegates to the phase statuses on the erminal). This will be removed in a future release (before v1). There is a caveat breaking change with this though, see breaking changes section below.

# Associated tasks

None.

# Test Steps

Run the unit tests. Some of the unit tests had to be changed because they combined normal/current in a single test (which was no longer relevant as there was no single object tracking both). And some of the tests were shuffled around as logic was moved between `TracedPhases` and `PhaseStatus`.

# Checklist

If any of these are not applicable, strikethrough the line `~like this~`. **Do not delete it!**. Let the reviewer decide if you should have done it.

### Code
- [x] I have performed a self review of my own code (including checking issues raised when creating the PR).
- [x] I have added/updated unit tests for these changes, and if not I have explained why they are not necessary.
- [x] I have commented my code in any hard-to-understand or hacky areas.
- [x] I have handled all new warnings generated by the compiler or IDE.
- [x] I have rebased onto the target branch (usually main).

### Documentation
- [x] I have updated the changelog.
- [x] I have updated any documentation required for these changes.

# Breaking Changes
- [x] I have considered if this is a breaking change and will communicate it with other team members if so.

This can theoretically be done without a breaking change to the SDK by deprecating `TracedPhases` and making `Termimal.tracedPhases` create a `TracedPhases` instance on demand. Existing users of `TracedPhases` could still use it, but the IDE should give them a warning saying it is deprecated and they should migrate to using `Terminal.normalPhases` and `Terminal.currentPhases` instead to make sure they aren't creating tons of short lived `TracedPhases` objects going forward. 
However, I have removed the `internalPhasesStatus` constructor parameter from `TracedPhases` as it is no longer used by it. Nobody really should have been using this though as it was internal, and it was always constructed by the `Terminal`. Someone may be though, and this is a breaking change. I could have kept the constructor parameter there and twiddled the values into the underlying terminal normal and current PhaseStatus, but if anyone is using an internal value outside the SDK they can just suck it up.

The gprc/protobuf messages do not need to change as we can encode the normal and current `PhaseStatus` internal values into the existing protobuf field by bit twiddling the 2 shorts into / out of the protobuf int in the same format it is now.
