### PR TITLE
[DEV-1865] Update jvm sdk update network state service to handle request processing asynchronously

### DIFF
--- a/docs/docs/update-network-state-service.mdx
+++ b/docs/docs/update-network-state-service.mdx
@@ -21,35 +21,12 @@ You do _**NOT**_ have to do this, you can register the services directly with a 
 
 The classes you need for performing these actions can be imported from the SDK:
 
-<Tabs
-    groupId="import-example"
-    defaultValue="java"
-    values={[
-        { label: "Java", value: "java", },
-        { label: "Kotlin", value: "kotlin", },
-    ]
-}>
-<TabItem value="java">
-
-```java
-import com.zepben.evolve.conn.grpc.GrpcServer;
-import com.zepben.evolve.streaming.data.CurrentStateEvent;
-import com.zepben.evolve.streaming.data.SetCurrentStatesStatus;
-import com.zepben.evolve.streaming.mutations.UpdateNetworkStateService;
-```
-
-</TabItem>
-<TabItem  value="kotlin">
-
 ```kotlin
 import com.zepben.evolve.conn.grpc.GrpcServer
 import com.zepben.evolve.streaming.data.CurrentStateEvent
 import com.zepben.evolve.streaming.data.SetCurrentStatesStatus
 import com.zepben.evolve.streaming.mutations.UpdateNetworkStateService
 ```
-
-</TabItem>
-</Tabs>
 
 ## Creating callbacks
 
@@ -59,84 +36,27 @@ callbacks can be done as either lambdas, or full method/function implementations
 ### onSetCurrentStates
 
 The `onSetCurrentStates` callback is triggered for each request passing in a batch of current state events, and should return a
