### PR TITLE
[DEV-1857] Update JVM SDK - Update network state service

### DIFF
--- a/docs/docs/update-network-state-client.mdx
+++ b/docs/docs/update-network-state-client.mdx
@@ -223,9 +223,8 @@ You can check the type of response or failure by check against the types from `c
 import com.zepben.evolve.streaming.data.BatchFailure;
 import com.zepben.evolve.streaming.data.StateEventUnknownMrid;
 
-var status = response.getStatus();
-if (status instanceof BatchFailure) {
-    var batchFailure = (BatchFailure) status;
+if (response instanceof BatchFailure) {
+    var batchFailure = (BatchFailure) response;
     batchFailure.getPartialFailure(); // Will be true if all event failed, otherwise false.
     batchFailure.getFailures().forEach((failure) -> {
         if (failure instanceof StateEventUnknownMrid) {
@@ -239,15 +238,17 @@ if (status instanceof BatchFailure) {
 <TabItem  value="kotlin">
 
 ```kotlin
-when (val status = response.status) {
+when (response) {
     is BatchFailure -> {
-        status.partialFailure // Will be true if all event failed, otherwise false.
-        status.failures.forEach { failure ->
+        response.partialFailure // Will be true if all event failed, otherwise false.
+        response.failures.forEach { failure ->
             when (failure) {
                 is StateEventUnknownMrid -> // Process failure
+                // process other failure types
             }
         }
     }
+    // process other response types
 }
 ```
 

--- a/src/test/kotlin/com/zepben/evolve/streaming/data/SetCurrentStatesStatusTest.kt
+++ b/src/test/kotlin/com/zepben/evolve/streaming/data/SetCurrentStatesStatusTest.kt
@@ -10,6 +10,7 @@ package com.zepben.evolve.streaming.data
 
 import com.google.protobuf.Timestamp
 import com.zepben.evolve.services.common.translator.toLocalDateTime
+import com.zepben.protobuf.ns.SetCurrentStatesResponse as PBSetCurrentStatesResponse
 import org.hamcrest.CoreMatchers.*
 import org.hamcrest.MatcherAssert.assertThat
 import org.junit.jupiter.api.Test
@@ -29,35 +30,53 @@ class SetCurrentStatesStatusTest {
     }.build()
 
     @Test
-    fun `BatchSuccessful from protobuf and then back to protobuf`(){
-        val pb = PBBatchSuccessful.newBuilder().build()
-        val status = BatchSuccessful.fromPb(pb) as BatchSuccessful
+    fun `BatchSuccessful from protobuf and then back to protobuf`() {
+        val pb = createSetCurrentStatesResponse { success = PBBatchSuccessful.newBuilder().build() }
+
+        val status = SetCurrentStatesStatus.fromPb(pb) as BatchSuccessful
         assertThat(status, instanceOf(BatchSuccessful::class.java))
-        assertThat(status.toPb(), instanceOf(PBBatchSuccessful::class.java))
+        assertThat(status.batchId, equalTo(1))
+
+        (status as SetCurrentStatesStatus).toPb().also {
+            assertThat(it.messageId, equalTo(1))
+            assertThat(it.statusCase, equalTo(PBSetCurrentStatesResponse.StatusCase.SUCCESS))
+        }
     }
 
     @Test
-    fun `ProcessingPaused from protobuf and then back to protobuf`(){
-        val pb = PBProcessingPaused.newBuilder().apply { since = Timestamp.newBuilder().apply { seconds = 1 }.build() }.build()
-        val status = ProcessingPaused.fromPb(pb) as ProcessingPaused
-        assertThat(status.since, equalTo(pb.since.toLocalDateTime()))
-        assertThat(status.toPb().since, equalTo(pb.since))
+    fun `ProcessingPaused from protobuf and then back to protobuf`() {
+        val pb = createSetCurrentStatesResponse {
+            paused = PBProcessingPaused.newBuilder().apply { since = Timestamp.newBuilder().apply { seconds = 1 }.build() }.build()
+        }
+
+        val status = SetCurrentStatesStatus.fromPb(pb) as ProcessingPaused
+        assertThat(status.since, equalTo(pb.paused.since.toLocalDateTime()))
+        assertThat(status.batchId, equalTo(1))
+
+        (status as SetCurrentStatesStatus).toPb().also {
+            assertThat(it.messageId, equalTo(1))
+            assertThat(it.paused.since, equalTo(pb.paused.since))
+        }
     }
 
     @Test
-    fun `BatchFailure from protobuf and then back to protobuf`(){
-        val pb = PBBatchFailure.newBuilder().apply {
-            partialFailure = true
-            addAllFailed(listOf(invalidMridPb))
-        }.build()
+    fun `BatchFailure from protobuf and then back to protobuf`() {
+        val pb = createSetCurrentStatesResponse {
+            failure = PBBatchFailure.newBuilder().apply {
+                partialFailure = true
+                addAllFailed(listOf(invalidMridPb))
+            }.build()
+        }
 
-        val status = BatchFailure.fromPb(pb) as BatchFailure
-        assertThat(status.partialFailure, equalTo(pb.partialFailure))
+
+        val status = SetCurrentStatesStatus.fromPb(pb) as BatchFailure
+        SetCurrentStatesStatus.fromPb(pb) as BatchFailure
+        assertThat(status.partialFailure, equalTo(pb.failure.partialFailure))
         assertThat(status.failures.size, equalTo(1))
         assertThat(status.failures.first(), instanceOf(StateEventInvalidMrid::class.java))
 
-        status.toPb().let {
-            assertThat(it.partialFailure, equalTo(pb.partialFailure))
+        (status as SetCurrentStatesStatus).toPb().failure.also {
+            assertThat(it.partialFailure, equalTo(pb.failure.partialFailure))
             assertThat(it.failedList.size, equalTo(1))
             assertThat(it.failedList.first().reasonCase, equalTo(PBStateEventFailure.ReasonCase.INVALIDMRID))
         }
@@ -87,7 +106,7 @@ class SetCurrentStatesStatusTest {
         assertThat(StateEventFailure.fromPb(PBStateEventFailure.newBuilder().build()), nullValue())
     }
 
-    private fun testStateEventFailure(pb: PBStateEventFailure, clazz: Class<out StateEventFailure>){
+    private fun testStateEventFailure(pb: PBStateEventFailure, clazz: Class<out StateEventFailure>) {
         val state = StateEventFailure.fromPb(pb)
         assertThat(state?.eventId, equalTo(pb.eventId))
         assertThat(state, instanceOf(clazz))
@@ -97,4 +116,10 @@ class SetCurrentStatesStatusTest {
             assertThat(it.reasonCase, equalTo(pb.reasonCase))
         }
     }
+
+    private fun createSetCurrentStatesResponse(block: PBSetCurrentStatesResponse.Builder.() -> Unit): PBSetCurrentStatesResponse =
+        PBSetCurrentStatesResponse.newBuilder().apply {
+            messageId = 1
+            block()
+        }.build()
 }

--- a/src/test/kotlin/com/zepben/evolve/streaming/data/SetCurrentStatesStatusTest.kt
+++ b/src/test/kotlin/com/zepben/evolve/streaming/data/SetCurrentStatesStatusTest.kt
@@ -33,13 +33,13 @@ class SetCurrentStatesStatusTest {
     fun `BatchSuccessful from protobuf and then back to protobuf`() {
         val pb = createSetCurrentStatesResponse { success = PBBatchSuccessful.newBuilder().build() }
 
-        val status = SetCurrentStatesStatus.fromPb(pb) as BatchSuccessful
+        val status = SetCurrentStatesStatus.fromPb(pb)
         assertThat(status, instanceOf(BatchSuccessful::class.java))
-        assertThat(status.batchId, equalTo(1))
+        assertThat(status?.batchId, equalTo(1))
 
-        (status as SetCurrentStatesStatus).toPb().also {
+        status?.toPb()?.also {
             assertThat(it.messageId, equalTo(1))
-            assertThat(it.statusCase, equalTo(PBSetCurrentStatesResponse.StatusCase.SUCCESS))
+            assertThat(it.success, not(equalTo(PBSetCurrentStatesResponse.getDefaultInstance())))
         }
     }
 
@@ -70,7 +70,6 @@ class SetCurrentStatesStatusTest {
 
 
         val status = SetCurrentStatesStatus.fromPb(pb) as BatchFailure
-        SetCurrentStatesStatus.fromPb(pb) as BatchFailure
         assertThat(status.partialFailure, equalTo(pb.failure.partialFailure))
         assertThat(status.failures.size, equalTo(1))
         assertThat(status.failures.first(), instanceOf(StateEventInvalidMrid::class.java))
@@ -118,8 +117,5 @@ class SetCurrentStatesStatusTest {
     }
 
     private fun createSetCurrentStatesResponse(block: PBSetCurrentStatesResponse.Builder.() -> Unit): PBSetCurrentStatesResponse =
-        PBSetCurrentStatesResponse.newBuilder().apply {
-            messageId = 1
-            block()
-        }.build()
+        PBSetCurrentStatesResponse.newBuilder().also { it.messageId = 1 }.apply(block).build()
 }

--- a/src/test/kotlin/com/zepben/evolve/streaming/mutations/UpdateNetworkStateClientTest.kt
+++ b/src/test/kotlin/com/zepben/evolve/streaming/mutations/UpdateNetworkStateClientTest.kt
@@ -154,7 +154,7 @@ class UpdateNetworkStateClientTest {
         act()
     }
 
-    private fun assertBatchedCurrentStatesResponse(currentStatesStatus: List<UpdateNetworkStateClient.SetCurrentStatesResponse>) {
+    private fun assertBatchedCurrentStatesResponse(currentStatesStatus: List<SetCurrentStatesStatus>) {
         assertThat(currentStatesStatus.size, equalTo(3))
         currentStatesStatus.assert<BatchSuccessful>(0)
         currentStatesStatus.assert<ProcessingPaused>(1) {
@@ -177,11 +177,11 @@ class UpdateNetworkStateClientTest {
         }
     }
 
-    private inline fun <reified T> List<UpdateNetworkStateClient.SetCurrentStatesResponse>.assert(index: Int, additionalAssertions: (T) -> Unit = {}) {
+    private inline fun <reified T> List<SetCurrentStatesStatus>.assert(index: Int, additionalAssertions: (T) -> Unit = {}) {
         this[index].also {
             assertThat(it.batchId, equalTo(index.toLong()))
-            assertThat(it.status, instanceOf(T::class.java))
-            additionalAssertions(it.status as T)
+            assertThat(it, instanceOf(T::class.java))
+            additionalAssertions(it as T)
         }
     }
 }


### PR DESCRIPTION
# Description

This is to allow the callback function of the update network state service to asynchronously accept request and respond by identifying each response with batch id.

Removed response object `UpdateNetworkStateClient.SetCurrentStatesResponse`.

# Associated tasks

None.

# Test Steps

Test by using the `UpdateNetworkStateClient` and `UpdateNetworkStateService` classes.

# Checklist

If any of these are not applicable, strikethrough the line `~like this~`. **Do not delete it!**. Let the reviewer decide if you should have done it.

### Code
- [x] I have performed a self review of my own code (including checking issues raised when creating the PR).
- [x] I have added/updated unit tests for these changes, and if not I have explained why they are not necessary.
- [x] I have commented my code in any hard-to-understand or hacky areas.
- [x] I have handled all new warnings generated by the compiler or IDE.
- [x] I have rebased onto the target branch (usually main).

### Documentation
- [ ] ~I have updated the changelog.~
Update to unreleased version of the code.
- [x] I have updated any documentation required for these changes.

# Breaking Changes
- [x] I have considered if this is a breaking change and will communicate it with other team members if so.

None
