### PR TITLE
[DEV-1775] Add `Services` collection and tightly coupled metadata to a service

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,11 +1,12 @@
 # Zepben EWB SDK changelog
 ## [0.24.0] - UNRELEASED
 ### Breaking Changes
-* None.
+* Database readers and writes for each `BaseService` no longer accept a `MetadataCollection`, and will instead use the collection of the provided service.
 
 ### New Features
 * Network state services for updating and querying network state events via gRPC.
 * Client functionality for updating and querying network states via gRPC service stub. 
+* `BaseService` now contains a `MetadataCollection` to tightly couple the metadata to the associated service.
 
 ### Enhancements
 * None.
@@ -35,8 +36,8 @@
 * Removed `PowerTransformer.forEachRating` which looped over the collection with an index that made no sense. Please loop over `PowerTransformer.sRatings`
   instead.
 * `Equipment` to `EquipmentContainer` links for LV feeders are no longer written to the database, they should never have been.
-*  Refactored `EwbDataFilePaths`: 
-  * The `EwbDataFilePaths` class has been refactored into an interface to enhance flexibility and abstraction. 
+* Refactored `EwbDataFilePaths`:
+  * The `EwbDataFilePaths` class has been refactored into an interface to enhance flexibility and abstraction.
   * A new class, `LocalEwbDataFilePaths`, has been introduced to specifically handle the resolution of database paths for the local file system.
 * `Switch.ratedCurrent` has been converted to a `double` (used to be an `integer`). Type safe languages will need to be updated to support floating point
   arithmatic/syntax.

--- a/changelog.md
+++ b/changelog.md
@@ -7,6 +7,7 @@
 * Network state services for updating and querying network state events via gRPC.
 * Client functionality for updating and querying network states via gRPC service stub. 
 * `BaseService` now contains a `MetadataCollection` to tightly couple the metadata to the associated service.
+* Added `Services`, a new class which contains a copy of each `BaseService` supported by the SDK.
 
 ### Enhancements
 * None.