-[batch result response](update-network-state-client.mdx#batch-result-responses) to reflect the success or failure of the update process.
-
-<Tabs
-    groupId="callback-example"
-    defaultValue="java"
-    values={[
-        { label: "Java", value: "java", },
-        { label: "Kotlin", value: "kotlin", },
-    ]
-}>
-<TabItem value="java">
-
-```java
-// Using a lambda expression
-Function<List<CurrentStateEvent>, SetCurrentStatesStatus> updateCurrentStatesLambda  = (events) -> {
-    // process updating of events here and return a batch result response
-};
-
-// Using a method
-class UpdateNetworkStateServiceImpl {
-
-    SetCurrentStatesStatus updateCurrentStates(List<? extends CurrentStateEvent> events) {
-        // process updating of events here and return a batch result response
-    }
-
-}
-```
-
-</TabItem>
-<TabItem  value="kotlin">
+`CompletableFuture` of [batch result response](update-network-state-client.mdx#batch-result-responses) to reflect the success or failure of the update process.
 
 ```kotlin
 // Using a lambda expression
-var updateCurrentStatesLambda = { events: List<CurrentStateEvent> ->
-    // process updating of events here and return a batch result response
+var updateCurrentStatesLambda = { batchId: Long, events: List<CurrentStateEvent> ->
+    // process updating of events here and return a CompletableFuture of batch result response
 }
 
 // Using a method
 class UpdateNetworkStateServiceImpl {
 
-    fun updateCurrentStates(events: List<CurrentStateEvent>): SetCurrentStatesStatus {
-        // process updating of events here and return a batch result response
+    fun updateCurrentStates(batchId: Long, events: List<CurrentStateEvent>): CompletableFuture<SetCurrentStatesStatus> {
+        // process updating of events here and return a CompletableFuture of batch result response
     }
 
 }
 ```
-
-</TabItem>
-</Tabs>
 
 ## Registering callbacks
 
 Registering the callbacks with the service is as simple as passing them into the `UpdateNetworkStateService` constructor.
-
-<Tabs
-    groupId="register-example"
-    defaultValue="java"
-    values={[
-        { label: "Java", value: "java", },
-        { label: "Kotlin", value: "kotlin", },
-    ]
-}>
-<TabItem value="java">
-
-```java
-// Using lambda expressions
-UpdateNetworkStateService service = new UpdateNetworkStateService(updateCurrentStatesLambda);
-
-// Using method references
-class UpdateNetworkStateServiceImpl {
-
-    UpdateNetworkStateService service = new UpdateNetworkStateService(this::updateCurrentStates);
-
-}
-```
-
-</TabItem>
-<TabItem  value="kotlin">
 
 ```kotlin
 // Using lambda expressions
@@ -150,46 +70,10 @@ class UpdateNetworkStateServiceImpl {
 }
 ```
 
-</TabItem>
-</Tabs>
-
 ## Registering the service
 
 For the above code to have any effect, you need to register the service with a gRPC server. Once this has been done, you should start to receive callbacks for
 each request sent from a gRPC client.
-
-<Tabs
-    groupId="code-example"
-    defaultValue="java"
-    values={[
-        { label: "Java", value: "java", },
-        { label: "Kotlin", value: "kotlin", },
-    ]
-}>
-<TabItem value="java">
-
-```java
-class Main {
-
-    public static void main(String[] args) {
-        var grpcServer = new GrpcServerImpl(9001, service);
-        grpcServer.start();
-    }
-
-    class GrpcServerImpl extends GrpcServer {
-
-        GrpcServerImpl(int port, UpdateNetworkStateService service) {
-            super(port, 0, null, List.of());
-            getServerBuilder().addService(service);
-        }
-
-    }
-
-}
-```
-
-</TabItem>
-<TabItem  value="kotlin">
 
 ```kotlin
 fun main() {
@@ -202,113 +86,19 @@ fun main() {
 }
 ```
 
-</TabItem>
-</Tabs>
-
 ## Putting it all together
 
 Putting each of the steps above together, you can build the scaffold of a working application
 
 <Tabs
     groupId="code-example"
-    defaultValue="java-lambda"
+    defaultValue="kotlin-lambda"
     values={[
-        { label: "Java Lambdas", value: "java-lambda", },
-        { label: "Java Methods", value: "java-method", },
         { label: "Kotlin Lambdas", value: "kotlin-lambda", },
         { label: "Kotlin Methods", value: "kotlin-method", },
     ]
 }>
-<TabItem value="java-lambda">
 
-`Main.java`:
-```java
-import com.zepben.evolve.streaming.mutations.UpdateNetworkStateService;
-
-class Main {
-
-    public static void main(String[] args) {
-        UpdateNetworkStateService service = new UpdateNetworkStateService(
-            (events) -> {
-                // process updating of events here and return a batch result response
-            });
-
-        var grpcServer = new GrpcServerImpl(9001, service);
-        grpcServer.start();
-    }
-
-}
-```
-
-`GrpcServerImpl.java`:
-```java
-import com.zepben.evolve.conn.grpc.GrpcServer;
-import com.zepben.evolve.streaming.mutations.UpdateNetworkStateService;
-
-import java.util.List;
-
-class GrpcServerImpl extends GrpcServer {
-
-    GrpcServerImpl(int port, UpdateNetworkStateService service) {
-        super(port, 0, null, List.of());
-        getServerBuilder().addService(service);
-    }
-
-}
-```
-
-</TabItem>
-<TabItem value="java-method">
-
-`Main.java`:
-```java
-class Main {
-
-    public static void main(String[] args) {
-        var service = new UpdateNetworkStateServiceImpl();
-        var grpcServer = new GrpcServerImpl(9001, service.service);
-        grpcServer.start();
-    }
-
-}
-```
-
-`GrpcServerImpl.java`:
-```java
-import com.zepben.evolve.conn.grpc.GrpcServer;
-import com.zepben.evolve.streaming.mutations.UpdateNetworkStateService;
-
-import java.util.List;
-
-class GrpcServerImpl extends GrpcServer {
-
-    GrpcServerImpl(int port, UpdateNetworkStateService service) {
-        super(port, 0, null, List.of());
-        getServerBuilder().addService(service);
-    }
-
-}
-```
-
-`UpdateNetworkStateServiceImpl.java`:
-```java
-import com.zepben.evolve.streaming.data.CurrentStateEvent;
-import com.zepben.evolve.streaming.data.SetCurrentStatesStatus;
-import com.zepben.evolve.streaming.mutations.UpdateNetworkStateService;
-
-import java.util.List;
-
-class UpdateNetworkStateServiceImpl {
-    UpdateNetworkStateService service = new UpdateNetworkStateService(this::updateCurrentStates);
-
-    SetCurrentStatesStatus updateCurrentStates(List<? extends CurrentStateEvent> events) {
-        // process updating of events here and return a batch result response
-    }
-
-}
-```
-
-</TabItem>
 <TabItem  value="kotlin-lambda">
 
 ```kotlin
@@ -317,8 +107,8 @@ import com.zepben.evolve.streaming.data.CurrentStateEvent
 import com.zepben.evolve.streaming.mutations.UpdateNetworkStateService
 
 fun main() {
-    val service = UpdateNetworkStateService(onSetCurrentStates = { events: List<CurrentStateEvent> ->
-        // process updating of events here and return a batch result response
+    val service = UpdateNetworkStateService(onSetCurrentStates = { batchId: Long, events: List<CurrentStateEvent> ->
+       // process updating of events here and return a CompletableFuture of batch result response
     })
 
     val grpcServer = object : GrpcServer(9001) {
@@ -341,10 +131,10 @@ import com.zepben.evolve.streaming.mutations.UpdateNetworkStateService
 
 class UpdateNetworkStateServiceImpl {
 
-    val service = UpdateNetworkStateService(::updateCurrentStates);
+    val service = UpdateNetworkStateService(::updateCurrentStates)
 
-    fun updateCurrentStates(events: List<CurrentStateEvent>): SetCurrentStatesStatus {
-        // process updating of events here and return a batch result response
+    fun updateCurrentStates(batchId: Long, events: List<CurrentStateEvent>): CompletableFuture<SetCurrentStatesStatus> {
+        // process updating of events here and return a CompletableFuture of batch result response
     }
 
 }

--- a/src/main/kotlin/com/zepben/evolve/streaming/mutations/UpdateNetworkStateService.kt
+++ b/src/main/kotlin/com/zepben/evolve/streaming/mutations/UpdateNetworkStateService.kt
@@ -8,12 +8,16 @@
 
 package com.zepben.evolve.streaming.mutations
 
+import com.zepben.evolve.conn.grpc.GrpcException
 import com.zepben.evolve.streaming.data.*
 import com.zepben.protobuf.ns.SetCurrentStatesRequest
 import com.zepben.protobuf.ns.SetCurrentStatesResponse
 import com.zepben.protobuf.ns.UpdateNetworkStateServiceGrpc
-import io.grpc.Status
 import io.grpc.stub.StreamObserver
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.sync.Mutex
+import java.util.concurrent.CompletableFuture
+import java.util.concurrent.atomic.AtomicInteger
 
 /**
  * A service class that provides a simplified interface for updating network state events
@@ -23,10 +27,15 @@ import io.grpc.stub.StreamObserver
  * allowing users to update the network state using a more convenient function type.
  *
  * @property onSetCurrentStates A function that takes a list of [CurrentStateEvent] objects
- * and returns a [SetCurrentStatesStatus], which reflects the success or failure of the update process.
+ * and returns a [CompletableFuture] of [SetCurrentStatesStatus], which reflects the success or failure of
+ * the update process. Care must be taken to ensure the [CompletableFuture] is configured with a timeout to
+ * avoid blocking the gRPC call.
+ * @property onProcessingError A function that takes a [Throwable] object. Called when onSetCurrentStates
+ * throws an exception or the [CompletableFuture] is completed with exception.
  */
 class UpdateNetworkStateService(
-    private val onSetCurrentStates: (batchId: Long, events: List<CurrentStateEvent>) -> SetCurrentStatesStatus
+    private val onSetCurrentStates: (batchId: Long, events: List<CurrentStateEvent>) -> CompletableFuture<SetCurrentStatesStatus>,
+    private val onProcessingError: (Throwable) -> Unit = {}
 ) : UpdateNetworkStateServiceGrpc.UpdateNetworkStateServiceImplBase() {
 
     /**
@@ -47,12 +56,30 @@ class UpdateNetworkStateService(
      */
     override fun setCurrentStates(responseObserver: StreamObserver<SetCurrentStatesResponse>): StreamObserver<SetCurrentStatesRequest> =
         object : StreamObserver<SetCurrentStatesRequest> {
+            val outstandingProcesses = AtomicInteger()
+            val onCompletedLock = Mutex()
             override fun onNext(request: SetCurrentStatesRequest) {
                 try {
                     onSetCurrentStates(request.messageId, request.eventList.map { CurrentStateEvent.fromPb(it) })
-                        .also { responseObserver.onNext(it.toPb()) }
+                        .also { completable ->
+                            // prevent onCompleted from happening when any request is being processed
+                            if (outstandingProcesses.incrementAndGet() == 1)
+                                onCompletedLock.tryLock()
+
+                            completable.whenComplete { result, e ->
+                                if (result != null)
+                                    responseObserver.onNext(result.toPb())
+                                else if(e != null)
+                                    handleError(request, "Error raised by the state updater", e)
+
+                                // Allow onCompleted from happening when there are no outstanding request processing
+                                if (outstandingProcesses.decrementAndGet() == 0)
+                                    onCompletedLock.unlock()
+                            }
+                        }
+
                 } catch (e: Throwable) {
-                    responseObserver.onError(Status.INTERNAL.withDescription(e.localizedMessage).asRuntimeException())
+                    handleError(request, "onSetCurrentStates has error", e)
                 }
             }
 
@@ -60,8 +87,14 @@ class UpdateNetworkStateService(
                 throw e
             }
 
-            override fun onCompleted() {
+            override fun onCompleted() = runBlocking {
+                onCompletedLock.lock()
                 responseObserver.onCompleted()
+            }
+
+            private fun handleError(request: SetCurrentStatesRequest, message: String, e: Throwable){
+                onProcessingError(GrpcException("$message for batch `${request.messageId}`: ${e.localizedMessage}", e))
+                responseObserver.onNext(BatchFailure(request.messageId, false, listOf()).toPb())
             }
         }
 

--- a/src/test/kotlin/com/zepben/evolve/streaming/data/SetCurrentStatesStatusTest.kt
+++ b/src/test/kotlin/com/zepben/evolve/streaming/data/SetCurrentStatesStatusTest.kt
@@ -39,7 +39,7 @@ class SetCurrentStatesStatusTest {
 
         status?.toPb()?.also {
             assertThat(it.messageId, equalTo(1))
-            assertThat(it.success, not(equalTo(PBSetCurrentStatesResponse.getDefaultInstance())))
+            assertThat(it.statusCase, equalTo(PBSetCurrentStatesResponse.StatusCase.SUCCESS))
         }
     }
 

--- a/src/test/kotlin/com/zepben/evolve/streaming/mutations/UpdateNetworkStateServiceTest.kt
+++ b/src/test/kotlin/com/zepben/evolve/streaming/mutations/UpdateNetworkStateServiceTest.kt
@@ -148,7 +148,7 @@ class UpdateNetworkStateServiceTest {
     }
 
     @Test
-    fun `setCurrentStates should setup timeout on the future returned by onSetCurrentStates callback to avoid blocking the grpc request`() {
+    fun `setCurrentStates should setup timeout on the future returned by onSetCurrentStates callback to avoid blocking the grpc connection`() {
         startGrpcServer(false)
         every { onSetCurrentStates(capture(batchIdSlot), capture(eventsSlot)) } answers {
             CompletableFuture<SetCurrentStatesStatus>().orTimeout(60, TimeUnit.SECONDS)

--- a/src/test/kotlin/com/zepben/evolve/streaming/mutations/UpdateNetworkStateServiceTest.kt
+++ b/src/test/kotlin/com/zepben/evolve/streaming/mutations/UpdateNetworkStateServiceTest.kt
@@ -10,6 +10,7 @@ package com.zepben.evolve.streaming.mutations
 
 import com.google.protobuf.Timestamp
 import com.zepben.evolve.cim.iec61970.base.core.PhaseCode
+import com.zepben.evolve.conn.grpc.GrpcException
 import com.zepben.evolve.services.common.translator.toLocalDateTime
 import com.zepben.evolve.services.common.translator.toTimestamp
 import com.zepben.evolve.streaming.data.*
@@ -23,11 +24,15 @@ import io.grpc.inprocess.InProcessServerBuilder
 import io.grpc.stub.StreamObserver
 import io.grpc.testing.GrpcCleanupRule
 import io.mockk.*
+import kotlinx.coroutines.runBlocking
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.*
 import org.junit.Rule
 import org.junit.jupiter.api.Test
 import java.time.LocalDateTime
+import java.util.concurrent.CompletableFuture
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.Executors
 import com.zepben.protobuf.ns.data.SwitchAction as PBSwitchAction
 import com.zepben.protobuf.cim.iec61970.base.core.PhaseCode as PBPhaseCode
 import com.zepben.protobuf.ns.data.SwitchStateEvent as PBSwitchStateEvent
@@ -44,21 +49,28 @@ class UpdateNetworkStateServiceTest {
     private val setCurrentStatesReturns = listOf(
         BatchSuccessful(1),
         ProcessingPaused(1, LocalDateTime.now()),
-        BatchFailure(1, true, listOf(
-            StateEventUnknownMrid("event id"),
-            StateEventDuplicateMrid("event id"),
-            StateEventInvalidMrid("event id"),
-            StateEventUnsupportedPhasing("event id")
-        ))
+        BatchFailure(
+            1, true, listOf(
+                StateEventUnknownMrid("event id"),
+                StateEventDuplicateMrid("event id"),
+                StateEventInvalidMrid("event id"),
+                StateEventUnsupportedPhasing("event id")
+            )
+        )
     )
-    private val onSetCurrentStates = mockk<(batchId: Long, events: List<CurrentStateEvent>) -> SetCurrentStatesStatus>().also {
-        every { it(capture(batchIdSlot), capture(eventsSlot)) } returnsMany setCurrentStatesReturns
+    private val onSetCurrentStates = mockk<(batchId: Long, events: List<CurrentStateEvent>) -> CompletableFuture<SetCurrentStatesStatus>>().also {
+        every { it(capture(batchIdSlot), capture(eventsSlot)) } returnsMany setCurrentStatesReturns.map { CompletableFuture.completedFuture(it) }
+    }
+    private val error = Error("TEST ERROR!")
+    private val onProcessingErrorSlot = slot<Throwable>()
+    private val onProcessingError = mockk<(Throwable) -> Unit>().also {
+        justRun { it(capture(onProcessingErrorSlot)) }
     }
 
     private val serverName = InProcessServerBuilder.generateName()
     private val channel = grpcCleanup.register(InProcessChannelBuilder.forName(serverName).directExecutor().build())
     private val stub = UpdateNetworkStateServiceGrpc.newStub(channel)
-    private val service = UpdateNetworkStateService(onSetCurrentStates)
+    private val service = UpdateNetworkStateService(onSetCurrentStates, onProcessingError)
 
     private val responseSlot = slot<SetCurrentStatesResponse>()
     private val responseErrorSlot = slot<Throwable>()
@@ -81,46 +93,47 @@ class UpdateNetworkStateServiceTest {
         }.build())
     }.build()
 
-    init {
-        grpcCleanup.register(InProcessServerBuilder.forName(serverName).directExecutor().addService(service).build().start())
-    }
-
     @Test
-    fun setCurrentStates(){
+    fun setCurrentStates() {
+        startGrpcServer()
         setCurrentStatesTest(SetCurrentStatesResponse.StatusCase.SUCCESS)
-        setCurrentStatesTest(SetCurrentStatesResponse.StatusCase.PAUSED){
+        setCurrentStatesTest(SetCurrentStatesResponse.StatusCase.PAUSED) {
             assertThat(it.paused.since, equalTo((setCurrentStatesReturns[1] as ProcessingPaused).since.toTimestamp()))
         }
-        setCurrentStatesTest(SetCurrentStatesResponse.StatusCase.FAILURE){ response ->
+        setCurrentStatesTest(SetCurrentStatesResponse.StatusCase.FAILURE) { response ->
             response.failure.apply {
                 assertThat(partialFailure, equalTo(true))
-                assertThat(failedList.map { it.reasonCase }, contains(
-                    PBStateEventFailure.ReasonCase.UNKNOWNMRID,
-                    PBStateEventFailure.ReasonCase.DUPLICATEMRID,
-                    PBStateEventFailure.ReasonCase.INVALIDMRID,
-                    PBStateEventFailure.ReasonCase.UNSUPPORTEDPHASING))
+                assertThat(
+                    failedList.map { it.reasonCase }, contains(
+                        PBStateEventFailure.ReasonCase.UNKNOWNMRID,
+                        PBStateEventFailure.ReasonCase.DUPLICATEMRID,
+                        PBStateEventFailure.ReasonCase.INVALIDMRID,
+                        PBStateEventFailure.ReasonCase.UNSUPPORTEDPHASING
+                    )
+                )
             }
 
         }
     }
 
     @Test
-    fun `setCurrentStates onNext handles error`(){
-        every { onSetCurrentStates(any(), any()) } throws Error("TEST ERROR!")
+    fun `setCurrentStates onNext handles error`() {
+        startGrpcServer()
+        every { onSetCurrentStates(any(), any()) } throws error
 
         sendGrpcRequest(request)
 
-        verify { responseObserver.onError(responseErrorSlot.captured) }
-
-        assertThat(responseErrorSlot.captured, instanceOf(StatusRuntimeException::class.java))
-        (responseErrorSlot.captured as StatusRuntimeException).status.apply {
-            assertThat(code, equalTo(Status.INTERNAL.code))
-            assertThat(description, equalTo("TEST ERROR!"))
+        verify {
+            onProcessingError.invoke(onProcessingErrorSlot.captured)
+            responseObserver.onNext(responseSlot.captured)
         }
+
+        validateOnProcessingError()
     }
 
     @Test
-    fun `setCurrentStates onError`(){
+    fun `setCurrentStates onError`() {
+        startGrpcServer()
         val throwable = Status.INTERNAL.withDescription("TEST ERROR!").asRuntimeException()
         val requestObserver = stub.setCurrentStates(responseObserver)
         requestObserver.onError(throwable)
@@ -129,7 +142,48 @@ class UpdateNetworkStateServiceTest {
         assertThat((responseErrorSlot.captured as StatusRuntimeException).status.code, equalTo(Status.CANCELLED.code))
     }
 
-    private fun setCurrentStatesTest(statusCase: SetCurrentStatesResponse.StatusCase, onResponseAssertion: ((SetCurrentStatesResponse) -> Unit)? = null){
+    @Test
+    fun `setCurrentStates responseObserver onCompleted should only be called when all processing has finished`() = runBlocking {
+        startGrpcServer(false)
+        val completableFutures: List<CompletableFuture<SetCurrentStatesStatus>> = List(3) { CompletableFuture() }
+        // Configure mock with latches to synchronize the test thread with the server thread
+        val onSetCurrentStatesLatch = CountDownLatch(3)
+        every { onSetCurrentStates(capture(batchIdSlot), capture(eventsSlot)) } answers {
+            onSetCurrentStatesLatch.countDown()
+            completableFutures[onSetCurrentStatesLatch.count.toInt()]
+        }
+        val responseObserverOnNextLatch = CountDownLatch(2)
+        every { responseObserver.onNext(capture(responseSlot)) } answers { responseObserverOnNextLatch.countDown() }
+        val responseObserverOnCompletedLatch = CountDownLatch(1)
+        every { responseObserver.onCompleted() } answers { responseObserverOnCompletedLatch.countDown() }
+
+        val requestObserver = stub.setCurrentStates(responseObserver)
+        requestObserver.onNext(request)
+        requestObserver.onNext(request)
+        requestObserver.onNext(request)
+        requestObserver.onCompleted()
+
+        onSetCurrentStatesLatch.await()
+        verify(exactly = 3) { onSetCurrentStates.invoke(batchIdSlot.captured, eventsSlot.captured) }
+        verify { responseObserver wasNot called }
+        completableFutures.take(2).forEach { it.complete(BatchSuccessful(1)) }
+
+        responseObserverOnNextLatch.await()
+        verify(exactly = 2) { responseObserver.onNext(responseSlot.captured) }
+        verify(exactly = 0) { responseObserver.onCompleted() }
+        clearMocks(responseObserver, answers = false)
+        completableFutures.last().completeExceptionally(error) // full completion
+
+        responseObserverOnCompletedLatch.await()
+        validateOnProcessingError()
+        verifySequence {
+            onProcessingError.invoke(onProcessingErrorSlot.captured)
+            responseObserver.onNext(responseSlot.captured)
+            responseObserver.onCompleted()
+        }
+    }
+
+    private fun setCurrentStatesTest(statusCase: SetCurrentStatesResponse.StatusCase, onResponseAssertion: ((SetCurrentStatesResponse) -> Unit)? = null) {
         sendGrpcRequest(request)
 
         verify {
@@ -139,7 +193,7 @@ class UpdateNetworkStateServiceTest {
         }
 
         assertThat(batchIdSlot.captured, equalTo(1))
-        eventsSlot.captured.also{
+        eventsSlot.captured.also {
             assertThat(it.size, equalTo(1))
             assertThat(it[0], instanceOf(SwitchStateEvent::class.java))
             (it[0] as SwitchStateEvent).apply {
@@ -158,10 +212,32 @@ class UpdateNetworkStateServiceTest {
         }
     }
 
-    private fun sendGrpcRequest(request: SetCurrentStatesRequest){
+    private fun sendGrpcRequest(request: SetCurrentStatesRequest) {
         // Having this requestObserver in the class property didn't work, so we just create it before sending the request.
         val requestObserver = stub.setCurrentStates(responseObserver)
         requestObserver.onNext(request)
         requestObserver.onCompleted()
+    }
+
+    private fun startGrpcServer(usingDirectExecutor: Boolean = true) {
+        val serverBuilder = InProcessServerBuilder.forName(serverName).addService(service)
+        if (usingDirectExecutor)
+            serverBuilder.directExecutor()
+        else
+            serverBuilder.executor(Executors.newSingleThreadExecutor())
+
+        grpcCleanup.register(serverBuilder.build().start())
+    }
+
+    private fun validateOnProcessingError() {
+        onProcessingErrorSlot.captured.also {
+            assertThat(it, instanceOf(GrpcException::class.java))
+            assertThat(it.cause, equalTo(error))
+        }
+        responseSlot.captured.also {
+            assertThat(it.statusCase, equalTo(SetCurrentStatesResponse.StatusCase.FAILURE))
+            assertThat(it.failure.partialFailure, equalTo(false))
+            assertThat(it.failure.failedList, empty())
+        }
     }
 }


### PR DESCRIPTION
# Description

Made the `UpdateNetworkStateService` handle processing of request asynchronously. The thread that handles the grpc request is blocked in `OnCompleted` until all processing are done via the `onSetCurrentStates` callback.

Minor fix in test src/test/kotlin/com/zepben/evolve/streaming/data/SetCurrentStatesStatusTest.kt

Updated docu and removed Java code example for `UpdateNetworkStateService` because we don't have interop implemented.

# Associated tasks

None.

# Test Steps

Test by using the service interface.

# Checklist

If any of these are not applicable, strikethrough the line `~like this~`. **Do not delete it!**. Let the reviewer decide if you should have done it.

### Code
- [x] I have performed a self review of my own code (including checking issues raised when creating the PR).
- [x] I have added/updated unit tests for these changes, and if not I have explained why they are not necessary.
- [x] I have commented my code in any hard-to-understand or hacky areas.
- [x] I have handled all new warnings generated by the compiler or IDE.
- [x] I have rebased onto the target branch (usually main).

### Documentation
- [x] I have updated the changelog.
Changes are related to unreleased version. No changelog update required.
- [x] I have updated any documentation required for these changes.

# Breaking Changes
- [x] I have considered if this is a breaking change and will communicate it with other team members if so.

No breaking change.