--- a/src/main/kotlin/com/zepben/evolve/database/sqlite/cim/BaseServiceReader.kt
+++ b/src/main/kotlin/com/zepben/evolve/database/sqlite/cim/BaseServiceReader.kt
@@ -29,7 +29,6 @@ abstract class BaseServiceReader(
 ) : BaseCollectionReader(databaseTables, connection) {
 
     final override fun load(): Boolean =
-        //todo try reorder to name types after doLoad
         doLoad()
             .andLoadEach<TableNameTypes>(reader::load)
             .andLoadEach<TableNames>(reader::load)

--- a/src/main/kotlin/com/zepben/evolve/database/sqlite/cim/customer/CustomerDatabaseReader.kt
+++ b/src/main/kotlin/com/zepben/evolve/database/sqlite/cim/customer/CustomerDatabaseReader.kt
@@ -20,17 +20,15 @@ import java.sql.Connection
  * A class for reading the [CustomerService] objects and [MetadataCollection] from our customer database.
  *
  * @param connection The connection to the database.
- * @param metadata The [MetadataCollection] to populate with metadata from the database.
  * @param service The [CustomerService] to populate with CIM objects from the database.
  * @param databaseDescription The description of the database for logging (e.g. filename).
  */
 class CustomerDatabaseReader @JvmOverloads constructor(
     connection: Connection,
-    metadata: MetadataCollection,
     override val service: CustomerService,
     databaseDescription: String,
     tables: CustomerDatabaseTables = CustomerDatabaseTables(),
-    metadataReader: MetadataCollectionReader = MetadataCollectionReader(metadata, tables, connection),
+    metadataReader: MetadataCollectionReader = MetadataCollectionReader(service, tables, connection),
     serviceReader: CustomerServiceReader = CustomerServiceReader(service, tables, connection),
     tableVersion: TableVersion = tableCimVersion
 ) : CimDatabaseReader(connection, metadataReader, serviceReader, service, databaseDescription, tableVersion)

--- a/src/main/kotlin/com/zepben/evolve/database/sqlite/cim/customer/CustomerDatabaseWriter.kt
+++ b/src/main/kotlin/com/zepben/evolve/database/sqlite/cim/customer/CustomerDatabaseWriter.kt
@@ -19,15 +19,13 @@ import java.sql.DriverManager
  * A class for writing the [CustomerService] objects and [MetadataCollection] to our customer database.
  *
  * @param databaseFile the filename of the database to write.
- * @param metadata The [MetadataCollection] to save to the database.
  * @param service The [CustomerService] to save to the database.
  */
 class CustomerDatabaseWriter @JvmOverloads constructor(
     databaseFile: String,
-    metadata: MetadataCollection,
     service: CustomerService,
     databaseTables: CustomerDatabaseTables = CustomerDatabaseTables(),
-    metadataWriter: MetadataCollectionWriter = MetadataCollectionWriter(metadata, databaseTables),
+    metadataWriter: MetadataCollectionWriter = MetadataCollectionWriter(service, databaseTables),
     serviceWriter: CustomerServiceWriter = CustomerServiceWriter(service, databaseTables),
     getConnection: (String) -> Connection = DriverManager::getConnection
 ) : CimDatabaseWriter(

--- a/src/main/kotlin/com/zepben/evolve/database/sqlite/cim/diagram/DiagramDatabaseReader.kt
+++ b/src/main/kotlin/com/zepben/evolve/database/sqlite/cim/diagram/DiagramDatabaseReader.kt
@@ -20,17 +20,15 @@ import java.sql.Connection
  * A class for reading the [DiagramService] objects and [MetadataCollection] from our diagram database.
  *
  * @param connection The connection to the database.
- * @param metadata The [MetadataCollection] to populate with metadata from the database.
  * @param service The [DiagramService] to populate with CIM objects from the database.
  * @param databaseDescription The description of the database for logging (e.g. filename).
  */
 class DiagramDatabaseReader @JvmOverloads constructor(
     connection: Connection,
-    metadata: MetadataCollection,
     override val service: DiagramService,
     databaseDescription: String,
     tables: DiagramDatabaseTables = DiagramDatabaseTables(),
-    metadataReader: MetadataCollectionReader = MetadataCollectionReader(metadata, tables, connection),
+    metadataReader: MetadataCollectionReader = MetadataCollectionReader(service, tables, connection),
     serviceReader: DiagramServiceReader = DiagramServiceReader(service, tables, connection),
     tableVersion: TableVersion = tableCimVersion
 ) : CimDatabaseReader(connection, metadataReader, serviceReader, service, databaseDescription, tableVersion)

--- a/src/main/kotlin/com/zepben/evolve/database/sqlite/cim/diagram/DiagramDatabaseWriter.kt
+++ b/src/main/kotlin/com/zepben/evolve/database/sqlite/cim/diagram/DiagramDatabaseWriter.kt
@@ -19,15 +19,13 @@ import java.sql.DriverManager
  * A class for writing the [DiagramService] objects and [MetadataCollection] to our diagram database.
  *
  * @param databaseFile the filename of the database to write.
- * @param metadata The [MetadataCollection] to save to the database.
  * @param service The [DiagramService] to save to the database.
  */
 class DiagramDatabaseWriter @JvmOverloads constructor(
     databaseFile: String,
-    metadata: MetadataCollection,
     service: DiagramService,
     databaseTables: DiagramDatabaseTables = DiagramDatabaseTables(),
-    metadataWriter: MetadataCollectionWriter = MetadataCollectionWriter(metadata, databaseTables),
+    metadataWriter: MetadataCollectionWriter = MetadataCollectionWriter(service, databaseTables),
     serviceWriter: DiagramServiceWriter = DiagramServiceWriter(service, databaseTables),
     getConnection: (String) -> Connection = DriverManager::getConnection
 ) : CimDatabaseWriter(

--- a/src/main/kotlin/com/zepben/evolve/database/sqlite/cim/metadata/MetadataCollectionReader.kt
+++ b/src/main/kotlin/com/zepben/evolve/database/sqlite/cim/metadata/MetadataCollectionReader.kt
@@ -8,24 +8,25 @@
 
 package com.zepben.evolve.database.sqlite.cim.metadata
 
+import com.zepben.evolve.database.sqlite.cim.tables.TableMetadataDataSources
 import com.zepben.evolve.database.sqlite.common.BaseCollectionReader
 import com.zepben.evolve.database.sqlite.common.BaseDatabaseTables
-import com.zepben.evolve.database.sqlite.cim.tables.TableMetadataDataSources
+import com.zepben.evolve.services.common.BaseService
 import com.zepben.evolve.services.common.meta.MetadataCollection
 import java.sql.Connection
 
 /**
  * Class for reading the [MetadataCollection] from the database.
  *
- * @param metadata The [MetadataCollection] to populate from the database.
+ * @param service The [BaseService] containing the [MetadataCollection] to populate from the database.
  * @param databaseTables The tables available in the database.
  * @param connection The [Connection] to the database.
  */
 class MetadataCollectionReader @JvmOverloads constructor(
-    metadata: MetadataCollection,
+    service: BaseService,
     databaseTables: BaseDatabaseTables,
     connection: Connection,
-    private val reader: MetadataEntryReader = MetadataEntryReader(metadata),
+    private val reader: MetadataEntryReader = MetadataEntryReader(service),
 ) : BaseCollectionReader(databaseTables, connection) {
 
     override fun load(): Boolean =

--- a/src/main/kotlin/com/zepben/evolve/database/sqlite/cim/metadata/MetadataCollectionWriter.kt
+++ b/src/main/kotlin/com/zepben/evolve/database/sqlite/cim/metadata/MetadataCollectionWriter.kt
@@ -8,23 +8,25 @@
 
 package com.zepben.evolve.database.sqlite.cim.metadata
 
-import com.zepben.evolve.database.sqlite.common.BaseCollectionWriter
 import com.zepben.evolve.database.sqlite.cim.CimDatabaseTables
+import com.zepben.evolve.database.sqlite.common.BaseCollectionWriter
+import com.zepben.evolve.services.common.BaseService
 import com.zepben.evolve.services.common.meta.MetadataCollection
 
 /**
  * Class for writing the [MetadataCollection] to the database.
  *
- * @param metadata The [MetadataCollection] to save to the database.
+ * @param service The [BaseService] containing the [MetadataCollection] to save to the database.
  * @param databaseTables The tables available in the database.
  */
 class MetadataCollectionWriter @JvmOverloads constructor(
-    private val metadata: MetadataCollection,
+    private val service: BaseService,
     databaseTables: CimDatabaseTables,
     private val writer: MetadataEntryWriter = MetadataEntryWriter(databaseTables)
 ) : BaseCollectionWriter() {
 
-    override fun save(): Boolean =
-        saveEach(metadata.dataSources, writer::save) { it, e -> logger.error("Failed to save DataSource '${it.source}': ${e.message}") }
+    override fun save(): Boolean = service.metadata.run {
+        saveEach(dataSources, writer::save) { it, e -> logger.error("Failed to save DataSource '${it.source}': ${e.message}") }
+    }
 
 }

--- a/src/main/kotlin/com/zepben/evolve/database/sqlite/cim/metadata/MetadataEntryReader.kt
+++ b/src/main/kotlin/com/zepben/evolve/database/sqlite/cim/metadata/MetadataEntryReader.kt
@@ -8,8 +8,9 @@
 
 package com.zepben.evolve.database.sqlite.cim.metadata
 
-import com.zepben.evolve.database.sqlite.extensions.getInstant
 import com.zepben.evolve.database.sqlite.cim.tables.TableMetadataDataSources
+import com.zepben.evolve.database.sqlite.extensions.getInstant
+import com.zepben.evolve.services.common.BaseService
 import com.zepben.evolve.services.common.meta.DataSource
 import com.zepben.evolve.services.common.meta.MetadataCollection
 import java.sql.ResultSet
@@ -18,10 +19,10 @@ import java.time.Instant
 /**
  * A class for reading the [MetadataCollection] entries from the database.
  *
- * @param metadata The [MetadataCollection] to populate from the database.
+ * @param service The [BaseService] containing the [MetadataCollection] to populate from the database.
  */
 class MetadataEntryReader(
-    private val metadata: MetadataCollection
+    private val service: BaseService
 ) {
 
     /**
@@ -41,7 +42,7 @@ class MetadataEntryReader(
             resultSet.getInstant(table.TIMESTAMP.queryIndex) ?: Instant.EPOCH
         )
 
-        return metadata.add(dataSource)
+        return service.metadata.add(dataSource)
     }
 
 }

--- a/src/main/kotlin/com/zepben/evolve/database/sqlite/cim/network/NetworkDatabaseReader.kt
+++ b/src/main/kotlin/com/zepben/evolve/database/sqlite/cim/network/NetworkDatabaseReader.kt
@@ -36,17 +36,15 @@ import java.util.*
  *   remove the split database logic - Check [UpgradeRunner] to see if this is still required.
  *
  * @param connection The connection to the database.
- * @param metadata The [MetadataCollection] to populate with metadata from the database.
  * @param service The [NetworkService] to populate with CIM objects from the database.
  * @param databaseDescription The description of the database for logging (e.g. filename).
  */
 class NetworkDatabaseReader @JvmOverloads constructor(
     connection: Connection,
-    metadata: MetadataCollection,
     override val service: NetworkService,
     databaseDescription: String,
     tables: NetworkDatabaseTables = NetworkDatabaseTables(),
-    metadataReader: MetadataCollectionReader = MetadataCollectionReader(metadata, tables, connection),
+    metadataReader: MetadataCollectionReader = MetadataCollectionReader(service, tables, connection),
     serviceReader: NetworkServiceReader = NetworkServiceReader(service, tables, connection),
     tableVersion: TableVersion = tableCimVersion,
     private val setDirection: SetDirection = SetDirection(),

--- a/src/main/kotlin/com/zepben/evolve/database/sqlite/cim/network/NetworkDatabaseWriter.kt
+++ b/src/main/kotlin/com/zepben/evolve/database/sqlite/cim/network/NetworkDatabaseWriter.kt
@@ -19,15 +19,13 @@ import java.sql.DriverManager
  * A class for writing the [NetworkService] objects and [MetadataCollection] to our network database.
  *
  * @param databaseFile the filename of the database to write.
- * @param metadata The [MetadataCollection] to save to the database.
  * @param service The [NetworkService] to save to the database.
  */
 class NetworkDatabaseWriter @JvmOverloads constructor(
     databaseFile: String,
-    metadata: MetadataCollection,
     service: NetworkService,
     databaseTables: NetworkDatabaseTables = NetworkDatabaseTables(),
-    metadataWriter: MetadataCollectionWriter = MetadataCollectionWriter(metadata, databaseTables),
+    metadataWriter: MetadataCollectionWriter = MetadataCollectionWriter(service, databaseTables),
     serviceWriter: NetworkServiceWriter = NetworkServiceWriter(service, databaseTables),
     getConnection: (String) -> Connection = DriverManager::getConnection
 ) : CimDatabaseWriter(

--- a/src/main/kotlin/com/zepben/evolve/services/Services.kt
+++ b/src/main/kotlin/com/zepben/evolve/services/Services.kt
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2024 Zeppelin Bend Pty Ltd
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+package com.zepben.evolve.services
+
+import com.zepben.evolve.services.customer.CustomerService
+import com.zepben.evolve.services.diagram.DiagramService
+import com.zepben.evolve.services.network.NetworkService
+
+/**
+ * A convenience class for storing the data supported by the SDK.
+ *
+ * @property networkService A [NetworkService].
+ * @property diagramService A [DiagramService].
+ * @property customerService A [CustomerService].
+ */
+open class Services(
+    val networkService: NetworkService = NetworkService(),
+    val diagramService: DiagramService = DiagramService(),
+    val customerService: CustomerService = CustomerService()
+) {
+
+    /**
+     * Accessor of the [networkService] to allow for destructuring.
+     */
+    operator fun component1(): NetworkService = networkService
+
+    /**
+     * Accessor of the [diagramService] to allow for destructuring.
+     */
+    operator fun component2(): DiagramService = diagramService
+
+    /**
+     * Accessor of the [customerService] to allow for destructuring.
+     */
+    operator fun component3(): CustomerService = customerService
+
+}

--- a/src/main/kotlin/com/zepben/evolve/services/customer/CustomerService.kt
+++ b/src/main/kotlin/com/zepben/evolve/services/customer/CustomerService.kt
@@ -14,11 +14,12 @@ import com.zepben.evolve.cim.iec61968.customers.CustomerAgreement
 import com.zepben.evolve.cim.iec61968.customers.PricingStructure
 import com.zepben.evolve.cim.iec61968.customers.Tariff
 import com.zepben.evolve.services.common.BaseService
+import com.zepben.evolve.services.common.meta.MetadataCollection
 
 /**
  * Maintains an in-memory model of customers and their organisations.
  */
-class CustomerService : BaseService("customer") {
+class CustomerService(metadata: MetadataCollection = MetadataCollection()) : BaseService("customer", metadata) {
 
     // ###################
     // # IEC61968 COMMON #

--- a/src/main/kotlin/com/zepben/evolve/services/diagram/DiagramService.kt
+++ b/src/main/kotlin/com/zepben/evolve/services/diagram/DiagramService.kt
@@ -12,11 +12,12 @@ import com.zepben.evolve.cim.iec61970.base.core.IdentifiedObject
 import com.zepben.evolve.cim.iec61970.base.diagramlayout.Diagram
 import com.zepben.evolve.cim.iec61970.base.diagramlayout.DiagramObject
 import com.zepben.evolve.services.common.BaseService
+import com.zepben.evolve.services.common.meta.MetadataCollection
 
 /**
  * Maintains an in-memory model of diagrams.
  */
-class DiagramService : BaseService("diagram") {
+class DiagramService(metadata: MetadataCollection = MetadataCollection()) : BaseService("diagram", metadata) {
 
     private val diagramObjectsByDiagramMRID: MutableMap<String, MutableMap<String, DiagramObject>> = mutableMapOf()
     private val diagramObjectsByIdentifiedObjectMRID: MutableMap<String, MutableMap<String, DiagramObject>> = mutableMapOf()

--- a/src/main/kotlin/com/zepben/evolve/services/network/NetworkService.kt
+++ b/src/main/kotlin/com/zepben/evolve/services/network/NetworkService.kt
@@ -38,6 +38,7 @@ import com.zepben.evolve.cim.iec61970.infiec61970.feeder.Loop
 import com.zepben.evolve.cim.iec61970.infiec61970.feeder.LvFeeder
 import com.zepben.evolve.cim.iec61970.infiec61970.wires.generation.production.EvChargingUnit
 import com.zepben.evolve.services.common.BaseService
+import com.zepben.evolve.services.common.meta.MetadataCollection
 import com.zepben.evolve.services.network.tracing.connectivity.ConnectivityResult
 import com.zepben.evolve.services.network.tracing.connectivity.TerminalConnectivityConnected
 import kotlin.reflect.KClass
@@ -45,7 +46,8 @@ import kotlin.reflect.KClass
 /**
  * Maintains an in-memory model of the network.
  */
-class NetworkService : BaseService("network") {
+class NetworkService(metadata: MetadataCollection = MetadataCollection()) : BaseService("network", metadata) {
+
     private enum class ProcessStatus {
         PROCESSED, SKIPPED, INVALID
     }

--- a/src/test/kotlin/com/zepben/evolve/database/sqlite/cim/customer/CustomerDatabaseReaderTest.kt
+++ b/src/test/kotlin/com/zepben/evolve/database/sqlite/cim/customer/CustomerDatabaseReaderTest.kt
@@ -44,7 +44,6 @@ internal class CustomerDatabaseReaderTest {
 
     private val reader = CustomerDatabaseReader(
         connection,
-        mockk(), // The metadata is unused if we provide a metadataReader.
         service,
         databaseFile,
         mockk(), // tables should not be used if we provide the rest of the parameters, so provide a mockk that will throw if used.

--- a/src/test/kotlin/com/zepben/evolve/database/sqlite/cim/customer/CustomerDatabaseSchemaTest.kt
+++ b/src/test/kotlin/com/zepben/evolve/database/sqlite/cim/customer/CustomerDatabaseSchemaTest.kt
@@ -16,7 +16,6 @@ import com.zepben.evolve.cim.iec61968.customers.Tariff
 import com.zepben.evolve.cim.iec61970.base.core.IdentifiedObject
 import com.zepben.evolve.database.sqlite.cim.CimDatabaseSchemaTest
 import com.zepben.evolve.services.common.Resolvers
-import com.zepben.evolve.services.common.meta.MetadataCollection
 import com.zepben.evolve.services.common.testdata.SchemaServices
 import com.zepben.evolve.services.common.testdata.fillFieldsCommon
 import com.zepben.evolve.services.customer.CustomerService
@@ -35,16 +34,11 @@ class CustomerDatabaseSchemaTest : CimDatabaseSchemaTest<CustomerService, Custom
 
     override fun createService(): CustomerService = CustomerService()
 
-    override fun createWriter(filename: String, metadata: MetadataCollection, service: CustomerService): CustomerDatabaseWriter =
-        CustomerDatabaseWriter(filename, metadata, service)
+    override fun createWriter(filename: String, service: CustomerService): CustomerDatabaseWriter =
+        CustomerDatabaseWriter(filename, service)
 
-    override fun createReader(
-        connection: Connection,
-        metadata: MetadataCollection,
-        service: CustomerService,
-        databaseDescription: String
-    ): CustomerDatabaseReader =
-        CustomerDatabaseReader(connection, metadata, service, databaseDescription)
+    override fun createReader(connection: Connection, service: CustomerService, databaseDescription: String): CustomerDatabaseReader =
+        CustomerDatabaseReader(connection, service, databaseDescription)
 
     override fun createComparator(): CustomerServiceComparator = CustomerServiceComparator()
 
@@ -60,11 +54,10 @@ class CustomerDatabaseSchemaTest : CimDatabaseSchemaTest<CustomerService, Custom
 
         assertThat("database must exist", Files.exists(Paths.get(databaseFile)))
 
-        val metadata = MetadataCollection()
         val customerService = CustomerService()
 
         DriverManager.getConnection("jdbc:sqlite:$databaseFile").use { connection ->
-            assertThat("Database should have loaded", CustomerDatabaseReader(connection, metadata, customerService, databaseFile).load())
+            assertThat("Database should have loaded", CustomerDatabaseReader(connection, customerService, databaseFile).load())
         }
 
         logger.info("Sleeping...")

--- a/src/test/kotlin/com/zepben/evolve/database/sqlite/cim/diagram/DiagramDatabaseReaderTest.kt
+++ b/src/test/kotlin/com/zepben/evolve/database/sqlite/cim/diagram/DiagramDatabaseReaderTest.kt
@@ -44,7 +44,6 @@ internal class DiagramDatabaseReaderTest {
 
     private val reader = DiagramDatabaseReader(
         connection,
-        mockk(), // The metadata is unused if we provide a metadataReader.
         service,
         databaseFile,
         mockk(), // tables should not be used if we provide the rest of the parameters, so provide a mockk that will throw if used.

--- a/src/test/kotlin/com/zepben/evolve/database/sqlite/cim/diagram/DiagramDatabaseSchemaTest.kt
+++ b/src/test/kotlin/com/zepben/evolve/database/sqlite/cim/diagram/DiagramDatabaseSchemaTest.kt
@@ -13,7 +13,6 @@ import com.zepben.evolve.cim.iec61970.base.diagramlayout.Diagram
 import com.zepben.evolve.cim.iec61970.base.diagramlayout.DiagramObject
 import com.zepben.evolve.database.sqlite.cim.CimDatabaseSchemaTest
 import com.zepben.evolve.services.common.Resolvers
-import com.zepben.evolve.services.common.meta.MetadataCollection
 import com.zepben.evolve.services.common.testdata.SchemaServices
 import com.zepben.evolve.services.diagram.DiagramService
 import com.zepben.evolve.services.diagram.DiagramServiceComparator
@@ -31,16 +30,11 @@ class DiagramDatabaseSchemaTest : CimDatabaseSchemaTest<DiagramService, DiagramD
 
     override fun createService(): DiagramService = DiagramService()
 
-    override fun createWriter(filename: String, metadata: MetadataCollection, service: DiagramService): DiagramDatabaseWriter =
-        DiagramDatabaseWriter(filename, metadata, service)
+    override fun createWriter(filename: String, service: DiagramService): DiagramDatabaseWriter =
+        DiagramDatabaseWriter(filename, service)
 
-    override fun createReader(
-        connection: Connection,
-        metadata: MetadataCollection,
-        service: DiagramService,
-        databaseDescription: String
-    ): DiagramDatabaseReader =
-        DiagramDatabaseReader(connection, metadata, service, databaseDescription)
+    override fun createReader(connection: Connection, service: DiagramService, databaseDescription: String): DiagramDatabaseReader =
+        DiagramDatabaseReader(connection, service, databaseDescription)
 
     override fun createComparator(): DiagramServiceComparator = DiagramServiceComparator()
 
@@ -56,11 +50,10 @@ class DiagramDatabaseSchemaTest : CimDatabaseSchemaTest<DiagramService, DiagramD
 
         assertThat("database must exist", Files.exists(Paths.get(databaseFile)))
 
-        val metadata = MetadataCollection()
         val diagramService = DiagramService()
 
         DriverManager.getConnection("jdbc:sqlite:$databaseFile").use { connection ->
-            assertThat("Database should have loaded", DiagramDatabaseReader(connection, metadata, diagramService, databaseFile).load())
+            assertThat("Database should have loaded", DiagramDatabaseReader(connection, diagramService, databaseFile).load())
         }
 
         logger.info("Sleeping...")

--- a/src/test/kotlin/com/zepben/evolve/database/sqlite/cim/network/NetworkDatabaseReaderTest.kt
+++ b/src/test/kotlin/com/zepben/evolve/database/sqlite/cim/network/NetworkDatabaseReaderTest.kt
@@ -59,8 +59,7 @@ internal class NetworkDatabaseReaderTest {
 
     private val reader = NetworkDatabaseReader(
         connection,
-        mockk(),
-        service, // Metadata is unused if we provide a metadataReader.
+        service,
         databaseFile,
         mockk(), // tables should not be used if we provide the rest of the parameters, so provide a mockk that will throw if used.
         metadataReader,

--- a/src/test/kotlin/com/zepben/evolve/services/ServicesTest.kt
+++ b/src/test/kotlin/com/zepben/evolve/services/ServicesTest.kt
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2024 Zeppelin Bend Pty Ltd
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+package com.zepben.evolve.services
+
+import com.zepben.evolve.services.customer.CustomerService
+import com.zepben.evolve.services.diagram.DiagramService
+import com.zepben.evolve.services.network.NetworkService
+import com.zepben.testutils.junit.SystemLogExtension
+import org.hamcrest.MatcherAssert.assertThat
+import org.hamcrest.Matchers.sameInstance
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.RegisterExtension
+
+class ServicesTest {
+
+    @JvmField
+    @RegisterExtension
+    var systemOut: SystemLogExtension = SystemLogExtension.SYSTEM_OUT.captureLog().muteOnSuccess()
+
+    private val expectedNs = NetworkService()
+    private val expectedDs = DiagramService()
+    private val expectedCs = CustomerService()
+
+    private val services = Services(expectedNs, expectedDs, expectedCs)
+
+    @Test
+    internal fun accessors() {
+        assertThat(services.networkService, sameInstance(expectedNs))
+        assertThat(services.diagramService, sameInstance(expectedDs))
+        assertThat(services.customerService, sameInstance(expectedCs))
+    }
+
+    @Test
+    internal fun `supports destructuring`() {
+        services.also { (ns, ds, cs) ->
+            assertThat(ns, sameInstance(expectedNs))
+            assertThat(ds, sameInstance(expectedDs))
+            assertThat(cs, sameInstance(expectedCs))
+        }
+    }
+
+}

--- a/src/test/kotlin/com/zepben/evolve/services/common/BaseServiceTest.kt
+++ b/src/test/kotlin/com/zepben/evolve/services/common/BaseServiceTest.kt
@@ -19,6 +19,7 @@ import com.zepben.evolve.cim.iec61970.base.wires.AcLineSegment
 import com.zepben.evolve.cim.iec61970.base.wires.Breaker
 import com.zepben.evolve.cim.iec61970.base.wires.Junction
 import com.zepben.evolve.services.common.exceptions.UnsupportedIdentifiedObjectException
+import com.zepben.evolve.services.common.meta.MetadataCollection
 import com.zepben.evolve.services.network.NetworkService
 import com.zepben.evolve.services.network.translator.addFromPb
 import com.zepben.evolve.services.network.translator.toPb
@@ -36,7 +37,7 @@ internal class BaseServiceTest {
     @RegisterExtension
     var systemErr: SystemLogExtension = SystemLogExtension.SYSTEM_ERR.captureLog().muteOnSuccess()
 
-    internal class TestBaseService : BaseService("test") {
+    internal class TestBaseService : BaseService("test", MetadataCollection()) {
         fun add(obj: Junction) = super.add(obj)
         fun remove(obj: Junction) = super.remove(obj)
         fun add(obj: Breaker) = super.add(obj)
@@ -308,7 +309,7 @@ internal class BaseServiceTest {
         override fun hashCode(): Int = 0
     }
 
-    private class MyService : BaseService("") {
+    private class MyService : BaseService("", MetadataCollection()) {
         fun add(cableInfo: MyIdentifiedObject): Boolean = super.add(cableInfo)
 
         // required, since BaseService checks that each add method has a matching remove method

--- a/src/test/kotlin/com/zepben/evolve/services/network/testdata/stupid/StupidlyLargeNetwork.kt
+++ b/src/test/kotlin/com/zepben/evolve/services/network/testdata/stupid/StupidlyLargeNetwork.kt
@@ -23,10 +23,9 @@ import com.zepben.evolve.cim.iec61970.base.core.PhaseCode
 import com.zepben.evolve.cim.iec61970.base.core.SubGeographicalRegion
 import com.zepben.evolve.cim.iec61970.base.core.Substation
 import com.zepben.evolve.cim.iec61970.base.wires.*
-import com.zepben.evolve.services.common.meta.MetadataCollection
+import com.zepben.evolve.services.Services
 import com.zepben.evolve.services.customer.CustomerService
 import com.zepben.evolve.services.diagram.DiagramService
-import com.zepben.evolve.services.measurement.MeasurementService
 import com.zepben.evolve.services.network.NetworkService
 import com.zepben.evolve.services.network.testdata.createAssetOwner
 import com.zepben.evolve.services.network.testdata.createTerminal
@@ -58,11 +57,10 @@ import org.hamcrest.Matchers.equalTo
 @Suppress("SameParameterValue", "BooleanLiteralArgument")
 object StupidlyLargeNetwork {
 
-    fun create(): StupidlyLargeNetworkUtils.Services {
+    fun create(): Services {
         val networkService = NetworkService()
         val diagramService = DiagramService()
         val customerService = CustomerService()
-        val measurementService = MeasurementService()
 
         addSampleNetwork(networkService, diagramService, customerService)
 
@@ -297,7 +295,7 @@ object StupidlyLargeNetwork {
         createAccumulator(networkService, transformer.getTerminal(1)?.mRID, isoTransformer1)
         createDiscrete(networkService, transformer.getTerminal(1)?.mRID, isoTransformer1)
 
-        return StupidlyLargeNetworkUtils.Services(MetadataCollection(), networkService, diagramService, customerService, measurementService)
+        return Services(networkService, diagramService, customerService)
     }
 
     private fun addSampleNetwork(networkService: NetworkService, diagramService: DiagramService, customerService: CustomerService) {

--- a/src/test/kotlin/com/zepben/evolve/services/network/testdata/stupid/StupidlyLargeNetworkUtils.kt
+++ b/src/test/kotlin/com/zepben/evolve/services/network/testdata/stupid/StupidlyLargeNetworkUtils.kt
@@ -28,10 +28,7 @@ import com.zepben.evolve.cim.iec61970.base.meas.Discrete
 import com.zepben.evolve.cim.iec61970.base.meas.Measurement
 import com.zepben.evolve.cim.iec61970.base.scada.RemoteSource
 import com.zepben.evolve.cim.iec61970.base.wires.*
-import com.zepben.evolve.services.common.meta.MetadataCollection
-import com.zepben.evolve.services.customer.CustomerService
 import com.zepben.evolve.services.diagram.DiagramService
-import com.zepben.evolve.services.measurement.MeasurementService
 import com.zepben.evolve.services.network.NetworkService
 import com.zepben.evolve.services.network.testdata.createTerminal
 import org.hamcrest.MatcherAssert.assertThat
@@ -39,15 +36,6 @@ import java.time.Instant
 
 @Suppress("SameParameterValue", "MemberVisibilityCanBePrivate")
 class StupidlyLargeNetworkUtils {
-
-    // Only used by the stupidly large network, so remove it if we ever fix that beast.
-    data class Services @JvmOverloads constructor(
-        val metadata: MetadataCollection = MetadataCollection(),
-        val networkService: NetworkService = NetworkService(),
-        val diagramService: DiagramService = DiagramService(),
-        val customerService: CustomerService = CustomerService(),
-        val measurementService: MeasurementService = MeasurementService()
-    )
 
     companion object {
         private val baseVoltagesByNominalVoltage = mutableMapOf<Int, BaseVoltage>()


### PR DESCRIPTION
# Description

* `BaseService` now contains a `MetadataCollection` to tightly couple the metadata to the associated service.
* Added `Services`, a new class which contains a copy of each `BaseService` supported by the SDK.
* Database readers and writes for each `BaseService` no longer accept a `MetadataCollection`, and will instead use the collection of the provided service.

# Checklist

If any of these are not applicable, strikethrough the line `~like this~`. **Do not delete it!**. Let the reviewer decide if you should have done it.

### Code
- [x] I have performed a self review of my own code (including checking issues raised when creating the PR).
- [x] I have added/updated unit tests for these changes, and if not I have explained why they are not necessary.
- [x] I have commented my code in any hard-to-understand or hacky areas.
- [x] I have handled all new warnings generated by the compiler or IDE.
- [x] I have rebased onto the target branch (usually main).

### Documentation
- [x] I have updated the changelog.
~- [ ] I have updated any documentation required for these changes.~

# Breaking Changes
- [x] I have considered if this is a breaking change and will communicate it with other team members if so.

* Database readers and writes for each `BaseService` no longer accept a `MetadataCollection`, and will instead use the collection of the provided service.

