### PR TITLE
[DEV-2034] Updates for new network state responses.

### DIFF
--- a/docs/docs/update-network-state-client.mdx
+++ b/docs/docs/update-network-state-client.mdx
@@ -15,7 +15,7 @@ wrapper for the gRPC library, with the ability to update information about the s
 
 ## Creating a gRPC channel
 
-The channel gRPC channel can be directly from the gPRC libray, or the channel wrapped in our `GrpcChannel` helper, which implements the `AutoClosable` interface
+The channel gRPC channel can be directly from the gPRC library, or the channel wrapped in our `GrpcChannel` helper, which implements the `AutoClosable` interface
 and performs shutdown operations for you. At its most basic, this can be achieved with:
 
 <Tabs

--- a/docs/docs/update-network-state-client.mdx
+++ b/docs/docs/update-network-state-client.mdx
@@ -197,8 +197,6 @@ client.setCurrentStates(batches).forEach { response ->
 Each batch will receive its own response, which will be one of the following:
 * `BatchSuccessful` - Indicates that all events in the batch were processed successfully. Events that are ignored because they set the state to one that is
   already present, or are skipped due to a later event applying the opposite action, will be marked as successful.
-* `ProcessingPaused` - Indicates the entire batch was ignore as current state processing in teh server is currently paused. The response will include the time
-  the server was paused.
 * `BatchFailure` - Indicates at least one event in the batch could not be applied. Each event that failed will indicate why it failed, some of which will have
   more impact than others.
   * `StateEventUnknownMrid` - The `mRID` of the event could not be found in the network hosted by this server.
@@ -207,6 +205,10 @@ Each batch will receive its own response, which will be one of the following:
     `mRID` that belongs to a `Cut`.
   * `StateEventUnsupportedPhasing` - You tried to specify phases that do not make sense to the item being updated. When using the default phasing of `NONE` you
     will never receive this error. Until un-ganged switching is supported, this error will be returned for all events that specify phases.
+  * `StateEventUnsupportedMrid` - The `mRID` provided can't be used to perform the given action even though it is of the correct type. e.g. Trying to open/close
+   a switch in a voltage level that hasn't been implemented in the server.
+
+* `BatchNotProcessed` - Indicates the entire batch was ignored because the message ID of the batch was prior to the last processed batch.
 
 You can check the type of response or failure by check against the types from `com.zepben.evolve.streaming.data.*`
 <Tabs

--- a/pom.xml
+++ b/pom.xml
@@ -74,7 +74,7 @@
         <dependency>
             <groupId>com.zepben.protobuf</groupId>
             <artifactId>evolve-grpc</artifactId>
-            <version>0.33.0-SNAPSHOT1</version>
+            <version>0.33.0-SNAPSHOT2</version>
         </dependency>
 
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -74,7 +74,7 @@
         <dependency>
             <groupId>com.zepben.protobuf</groupId>
             <artifactId>evolve-grpc</artifactId>
-            <version>0.32.0-SNAPSHOT1</version>
+            <version>0.33.0-SNAPSHOT1</version>
         </dependency>
 
         <dependency>

--- a/src/main/kotlin/com/zepben/evolve/streaming/data/CurrentStateEventBatch.kt
+++ b/src/main/kotlin/com/zepben/evolve/streaming/data/CurrentStateEventBatch.kt
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2024 Zeppelin Bend Pty Ltd
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+package com.zepben.evolve.streaming.data
+
+/**
+ * A collection of events that should be operated on as a batch.
+ *
+ * @property batchId A unique identifier for the batch of events being processed.
+ * This allows to track or group multiple events under a single batch.
+ *
+ * @property events A list of [CurrentStateEvent] objects representing the state changes or
+ * events that are being applied in the current batch.
+ */
+data class CurrentStateEventBatch(
+    val batchId: Long,
+    val events: List<CurrentStateEvent>
+)

--- a/src/main/kotlin/com/zepben/evolve/streaming/data/SetCurrentStatesStatus.kt
+++ b/src/main/kotlin/com/zepben/evolve/streaming/data/SetCurrentStatesStatus.kt
@@ -128,7 +128,10 @@ sealed class StateEventFailure(val eventId: String, val message: String) {
      * Creates a [PBStateEventFailure] with [eventId] assigned along with the specified [block].
      */
     protected fun toPb(block: PBStateEventFailure.Builder.() -> Unit): PBStateEventFailure =
-        PBStateEventFailure.newBuilder().also { it.eventId = eventId }.apply(block).build()
+        PBStateEventFailure.newBuilder().also {
+            it.eventId = eventId
+            it.message = message
+        }.apply(block).build()
 
 }
 

--- a/src/main/kotlin/com/zepben/evolve/streaming/data/SetCurrentStatesStatus.kt
+++ b/src/main/kotlin/com/zepben/evolve/streaming/data/SetCurrentStatesStatus.kt
@@ -11,15 +11,17 @@ package com.zepben.evolve.streaming.data
 import com.zepben.evolve.services.common.translator.toLocalDateTime
 import com.zepben.evolve.services.common.translator.toTimestamp
 import java.time.LocalDateTime
+import com.zepben.protobuf.ns.SetCurrentStatesResponse as PBSetCurrentStatesResponse
 import com.zepben.protobuf.ns.data.BatchFailure as PBBatchFailure
+import com.zepben.protobuf.ns.data.BatchNotProcessed as PBBatchNotProcessed
 import com.zepben.protobuf.ns.data.BatchSuccessful as PBBatchSuccessful
 import com.zepben.protobuf.ns.data.ProcessingPaused as PBProcessingPaused
 import com.zepben.protobuf.ns.data.StateEventDuplicateMrid as PBStateEventDuplicateMrid
 import com.zepben.protobuf.ns.data.StateEventFailure as PBStateEventFailure
 import com.zepben.protobuf.ns.data.StateEventInvalidMrid as PBStateEventInvalidMrid
 import com.zepben.protobuf.ns.data.StateEventUnknownMrid as PBStateEventUnknownMrid
+import com.zepben.protobuf.ns.data.StateEventUnsupportedMrid as PBStateEventUnsupportedMrid
 import com.zepben.protobuf.ns.data.StateEventUnsupportedPhasing as PBStateEventUnsupportedPhasing
-import com.zepben.protobuf.ns.SetCurrentStatesResponse as PBSetCurrentStatesResponse
 
 /**
  * The outcome of processing this batch of updates.
@@ -35,6 +37,7 @@ sealed class SetCurrentStatesStatus(val batchId: Long) {
                 PBSetCurrentStatesResponse.StatusCase.SUCCESS -> BatchSuccessful.fromPb(pb)
                 PBSetCurrentStatesResponse.StatusCase.PAUSED -> ProcessingPaused.fromPb(pb)
                 PBSetCurrentStatesResponse.StatusCase.FAILURE -> BatchFailure.fromPb(pb)
+                PBSetCurrentStatesResponse.StatusCase.NOTPROCESSED -> BatchNotProcessed.fromPb(pb)
                 else -> null
             }
     }
@@ -45,7 +48,8 @@ sealed class SetCurrentStatesStatus(val batchId: Long) {
      * Creates a [PBSetCurrentStatesResponse] with messageId assigned along with the specified [block].
      */
     protected fun toPb(block: PBSetCurrentStatesResponse.Builder.() -> Unit): PBSetCurrentStatesResponse =
-        PBSetCurrentStatesResponse.newBuilder().also { it.messageId = batchId }.apply(block).build()
+        PBSetCurrentStatesResponse.newBuilder().setMessageId(batchId).apply(block).build()
+
 }
 
 /**
@@ -54,7 +58,7 @@ sealed class SetCurrentStatesStatus(val batchId: Long) {
 class BatchSuccessful(batchId: Long) : SetCurrentStatesStatus(batchId) {
 
     companion object {
-        internal fun fromPb(pb: PBSetCurrentStatesResponse): SetCurrentStatesStatus =
+        internal fun fromPb(pb: PBSetCurrentStatesResponse): BatchSuccessful =
             BatchSuccessful(pb.messageId)
     }
 
@@ -72,7 +76,7 @@ class BatchSuccessful(batchId: Long) : SetCurrentStatesStatus(batchId) {
 class ProcessingPaused(batchId: Long, val since: LocalDateTime?) : SetCurrentStatesStatus(batchId) {
 
     companion object {
-        internal fun fromPb(pb: PBSetCurrentStatesResponse): SetCurrentStatesStatus =
+        internal fun fromPb(pb: PBSetCurrentStatesResponse): ProcessingPaused =
             ProcessingPaused(pb.messageId, pb.paused.since.toLocalDateTime())
     }
 
@@ -90,7 +94,7 @@ class ProcessingPaused(batchId: Long, val since: LocalDateTime?) : SetCurrentSta
 class BatchFailure(batchId: Long, val partialFailure: Boolean, val failures: List<StateEventFailure>) : SetCurrentStatesStatus(batchId) {
 
     companion object {
-        internal fun fromPb(pb: PBSetCurrentStatesResponse): SetCurrentStatesStatus =
+        internal fun fromPb(pb: PBSetCurrentStatesResponse): BatchFailure =
             BatchFailure(pb.messageId, pb.failure.partialFailure, pb.failure.failedList.mapNotNull { StateEventFailure.fromPb(it) })
     }
 
@@ -105,11 +109,29 @@ class BatchFailure(batchId: Long, val partialFailure: Boolean, val failures: Lis
 }
 
 /**
+ * A response indicating all items in the batch were ignored because the message ID of the batch was prior to the
+ * last processed batch. This is expected when starting the service if the same item is sent to the current state
+ * processing queue and is also included in the backlog processing response.
+ */
+class BatchNotProcessed(batchId: Long) : SetCurrentStatesStatus(batchId) {
+
+    companion object {
+        internal fun fromPb(pb: PBSetCurrentStatesResponse): BatchNotProcessed =
+            BatchNotProcessed(pb.messageId)
+    }
+
+    override fun toPb(): PBSetCurrentStatesResponse =
+        toPb { notProcessed = PBBatchNotProcessed.newBuilder().build() }
+
+}
+
+/**
  * A wrapper class for allowing a one-of to be repeated.
  *
  * @property eventId The eventId of the state event that failed.
+ * @property message A message describing why the event failed.
  */
-sealed class StateEventFailure(val eventId: String) {
+sealed class StateEventFailure(val eventId: String, val message: String) {
 
     companion object {
         internal fun fromPb(pb: PBStateEventFailure): StateEventFailure? =
@@ -118,6 +140,7 @@ sealed class StateEventFailure(val eventId: String) {
                 PBStateEventFailure.ReasonCase.DUPLICATEMRID -> StateEventDuplicateMrid.fromPb(pb)
                 PBStateEventFailure.ReasonCase.INVALIDMRID -> StateEventInvalidMrid.fromPb(pb)
                 PBStateEventFailure.ReasonCase.UNSUPPORTEDPHASING -> StateEventUnsupportedPhasing.fromPb(pb)
+                PBStateEventFailure.ReasonCase.UNSUPPORTEDMRID -> StateEventUnsupportedMrid.fromPb(pb)
                 else -> null
             }
     }
@@ -135,11 +158,11 @@ sealed class StateEventFailure(val eventId: String) {
 /**
  * The requested mRID was not found in the network.
  */
-class StateEventUnknownMrid(eventId: String) : StateEventFailure(eventId) {
+class StateEventUnknownMrid(eventId: String, message: String) : StateEventFailure(eventId, message) {
 
     companion object {
         internal fun fromPb(pb: PBStateEventFailure): StateEventFailure =
-            StateEventUnknownMrid(pb.eventId)
+            StateEventUnknownMrid(pb.eventId, pb.message)
     }
 
     override fun toPb(): PBStateEventFailure = toPb {
@@ -151,11 +174,11 @@ class StateEventUnknownMrid(eventId: String) : StateEventFailure(eventId) {
 /**
  * The requested mRID already existed in the network and can't be used.
  */
-class StateEventDuplicateMrid(eventId: String) : StateEventFailure(eventId) {
+class StateEventDuplicateMrid(eventId: String, message: String) : StateEventFailure(eventId, message) {
 
     companion object {
         internal fun fromPb(pb: PBStateEventFailure): StateEventFailure =
-            StateEventDuplicateMrid(pb.eventId)
+            StateEventDuplicateMrid(pb.eventId, pb.message)
     }
 
     override fun toPb(): PBStateEventFailure = toPb {
@@ -167,11 +190,11 @@ class StateEventDuplicateMrid(eventId: String) : StateEventFailure(eventId) {
 /**
  * The requested mRID was found in the network model, but was of an invalid type.
  */
-class StateEventInvalidMrid(eventId: String) : StateEventFailure(eventId) {
+class StateEventInvalidMrid(eventId: String, message: String) : StateEventFailure(eventId, message) {
 
     companion object {
         internal fun fromPb(pb: PBStateEventFailure): StateEventFailure =
-            StateEventInvalidMrid(pb.eventId)
+            StateEventInvalidMrid(pb.eventId, pb.message)
     }
 
     override fun toPb(): PBStateEventFailure = toPb {
@@ -184,15 +207,32 @@ class StateEventInvalidMrid(eventId: String) : StateEventFailure(eventId) {
  * The requested phasing was not available for the given operation. e.g. An open state request was made with
  * unsupported phases.
  */
-class StateEventUnsupportedPhasing(eventId: String) : StateEventFailure(eventId) {
+class StateEventUnsupportedPhasing(eventId: String, message: String) : StateEventFailure(eventId, message) {
 
     companion object {
         internal fun fromPb(pb: PBStateEventFailure): StateEventFailure =
-            StateEventUnsupportedPhasing(pb.eventId)
+            StateEventUnsupportedPhasing(pb.eventId, pb.message)
     }
 
     override fun toPb(): PBStateEventFailure = toPb {
         unsupportedPhasing = PBStateEventUnsupportedPhasing.newBuilder().build()
+    }
+
+}
+
+/**
+ * The mRID provided can't be used to perform the given action even though it is of the correct type. e.g. Trying to
+ * open/close a switch in a voltage level that hasn't been implemented in the server.
+ */
+class StateEventUnsupportedMrid(eventId: String, message: String) : StateEventFailure(eventId, message) {
+
+    companion object {
+        internal fun fromPb(pb: PBStateEventFailure): StateEventFailure =
+            StateEventUnsupportedMrid(pb.eventId, pb.message)
+    }
+
+    override fun toPb(): PBStateEventFailure = toPb {
+        unsupportedMrid = PBStateEventUnsupportedMrid.newBuilder().build()
     }
 
 }

--- a/src/main/kotlin/com/zepben/evolve/streaming/get/QueryNetworkStateClient.kt
+++ b/src/main/kotlin/com/zepben/evolve/streaming/get/QueryNetworkStateClient.kt
@@ -10,6 +10,7 @@ package com.zepben.evolve.streaming.get
 
 import com.zepben.evolve.services.common.translator.toTimestamp
 import com.zepben.evolve.streaming.data.CurrentStateEvent
+import com.zepben.evolve.streaming.data.CurrentStateEventBatch
 import com.zepben.evolve.streaming.grpc.GrpcChannel
 import com.zepben.evolve.streaming.grpc.GrpcClient
 import com.zepben.protobuf.ns.GetCurrentStatesRequest
@@ -71,10 +72,10 @@ class QueryNetworkStateClient(
      * @return A [Sequence] of [List]s of [CurrentStateEvent] objects, where each list represents a
      * collection of network state events in the specified time range.
      */
-    fun getCurrentStates(queryId: Long, from: LocalDateTime, to: LocalDateTime): Sequence<List<CurrentStateEvent>>{
-        val results = mutableListOf<List<CurrentStateEvent>>()
+    fun getCurrentStates(queryId: Long, from: LocalDateTime, to: LocalDateTime): Sequence<CurrentStateEventBatch> {
+        val results = mutableListOf<CurrentStateEventBatch>()
         val responseObserver = AwaitableStreamObserver<GetCurrentStatesResponse>{ response ->
-            results.add(response.eventList.map { CurrentStateEvent.fromPb(it) })
+            results.add(CurrentStateEventBatch(response.messageId, response.eventList.map { CurrentStateEvent.fromPb(it) }))
         }
         val request = GetCurrentStatesRequest.newBuilder().also {
             it.messageId = queryId
@@ -100,7 +101,7 @@ class QueryNetworkStateClient(
      * @return A [Stream] of [List]s of [CurrentStateEvent] objects, where each list represents a collection
      * of network state events in the specified time range.
      */
-    fun getCurrentStatesStream(queryId: Long, from: LocalDateTime, to: LocalDateTime): Stream<List<CurrentStateEvent>> =
+    fun getCurrentStatesStream(queryId: Long, from: LocalDateTime, to: LocalDateTime): Stream<CurrentStateEventBatch> =
         getCurrentStates(queryId, from, to).asStream()
 
 }

--- a/src/main/kotlin/com/zepben/evolve/streaming/get/QueryNetworkStateService.kt
+++ b/src/main/kotlin/com/zepben/evolve/streaming/get/QueryNetworkStateService.kt
@@ -8,11 +8,16 @@
 
 package com.zepben.evolve.streaming.get
 
+import com.google.protobuf.Empty
+import com.zepben.evolve.conn.grpc.GrpcException
 import com.zepben.evolve.services.common.translator.toLocalDateTime
 import com.zepben.evolve.streaming.data.CurrentStateEvent
+import com.zepben.evolve.streaming.data.CurrentStateEventBatch
+import com.zepben.evolve.streaming.data.SetCurrentStatesStatus
 import com.zepben.protobuf.ns.GetCurrentStatesRequest
 import com.zepben.protobuf.ns.GetCurrentStatesResponse
 import com.zepben.protobuf.ns.QueryNetworkStateServiceGrpc
+import com.zepben.protobuf.ns.SetCurrentStatesResponse
 import io.grpc.Status
 import io.grpc.stub.StreamObserver
 import java.time.LocalDateTime
@@ -28,68 +33,141 @@ import kotlin.streams.asSequence
  *
  * @property onGetCurrentStates A function that retrieves a sequence of lists of
  * [CurrentStateEvent] objects within the specified time range.
+ * @property onCurrentStatesStatus A callback triggered when the response status
+ * of an event returned via [onGetCurrentStates] is received from the client.
+ * @property onProcessingError A function that takes a [GrpcException] object. Called when [onCurrentStatesStatus]
+ * throws an exception, or the [SetCurrentStatesResponse] is for an unknown event status.
  */
 class QueryNetworkStateService(
-    private val onGetCurrentStates: (from: LocalDateTime?, to: LocalDateTime?) -> Sequence<List<CurrentStateEvent>>
+    private val onGetCurrentStates: (from: LocalDateTime?, to: LocalDateTime?) -> Sequence<CurrentStateEventBatch>,
+    private val onCurrentStatesStatus: (SetCurrentStatesStatus) -> Unit,
+    private val onProcessingError: (GrpcException) -> Unit = {},
 ) : QueryNetworkStateServiceGrpc.QueryNetworkStateServiceImplBase() {
 
     /**
-     * Secondary constructor for Java compatibility that initializes the service using
-     * a method that returns Stream for retrieving current states.
+     * Secondary constructor for Java compatibility.
      *
      * @param onGetCurrentStates A [GetCurrentStates] functional interface that provides
      * a method to fetch current state events.
+     * @param onCurrentStatesStatus A [CurrentStatesStatusHandler] functional interface that provides a method which
+     * is called when the response status of an event returned via [onGetCurrentStates] is received from the client.
+     * @param onProcessingError A [ProcessingErrorHandler] functional interface that provides a method which is
+     * called when there is an error handling a response status of an event.
      *
      * Examples:
-     * ```
-     * //Lambda expression
-     * QueryNetworkStateService service = new QueryNetworkStateService((QueryNetworkStateService.GetCurrentStates) (from, to) -> Stream.of(List.of()));
+     * ```java
+     * // Lambda expression
+     * QueryNetworkStateService service = new QueryNetworkStateService(
+     *     (QueryNetworkStateService.GetCurrentStates) (from, to) -> Stream.of(List.of()),
+     *     (QueryNetworkStateService.CurrentStatesStatusHandler) (eventStatus) -> System.out.println(eventStatus.getBatchId()),
+     *     (QueryNetworkStateService.ProcessingErrorHandler) (error) -> error.printStackTrace(System.out)
+     * );
      *
-     * //Method reference
+     * // Method reference
      * public class QueryNetworkStateServiceImpl {
-     *     QueryNetworkStateService service = new QueryNetworkStateService(this::getCurrentStates);
      *
-     *     Stream<List<CurrentStateEvent>> getCurrentStates(LocalDateTime from, LocalDateTime to){
+     *     QueryNetworkStateService service = new QueryNetworkStateService(
+     *         this::getCurrentStates,
+     *         this::onBatchStatus,
+     *         this::onProcessorError
+     *     );
+     *
+     *     Stream<List<CurrentStateEvent>> getCurrentStates(LocalDateTime from, LocalDateTime to) {
      *         // implementation here
      *         return Stream.of(List.of());
      *     }
+     *
+     *     void onBatchStatus(SetCurrentStatesStatus eventStatus) {
+     *         // implementation here
+     *         System.out.println(eventStatus.getBatchId());
+     *     }
+     *
+     *     void onProcessorError(GrpcException error) {
+     *         // implementation here
+     *         error.printStackTrace(System.out);
+     *     }
+     *
      * }
      * ```
      */
-    constructor(onGetCurrentStates: GetCurrentStates) : this({ from, to -> onGetCurrentStates.get(from, to).asSequence() })
+    @JvmOverloads
+    constructor(
+        onGetCurrentStates: GetCurrentStates,
+        onCurrentStatesStatus: CurrentStatesStatusHandler,
+        onProcessingError: ProcessingErrorHandler = ProcessingErrorHandler {},
+    ) :
+        this(
+            { from, to -> onGetCurrentStates.get(from, to).asSequence() },
+            { eventStatus -> onCurrentStatesStatus.handle(eventStatus) },
+            { error -> onProcessingError.handle(error) }
+        )
 
     /**
      * Handles the incoming request for retrieving current state events.
      *
-     * This method processes the provided [GetCurrentStatesRequest], retrieves the
-     * corresponding current state events using the callback function passed in
-     * the constructor, and sends the response back through the provided [StreamObserver].
+     * You shouldn't be calling this method directly, it will be invoked automatically via the gRPC engine. Each
+     * [GetCurrentStatesRequest] retrieves the corresponding current state events using the [onGetCurrentStates]
+     * callback function passed in the constructor, and sends the response back through the provided [StreamObserver].
+     *
      * It acts as a bridge between the gRPC request and the business logic that fetches the current state events.
      *
-     * @param request The request object containing parameters for fetching current
-     * state events, including the time range for the query. This parameter must not be null.
-     * @param responseObserver The observer used to send the response back to the
-     * client. This parameter must not be null.
+     * @param request The request object containing parameters for fetching current state events, including the time
+     * range for the query.
+     * @param responseObserver The observer used to send responses back to the client.
      */
     override fun getCurrentStates(request: GetCurrentStatesRequest, responseObserver: StreamObserver<GetCurrentStatesResponse>) {
         try {
             val from = request.fromTimestamp.toLocalDateTime()
             val to = request.toTimestamp.toLocalDateTime()
 
-            onGetCurrentStates(from, to).forEach { sendResponse(it, request.messageId, responseObserver) }
+            onGetCurrentStates(from, to).forEach { batch ->
+                val response = GetCurrentStatesResponse.newBuilder()
+                    .setMessageId(batch.batchId)
+                    .addAllEvent(batch.events.map { it.toPb() })
+                    .build()
+
+                responseObserver.onNext(response)
+            }
 
             responseObserver.onCompleted()
         } catch (e: Throwable) {
-            responseObserver.onError(Status.INTERNAL.withDescription(e.localizedMessage).asRuntimeException())
+            responseObserver.onError(Status.fromThrowable(e).asRuntimeException())
         }
     }
 
-    private fun sendResponse(currentStateEvents: List<CurrentStateEvent>, messageId: Long, responseObserver: StreamObserver<GetCurrentStatesResponse>) {
-        val responseBuilder = GetCurrentStatesResponse.newBuilder()
-        responseBuilder.setMessageId(messageId)
-        responseBuilder.addAllEvent(currentStateEvents.map { it.toPb() })
-        responseObserver.onNext(responseBuilder.build())
-    }
+    /**
+     * Handles incoming status reports in response to an event batch returned via [getCurrentStates].
+     *
+     * You shouldn't be calling this method directly, it will be invoked automatically via the gRPC engine. Each
+     * [SetCurrentStatesResponse] will trigger the [onCurrentStatesStatus] callback function passed in the constructor.
+     *
+     * It acts as a bridge between the gRPC request and the business logic that validates/logs the status of event
+     * handling. Any errors in this handling, or unexpected status message will trigger the [onProcessingError]
+     * callback function passed in the constructor.
+     *
+     * @param responseObserver The observer used to a completion back to the client.
+     * @return An observer the gRPC engine can use on each request it receives.
+     */
+    override fun reportBatchStatus(responseObserver: StreamObserver<Empty>): StreamObserver<SetCurrentStatesResponse> =
+        object : StreamObserver<SetCurrentStatesResponse> {
+            override fun onNext(statusResponse: SetCurrentStatesResponse) {
+                val status = SetCurrentStatesStatus.fromPb(statusResponse)
+                if (status != null) {
+                    try {
+                        onCurrentStatesStatus(status)
+                    } catch (e: Throwable) {
+                        val message = "Exception thrown in status response handler for batch `${statusResponse.messageId}`: ${e.localizedMessage}"
+                        onProcessingError(GrpcException(message, e))
+                    }
+                } else
+                    onProcessingError(GrpcException("Failed to decode status response for batch `${statusResponse.messageId}`: Unsupported type ${statusResponse.statusCase}"))
+            }
+
+            override fun onError(e: Throwable) = throw e
+
+            override fun onCompleted() = responseObserver.onCompleted()
+
+        }
 
     /**
      * A functional interface that defines a contract for retrieving current state events
@@ -100,7 +178,7 @@ class QueryNetworkStateService(
      * to fetch current state events based on the provided start and end
      * timestamps.
      */
-    interface GetCurrentStates {
+    fun interface GetCurrentStates {
         /**
          * Retrieves a stream of lists of current state events that occur
          * between the specified time range.
@@ -113,7 +191,34 @@ class QueryNetworkStateService(
          * represent the current states within the specified time range.
          * If no events are found, an empty stream is returned.
          */
-        fun get(from: LocalDateTime?, to: LocalDateTime?): Stream<List<CurrentStateEvent>>
+        fun get(from: LocalDateTime?, to: LocalDateTime?): Stream<CurrentStateEventBatch>
+    }
+
+    /**
+     * A functional interface that defines a contract for processing responses to current
+     * state events returned from the client. This interface can be used as a lambda expression
+     * or method reference, providing a concise way to implement the handling logic.
+     */
+    fun interface CurrentStatesStatusHandler {
+        /**
+         * Handle the status of an event.
+         *
+         * @param eventStatus The status of an event.
+         */
+        fun handle(eventStatus: SetCurrentStatesStatus)
+    }
+
+    /**
+     * A functional interface that defines a contract for handling a [GrpcException] object raised when [onCurrentStatesStatus]
+     * throws an exception, or the [SetCurrentStatesResponse] is for an unknown event status.
+     */
+    fun interface ProcessingErrorHandler {
+        /**
+         * Handle an error raised in the processing of event status responses.
+         *
+         * @param error A [GrpcException] indicating what went wrong in the processing.
+         */
+        fun handle(error: GrpcException)
     }
 
 }

--- a/src/main/kotlin/com/zepben/evolve/streaming/mutations/UpdateNetworkStateClient.kt
+++ b/src/main/kotlin/com/zepben/evolve/streaming/mutations/UpdateNetworkStateClient.kt
@@ -8,7 +8,9 @@
 
 package com.zepben.evolve.streaming.mutations
 
-import com.zepben.evolve.streaming.data.*
+import com.zepben.evolve.streaming.data.CurrentStateEvent
+import com.zepben.evolve.streaming.data.CurrentStateEventBatch
+import com.zepben.evolve.streaming.data.SetCurrentStatesStatus
 import com.zepben.evolve.streaming.get.AwaitableStreamObserver
 import com.zepben.evolve.streaming.grpc.GrpcChannel
 import com.zepben.evolve.streaming.grpc.GrpcClient
@@ -74,7 +76,7 @@ class UpdateNetworkStateClient(
      * being processed by the service.
      */
     fun setCurrentStates(batchId: Long, batch: List<CurrentStateEvent>): SetCurrentStatesStatus =
-        setCurrentStates(sequenceOf(SetCurrentStatesRequest(batchId, batch))).first()
+        setCurrentStates(sequenceOf(CurrentStateEventBatch(batchId, batch))).first()
 
     /**
      * Sends batches of current state events to the gRPC service for processing.
@@ -82,13 +84,13 @@ class UpdateNetworkStateClient(
      * This method is responsible for streaming a sequence of current state event batches to the
      * `UpdateNetworkStateServiceGrpc` service using the gRPC stub provided in the constructor.
      *
-     * @param batches A sequence of [SetCurrentStatesRequest] objects, where each request contains a
+     * @param batches A sequence of [CurrentStateEventBatch] objects, where each request contains a
      * collection of [CurrentStateEvent] objects to be processed by the gRPC service.
      *
      * @return A sequence of [SetCurrentStatesStatus] objects representing the status of each batch
      * after being processed by the service.
      */
-    fun setCurrentStates(batches: Sequence<SetCurrentStatesRequest>): Sequence<SetCurrentStatesStatus> {
+    fun setCurrentStates(batches: Sequence<CurrentStateEventBatch>): Sequence<SetCurrentStatesStatus> {
         val results = mutableListOf<SetCurrentStatesStatus>()
         val responseObserver = AwaitableStreamObserver<PBSetCurrentStatesResponse> { response ->
             SetCurrentStatesStatus.fromPb(response)?.also { results.add(it) }
@@ -115,27 +117,13 @@ class UpdateNetworkStateClient(
      * This method streams batches of current state events to the `UpdateNetworkStateServiceGrpc` service
      * using the gRPC stub provided in the constructor.
      *
-     * @param batches A Java [Stream] of [SetCurrentStatesRequest] objects, where each request contains a
+     * @param batches A Java [Stream] of [CurrentStateEventBatch] objects, where each request contains a
      * collection of [CurrentStateEvent] objects to be processed by the gRPC service.
      *
      * @return A Java [Stream] of [SetCurrentStatesStatus] objects representing the status of each batch
      * after being processed by the service.
      */
-    fun setCurrentStates(batches: Stream<SetCurrentStatesRequest>): Stream<SetCurrentStatesStatus> =
+    fun setCurrentStates(batches: Stream<CurrentStateEventBatch>): Stream<SetCurrentStatesStatus> =
         setCurrentStates(batches.asSequence()).asStream()
-
-    /**
-     * A request object for submitting a batch of current state events for processing.
-     *
-     * @property batchId A unique identifier for the batch of events being processed.
-     * This allows to track or group multiple events under a single batch.
-     *
-     * @property events A list of [CurrentStateEvent] objects representing the state changes or
-     * events that are being submitted in the current batch.
-     */
-    data class SetCurrentStatesRequest(
-        val batchId: Long,
-        val events: List<CurrentStateEvent>
-    )
 
 }

--- a/src/test/kotlin/com/zepben/evolve/streaming/data/CurrentStateEventTest.kt
+++ b/src/test/kotlin/com/zepben/evolve/streaming/data/CurrentStateEventTest.kt
@@ -16,18 +16,19 @@ import org.hamcrest.CoreMatchers.instanceOf
 import org.hamcrest.MatcherAssert.assertThat
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
-import com.zepben.protobuf.ns.data.CurrentStateEvent as PBCurrentStateEvent
-import com.zepben.protobuf.ns.data.SwitchStateEvent as PBSwitchStateEvent
+import com.zepben.protobuf.cim.iec61970.base.core.PhaseCode as PBPhaseCode
 import com.zepben.protobuf.ns.data.AddCutEvent as PBAddCutEvent
-import com.zepben.protobuf.ns.data.RemoveCutEvent as PBRemoveCutEvent
 import com.zepben.protobuf.ns.data.AddJumperEvent as PBAddJumperEvent
+import com.zepben.protobuf.ns.data.CurrentStateEvent as PBCurrentStateEvent
+import com.zepben.protobuf.ns.data.RemoveCutEvent as PBRemoveCutEvent
 import com.zepben.protobuf.ns.data.RemoveJumperEvent as PBRemoveJumperEvent
 import com.zepben.protobuf.ns.data.SwitchAction as PBSwitchAction
-import com.zepben.protobuf.cim.iec61970.base.core.PhaseCode as PBPhaseCode
+import com.zepben.protobuf.ns.data.SwitchStateEvent as PBSwitchStateEvent
 
-class CurrentStateEventTest {
+internal class CurrentStateEventTest {
+
     @Test
-    fun `CurrentStateEvent from protobuf`() {
+    internal fun `CurrentStateEvent from protobuf`() {
         val stateEvent = CurrentStateEvent.fromPb(PBCurrentStateEvent.newBuilder().apply {
             switch = PBSwitchStateEvent.newBuilder().build()
         }.build())
@@ -36,7 +37,7 @@ class CurrentStateEventTest {
     }
 
     @Test
-    fun `CurrentStateEvent from protobuf throws UnsupportedException for classes other than switch`() {
+    internal fun `CurrentStateEvent from protobuf throws UnsupportedException for classes other than switch`() {
         notSupportedState { addCut = PBAddCutEvent.newBuilder().build() }
 
         notSupportedState { removeCut = PBRemoveCutEvent.newBuilder().build() }
@@ -47,7 +48,7 @@ class CurrentStateEventTest {
     }
 
     @Test
-    fun `SwitchStateEvent from protobuf and then back to protobuf`() {
+    internal fun `SwitchStateEvent from protobuf and then back to protobuf`() {
         val time = Timestamp.newBuilder().apply { nanos = 1 }.build()
         val event = PBCurrentStateEvent.newBuilder().apply {
             eventId = "event id"
@@ -82,4 +83,5 @@ class CurrentStateEventTest {
             CurrentStateEvent.fromPb(PBCurrentStateEvent.newBuilder().apply(block).build())
         }
     }
+
 }

--- a/src/test/kotlin/com/zepben/evolve/streaming/data/SetCurrentStatesStatusTest.kt
+++ b/src/test/kotlin/com/zepben/evolve/streaming/data/SetCurrentStatesStatusTest.kt
@@ -16,9 +16,9 @@ import com.zepben.protobuf.ns.data.StateEventFailure as PBStateEventFailure
 internal class SetCurrentStatesStatusTest {
 
     //
-    // NOTE: We don;t bother to check that the correct thing was put into the protobuf variants directly because it is
+    // NOTE: We don't bother to check that the correct thing was put into the protobuf variants directly because it is
     //       assumed that if the resulting object coming out the other side is correct then the intermediate one must
-    //       have been correct (good enough fo us anyway).
+    //       have been correct (good enough for us anyway).
     //
 
     @Test

--- a/src/test/kotlin/com/zepben/evolve/streaming/data/SetCurrentStatesStatusTest.kt
+++ b/src/test/kotlin/com/zepben/evolve/streaming/data/SetCurrentStatesStatusTest.kt
@@ -84,7 +84,7 @@ internal class SetCurrentStatesStatusTest {
 
     @Test
     internal fun `StateEventFailure from protobuf and then back to protobuf`() {
-        val unknowMridPb = PBStateEventFailure.newBuilder().apply {
+        val unknownMridPb = PBStateEventFailure.newBuilder().apply {
             eventId = "event1"
             unknownMrid = PBStateEventUnknownMrid.newBuilder().build()
         }.build()
@@ -99,7 +99,7 @@ internal class SetCurrentStatesStatusTest {
             unsupportedPhasing = PBStateEventUnsupportedPhasing.newBuilder().build()
         }.build()
 
-        testStateEventFailure(unknowMridPb, StateEventUnknownMrid::class.java)
+        testStateEventFailure(unknownMridPb, StateEventUnknownMrid::class.java)
         testStateEventFailure(duplicateMridPb, StateEventDuplicateMrid::class.java)
         testStateEventFailure(unsupportedPhasingPb, StateEventUnsupportedPhasing::class.java)
         testStateEventFailure(invalidMridPb, StateEventInvalidMrid::class.java)

--- a/src/test/kotlin/com/zepben/evolve/streaming/data/SetCurrentStatesStatusTest.kt
+++ b/src/test/kotlin/com/zepben/evolve/streaming/data/SetCurrentStatesStatusTest.kt
@@ -8,99 +8,71 @@
 
 package com.zepben.evolve.streaming.data
 
-import com.google.protobuf.Timestamp
-import com.zepben.evolve.services.common.translator.toLocalDateTime
-import org.hamcrest.CoreMatchers.*
 import org.hamcrest.MatcherAssert.assertThat
+import org.hamcrest.Matchers.*
 import org.junit.jupiter.api.Test
-import com.zepben.protobuf.ns.SetCurrentStatesResponse as PBSetCurrentStatesResponse
-import com.zepben.protobuf.ns.data.BatchFailure as PBBatchFailure
-import com.zepben.protobuf.ns.data.BatchSuccessful as PBBatchSuccessful
-import com.zepben.protobuf.ns.data.StateEventDuplicateMrid as PBStateEventDuplicateMrid
 import com.zepben.protobuf.ns.data.StateEventFailure as PBStateEventFailure
-import com.zepben.protobuf.ns.data.StateEventInvalidMrid as PBStateEventInvalidMrid
-import com.zepben.protobuf.ns.data.StateEventUnknownMrid as PBStateEventUnknownMrid
-import com.zepben.protobuf.ns.data.StateEventUnsupportedPhasing as PBStateEventUnsupportedPhasing
 
 internal class SetCurrentStatesStatusTest {
 
-    private val invalidMridPb = PBStateEventFailure.newBuilder().apply {
-        eventId = "event2"
-        invalidMrid = PBStateEventInvalidMrid.newBuilder().build()
-    }.build()
+    //
+    // NOTE: We don;t bother to check that the correct thing was put into the protobuf variants directly because it is
+    //       assumed that if the resulting object coming out the other side is correct then the intermediate one must
+    //       have been correct (good enough fo us anyway).
+    //
 
     @Test
-    internal fun `BatchSuccessful from protobuf and then back to protobuf`() {
-        val pb = createSetCurrentStatesResponse { success = PBBatchSuccessful.newBuilder().build() }
+    internal fun `Batch successful to and from protobuf`() {
+        val original = BatchSuccessful(1)
+        val converted = SetCurrentStatesStatus.fromPb(original.toPb())
 
-        val status = SetCurrentStatesStatus.fromPb(pb)
-        assertThat(status, instanceOf(BatchSuccessful::class.java))
-        assertThat(status?.batchId, equalTo(1))
+        assertThat(converted, instanceOf(original.javaClass))
+        assertThat(converted?.batchId, equalTo(original.batchId))
+    }
 
-        status?.toPb()?.also {
-            assertThat(it.messageId, equalTo(1))
-            assertThat(it.statusCase, equalTo(PBSetCurrentStatesResponse.StatusCase.SUCCESS))
+    @Test
+    internal fun `Batch failure to and from protobuf`() {
+        val original = BatchFailure(1, true, listOf(StateEventInvalidMrid("event1", "message1"), StateEventUnsupportedMrid("event2", "message2")))
+        val converted = SetCurrentStatesStatus.fromPb(original.toPb())
+
+        assertThat(converted, instanceOf(original.javaClass))
+        with(converted as BatchFailure) {
+            assertThat(batchId, equalTo(original.batchId))
+            assertThat(partialFailure, equalTo(original.partialFailure))
+
+            assertThat(failures.map { it.javaClass }, contains(StateEventInvalidMrid::class.java, StateEventUnsupportedMrid::class.java))
+            assertThat(failures.map { it.eventId }, contains("event1", "event2"))
+            assertThat(failures.map { it.message }, contains("message1", "message2"))
         }
     }
 
     @Test
-    internal fun `BatchFailure from protobuf and then back to protobuf`() {
-        val pb = createSetCurrentStatesResponse {
-            failure = PBBatchFailure.newBuilder().apply {
-                partialFailure = true
-                addAllFailed(listOf(invalidMridPb))
-            }.build()
-        }
+    internal fun `Batch not processed to and from protobuf`() {
+        val original = BatchNotProcessed(1)
+        val converted = SetCurrentStatesStatus.fromPb(original.toPb())
 
-
-        val status = SetCurrentStatesStatus.fromPb(pb) as BatchFailure
-        assertThat(status.partialFailure, equalTo(pb.failure.partialFailure))
-        assertThat(status.failures.size, equalTo(1))
-        assertThat(status.failures.first(), instanceOf(StateEventInvalidMrid::class.java))
-
-        (status as SetCurrentStatesStatus).toPb().failure.also {
-            assertThat(it.partialFailure, equalTo(pb.failure.partialFailure))
-            assertThat(it.failedList.size, equalTo(1))
-            assertThat(it.failedList.first().reasonCase, equalTo(PBStateEventFailure.ReasonCase.INVALIDMRID))
-        }
+        assertThat(converted, instanceOf(original.javaClass))
+        assertThat(converted?.batchId, equalTo(original.batchId))
     }
 
     @Test
-    internal fun `StateEventFailure from protobuf and then back to protobuf`() {
-        val unknownMridPb = PBStateEventFailure.newBuilder().apply {
-            eventId = "event1"
-            unknownMrid = PBStateEventUnknownMrid.newBuilder().build()
-        }.build()
+    internal fun `State event failures to and from protobuf`() {
+        testStateEventFailure(StateEventUnknownMrid("event1", "unknown mrid message"))
+        testStateEventFailure(StateEventInvalidMrid("event2", "invalid mrid message"))
+        testStateEventFailure(StateEventDuplicateMrid("event3", "duplicate mrid message"))
+        testStateEventFailure(StateEventUnsupportedPhasing("event4", "unsupported phasing message"))
+        testStateEventFailure(StateEventUnsupportedMrid("event5", "unsupported mrid message"))
 
-        val duplicateMridPb = PBStateEventFailure.newBuilder().apply {
-            eventId = "event3"
-            duplicateMrid = PBStateEventDuplicateMrid.newBuilder().build()
-        }.build()
-
-        val unsupportedPhasingPb = PBStateEventFailure.newBuilder().apply {
-            eventId = "event4"
-            unsupportedPhasing = PBStateEventUnsupportedPhasing.newBuilder().build()
-        }.build()
-
-        testStateEventFailure(unknownMridPb, StateEventUnknownMrid::class.java)
-        testStateEventFailure(duplicateMridPb, StateEventDuplicateMrid::class.java)
-        testStateEventFailure(unsupportedPhasingPb, StateEventUnsupportedPhasing::class.java)
-        testStateEventFailure(invalidMridPb, StateEventInvalidMrid::class.java)
+        // Unknown protobuf types return null.
         assertThat(StateEventFailure.fromPb(PBStateEventFailure.newBuilder().build()), nullValue())
     }
 
-    private fun testStateEventFailure(pb: PBStateEventFailure, clazz: Class<out StateEventFailure>) {
-        val state = StateEventFailure.fromPb(pb)
-        assertThat(state?.eventId, equalTo(pb.eventId))
-        assertThat(state, instanceOf(clazz))
+    private fun testStateEventFailure(original: StateEventFailure) {
+        val converted = StateEventFailure.fromPb(original.toPb())
 
-        state?.toPb()?.let {
-            assertThat(it.eventId, equalTo(pb.eventId))
-            assertThat(it.reasonCase, equalTo(pb.reasonCase))
-        }
+        assertThat(converted, instanceOf(original.javaClass))
+        assertThat(converted?.eventId, equalTo(original.eventId))
+        assertThat(converted?.message, equalTo(original.message))
     }
-
-    private fun createSetCurrentStatesResponse(block: PBSetCurrentStatesResponse.Builder.() -> Unit): PBSetCurrentStatesResponse =
-        PBSetCurrentStatesResponse.newBuilder().also { it.messageId = 1 }.apply(block).build()
 
 }

--- a/src/test/kotlin/com/zepben/evolve/streaming/data/SetCurrentStatesStatusTest.kt
+++ b/src/test/kotlin/com/zepben/evolve/streaming/data/SetCurrentStatesStatusTest.kt
@@ -16,7 +16,6 @@ import org.junit.jupiter.api.Test
 import com.zepben.protobuf.ns.SetCurrentStatesResponse as PBSetCurrentStatesResponse
 import com.zepben.protobuf.ns.data.BatchFailure as PBBatchFailure
 import com.zepben.protobuf.ns.data.BatchSuccessful as PBBatchSuccessful
-import com.zepben.protobuf.ns.data.ProcessingPaused as PBProcessingPaused
 import com.zepben.protobuf.ns.data.StateEventDuplicateMrid as PBStateEventDuplicateMrid
 import com.zepben.protobuf.ns.data.StateEventFailure as PBStateEventFailure
 import com.zepben.protobuf.ns.data.StateEventInvalidMrid as PBStateEventInvalidMrid
@@ -41,22 +40,6 @@ internal class SetCurrentStatesStatusTest {
         status?.toPb()?.also {
             assertThat(it.messageId, equalTo(1))
             assertThat(it.statusCase, equalTo(PBSetCurrentStatesResponse.StatusCase.SUCCESS))
-        }
-    }
-
-    @Test
-    internal fun `ProcessingPaused from protobuf and then back to protobuf`() {
-        val pb = createSetCurrentStatesResponse {
-            paused = PBProcessingPaused.newBuilder().apply { since = Timestamp.newBuilder().apply { seconds = 1 }.build() }.build()
-        }
-
-        val status = SetCurrentStatesStatus.fromPb(pb) as ProcessingPaused
-        assertThat(status.since, equalTo(pb.paused.since.toLocalDateTime()))
-        assertThat(status.batchId, equalTo(1))
-
-        (status as SetCurrentStatesStatus).toPb().also {
-            assertThat(it.messageId, equalTo(1))
-            assertThat(it.paused.since, equalTo(pb.paused.since))
         }
     }
 

--- a/src/test/kotlin/com/zepben/evolve/streaming/data/SetCurrentStatesStatusTest.kt
+++ b/src/test/kotlin/com/zepben/evolve/streaming/data/SetCurrentStatesStatusTest.kt
@@ -10,27 +10,28 @@ package com.zepben.evolve.streaming.data
 
 import com.google.protobuf.Timestamp
 import com.zepben.evolve.services.common.translator.toLocalDateTime
-import com.zepben.protobuf.ns.SetCurrentStatesResponse as PBSetCurrentStatesResponse
 import org.hamcrest.CoreMatchers.*
 import org.hamcrest.MatcherAssert.assertThat
 import org.junit.jupiter.api.Test
+import com.zepben.protobuf.ns.SetCurrentStatesResponse as PBSetCurrentStatesResponse
+import com.zepben.protobuf.ns.data.BatchFailure as PBBatchFailure
 import com.zepben.protobuf.ns.data.BatchSuccessful as PBBatchSuccessful
 import com.zepben.protobuf.ns.data.ProcessingPaused as PBProcessingPaused
-import com.zepben.protobuf.ns.data.BatchFailure as PBBatchFailure
-import com.zepben.protobuf.ns.data.StateEventFailure as PBStateEventFailure
-import com.zepben.protobuf.ns.data.StateEventUnknownMrid as PBStateEventUnknownMrid
 import com.zepben.protobuf.ns.data.StateEventDuplicateMrid as PBStateEventDuplicateMrid
+import com.zepben.protobuf.ns.data.StateEventFailure as PBStateEventFailure
 import com.zepben.protobuf.ns.data.StateEventInvalidMrid as PBStateEventInvalidMrid
+import com.zepben.protobuf.ns.data.StateEventUnknownMrid as PBStateEventUnknownMrid
 import com.zepben.protobuf.ns.data.StateEventUnsupportedPhasing as PBStateEventUnsupportedPhasing
 
-class SetCurrentStatesStatusTest {
+internal class SetCurrentStatesStatusTest {
+
     private val invalidMridPb = PBStateEventFailure.newBuilder().apply {
         eventId = "event2"
         invalidMrid = PBStateEventInvalidMrid.newBuilder().build()
     }.build()
 
     @Test
-    fun `BatchSuccessful from protobuf and then back to protobuf`() {
+    internal fun `BatchSuccessful from protobuf and then back to protobuf`() {
         val pb = createSetCurrentStatesResponse { success = PBBatchSuccessful.newBuilder().build() }
 
         val status = SetCurrentStatesStatus.fromPb(pb)
@@ -44,7 +45,7 @@ class SetCurrentStatesStatusTest {
     }
 
     @Test
-    fun `ProcessingPaused from protobuf and then back to protobuf`() {
+    internal fun `ProcessingPaused from protobuf and then back to protobuf`() {
         val pb = createSetCurrentStatesResponse {
             paused = PBProcessingPaused.newBuilder().apply { since = Timestamp.newBuilder().apply { seconds = 1 }.build() }.build()
         }
@@ -60,7 +61,7 @@ class SetCurrentStatesStatusTest {
     }
 
     @Test
-    fun `BatchFailure from protobuf and then back to protobuf`() {
+    internal fun `BatchFailure from protobuf and then back to protobuf`() {
         val pb = createSetCurrentStatesResponse {
             failure = PBBatchFailure.newBuilder().apply {
                 partialFailure = true
@@ -82,7 +83,7 @@ class SetCurrentStatesStatusTest {
     }
 
     @Test
-    fun `StateEventFailure from protobuf and then back to protobuf`() {
+    internal fun `StateEventFailure from protobuf and then back to protobuf`() {
         val unknowMridPb = PBStateEventFailure.newBuilder().apply {
             eventId = "event1"
             unknownMrid = PBStateEventUnknownMrid.newBuilder().build()
@@ -118,4 +119,5 @@ class SetCurrentStatesStatusTest {
 
     private fun createSetCurrentStatesResponse(block: PBSetCurrentStatesResponse.Builder.() -> Unit): PBSetCurrentStatesResponse =
         PBSetCurrentStatesResponse.newBuilder().also { it.messageId = 1 }.apply(block).build()
+
 }

--- a/src/test/kotlin/com/zepben/evolve/streaming/get/QueryNetworkStateServiceTest.kt
+++ b/src/test/kotlin/com/zepben/evolve/streaming/get/QueryNetworkStateServiceTest.kt
@@ -8,20 +8,19 @@
 
 package com.zepben.evolve.streaming.get
 
+import com.google.protobuf.Empty
 import com.google.protobuf.Timestamp
 import com.zepben.evolve.cim.iec61970.base.core.PhaseCode
+import com.zepben.evolve.conn.grpc.GrpcException
 import com.zepben.evolve.services.common.translator.toLocalDateTime
 import com.zepben.evolve.services.common.translator.toTimestamp
-import com.zepben.evolve.streaming.data.CurrentStateEvent
-import com.zepben.evolve.streaming.data.SwitchAction
-import com.zepben.evolve.streaming.data.SwitchStateEvent
+import com.zepben.evolve.streaming.data.*
 import com.zepben.protobuf.ns.GetCurrentStatesRequest
 import com.zepben.protobuf.ns.GetCurrentStatesResponse
-import com.zepben.protobuf.ns.QueryNetworkStateServiceGrpc
+import com.zepben.protobuf.ns.SetCurrentStatesResponse
+import com.zepben.testutils.exception.ExpectException.Companion.expect
 import io.grpc.Status
 import io.grpc.StatusRuntimeException
-import io.grpc.inprocess.InProcessChannelBuilder
-import io.grpc.inprocess.InProcessServerBuilder
 import io.grpc.stub.StreamObserver
 import io.grpc.testing.GrpcCleanupRule
 import io.mockk.*
@@ -31,7 +30,7 @@ import org.junit.Rule
 import org.junit.jupiter.api.Test
 import java.time.LocalDateTime
 
-class QueryNetworkStateServiceTest {
+internal class QueryNetworkStateServiceTest {
 
     @JvmField
     @Rule
@@ -42,100 +41,164 @@ class QueryNetworkStateServiceTest {
         SwitchStateEvent("event2", LocalDateTime.now(), "mrid1", SwitchAction.CLOSE, PhaseCode.ABN),
         SwitchStateEvent("event3", LocalDateTime.now(), "mrid2", SwitchAction.CLOSE, PhaseCode.A)
     )
-    private val switchStateEvents = currentStateEvents.filterIsInstance<SwitchStateEvent>()
-    private val responseCurrentStateEvents = listOf(currentStateEvents.take(2), currentStateEvents.drop(2))
-    private val fromSlot = slot<LocalDateTime>()
-    private val toSlot = slot<LocalDateTime>()
-    private val onGetCurrentStatesSequence = mockk<(from: LocalDateTime?, to: LocalDateTime?) -> Sequence<List<CurrentStateEvent>>>().also {
-        every { it(capture(fromSlot), capture(toSlot)) } returns responseCurrentStateEvents.asSequence()
-    }
-    private val onGetCurrentStatesStream = mockk<QueryNetworkStateService.GetCurrentStates>().also {
-        every { it.get(capture(fromSlot), capture(toSlot)) } returns responseCurrentStateEvents.stream()
-    }
+    private val currentStateEventBatches = listOf(
+        CurrentStateEventBatch(1, currentStateEvents.take(2)),
+        CurrentStateEventBatch(2, currentStateEvents.drop(2))
+    )
 
-    private val serverName = InProcessServerBuilder.generateName()
-    private val channel = grpcCleanup.register(InProcessChannelBuilder.forName(serverName).directExecutor().build())
-    private val stub = QueryNetworkStateServiceGrpc.newStub(channel)
-
-    private val responseSlot = mutableListOf<GetCurrentStatesResponse>()
-    private val responseErrorSlot = slot<Throwable>()
-    private val responseObserver = mockk<StreamObserver<GetCurrentStatesResponse>>().also {
-        justRun { it.onNext(capture(responseSlot)) }
-        justRun { it.onCompleted() }
-        justRun { it.onError(capture(responseErrorSlot)) }
+    // Callbacks for the Kotlin/lambda constructor.
+    private val onGetCurrentStates = mockk<(LocalDateTime?, LocalDateTime?) -> Sequence<CurrentStateEventBatch>>().also {
+        every { it(any(), any()) } returns currentStateEventBatches.asSequence()
     }
-    private val serviceSequence = QueryNetworkStateService(onGetCurrentStatesSequence)
-    private val serviceStream = QueryNetworkStateService(onGetCurrentStatesStream)
-    private val request = GetCurrentStatesRequest.newBuilder().apply {
-        messageId = 1
-        fromTimestamp = Timestamp.newBuilder().apply { nanos = 1 }.build()
-        toTimestamp = Timestamp.newBuilder().apply { seconds = 1 }.build()
-    }.build()
+    private val onCurrentStatesStatus = mockk<(SetCurrentStatesStatus) -> Unit>().also { justRun { it(any()) } }
+    private val onProcessingError = mockk<(GrpcException) -> Unit>().also { justRun { it(any()) } }
+
+    // Callbacks for the Java/interface constructor.
+    private val onGetCurrentStatesInterface = mockk<QueryNetworkStateService.GetCurrentStates> {
+        every { get(any(), any()) } returns currentStateEventBatches.stream()
+    }
+    private val onCurrentStatesStatusInterface = mockk<QueryNetworkStateService.CurrentStatesStatusHandler> { justRun { handle(any()) } }
+    private val onProcessingErrorInterface = mockk<QueryNetworkStateService.ProcessingErrorHandler> { justRun { handle(any()) } }
+
+    private val service = QueryNetworkStateService(onGetCurrentStates, onCurrentStatesStatus, onProcessingError)
+    private val serviceJava = QueryNetworkStateService(onGetCurrentStatesInterface, onCurrentStatesStatusInterface, onProcessingErrorInterface)
 
     @Test
-    fun getCurrentStates() {
-        startGrpcServerWith(serviceSequence)
-
-        stub.getCurrentStates(request, responseObserver)
-        assertGetCurrentStates {
-            verify { onGetCurrentStatesSequence(fromSlot.captured, toSlot.captured) }
+    internal fun getCurrentStates() {
+        service.assertGetCurrentStates { request ->
+            verify { onGetCurrentStates(request.fromTimestamp.toLocalDateTime(), request.toTimestamp.toLocalDateTime()) }
         }
     }
 
     @Test
-    fun `getCurrentStates using Java Streams`() {
-        startGrpcServerWith(serviceStream)
-
-        stub.getCurrentStates(request, responseObserver)
-        assertGetCurrentStates {
-            verify { onGetCurrentStatesStream.get(fromSlot.captured, toSlot.captured) }
+    internal fun `getCurrentStates using Java`() {
+        serviceJava.assertGetCurrentStates { request ->
+            verify { onGetCurrentStatesInterface.get(request.fromTimestamp.toLocalDateTime(), request.toTimestamp.toLocalDateTime()) }
         }
     }
 
     @Test
-    fun `getCurrentStates handles error`(){
-        startGrpcServerWith(serviceSequence)
+    internal fun `getCurrentStates handles error`() {
+        val responseObserver = mockk<StreamObserver<GetCurrentStatesResponse>> { justRun { onError(any()) } }
+        val error = Error("TEST ERROR!")
+        every { onGetCurrentStates(any(), any()) } throws error
 
-        every { onGetCurrentStatesSequence(any(), any()) } throws Error("TEST ERROR!")
+        service.getCurrentStates(GetCurrentStatesRequest.newBuilder().build(), responseObserver)
 
-        serviceSequence.getCurrentStates(request, responseObserver)
+        val responseError = slot<Throwable>()
+        verifySequence { responseObserver.onError(capture(responseError)) }
 
-        verify { responseObserver.onError(responseErrorSlot.captured) }
-        assertThat(responseErrorSlot.captured, instanceOf(StatusRuntimeException::class.java))
-        (responseErrorSlot.captured as StatusRuntimeException).status.let {
-            assertThat(it.code, equalTo(Status.INTERNAL.code))
-            assertThat(it.description, equalTo("TEST ERROR!"))
+        assertThat(responseError.captured, instanceOf(StatusRuntimeException::class.java))
+        (responseError.captured as StatusRuntimeException).status.let {
+            assertThat(it.code, equalTo(Status.UNKNOWN.code))
+            assertThat(it.cause, equalTo(error))
         }
-
-
     }
 
-    private fun assertGetCurrentStates(onAdditionalVerification: (() -> Unit)? = null) {
-        onAdditionalVerification?.let { it() }
+    @Test
+    internal fun `can receive status responses`() {
+        val responseObserver = mockk<StreamObserver<Empty>> { justRun { onCompleted() } }
+        val requestObserver = service.reportBatchStatus(responseObserver)
 
-        assertThat(fromSlot.captured, equalTo(request.fromTimestamp.toLocalDateTime()))
-        assertThat(toSlot.captured, equalTo(request.toTimestamp.toLocalDateTime()))
+        requestObserver.onNext(BatchNotProcessed(1L).toPb())
+        requestObserver.onNext(BatchSuccessful(2L).toPb())
+        requestObserver.onCompleted()
 
-        assertThat(responseSlot.map { it.messageId }, contains(1, 1))
-        responseSlot.flatMap { it.eventList }.also { events ->
-            assertThat(events.map { it.eventId }, contains(*currentStateEvents.map { it.eventId }.toTypedArray()))
-            assertThat(events.map { it.timestamp }, contains(*currentStateEvents.map { it.timestamp.toTimestamp() }.toTypedArray()))
-            assertThat(events.map { it.switch.mrid }, contains(*switchStateEvents.map { it.mRID }.toTypedArray()))
-            assertThat(events.map { it.switch.action.name }, contains(*switchStateEvents.map { it.action.name }.toTypedArray()))
-            assertThat(events.map { it.switch.phases.name }, contains(*switchStateEvents.map { it.phases.name }.toTypedArray()))
-        }
+        val exception = Exception("Test")
+        expect { requestObserver.onError(exception) }.toThrow<Exception>().withMessage("Test")
 
+        val statuses = mutableListOf<SetCurrentStatesStatus>()
         verifySequence {
-            responseObserver.onNext(responseSlot[0])
-            responseObserver.onNext(responseSlot[1])
+            onCurrentStatesStatus(capture(statuses))
+            onCurrentStatesStatus(capture(statuses))
             responseObserver.onCompleted()
         }
+
+        assertThat(statuses.map { it.batchId }, contains(1L, 2L))
+        assertThat(statuses.map { it::class }, contains(BatchNotProcessed::class, BatchSuccessful::class))
     }
 
-    private fun startGrpcServerWith(service: QueryNetworkStateService){
-        grpcCleanup.register(InProcessServerBuilder.forName(serverName).directExecutor()
-            .addService(service)
-            .build().start())
+    @Test
+    internal fun `calls process error handler with unknown status responses`() {
+        val responseObserver = mockk<StreamObserver<Empty>> { justRun { onCompleted() } }
+        val requestObserver = service.reportBatchStatus(responseObserver)
+
+        // Not sure if/how we can set this to something not supported like you would get from a future version, so just leave it blank.
+        requestObserver.onNext(SetCurrentStatesResponse.newBuilder().setMessageId(1).build())
+        requestObserver.onCompleted()
+
+        val error = slot<GrpcException>()
+        verifySequence {
+            onProcessingError(capture(error))
+            responseObserver.onCompleted()
+        }
+
+        assertThat(
+            error.captured.message,
+            equalTo("Failed to decode status response for batch `1`: Unsupported type STATUS_NOT_SET")
+        )
+    }
+
+    @Test
+    internal fun `calls process error handler with exception in status handler`() {
+        val responseObserver = mockk<StreamObserver<Empty>> { justRun { onCompleted() } }
+        val requestObserver = service.reportBatchStatus(responseObserver)
+
+        // Not sure if/how we can set this to something not supported like you would get from a future version, so just leave it blank.
+        requestObserver.onNext(SetCurrentStatesResponse.newBuilder().setMessageId(1).build())
+        requestObserver.onCompleted()
+
+        val error = slot<GrpcException>()
+        verifySequence {
+            onProcessingError(capture(error))
+            responseObserver.onCompleted()
+        }
+
+        assertThat(
+            error.captured.message,
+            equalTo("Failed to decode status response for batch `1`: Unsupported type STATUS_NOT_SET")
+        )
+    }
+
+    private fun QueryNetworkStateService.assertGetCurrentStates(onAdditionalVerification: (GetCurrentStatesRequest) -> Unit = {}) {
+        val request = GetCurrentStatesRequest.newBuilder().apply {
+            messageId = 1
+            fromTimestamp = Timestamp.newBuilder().apply { nanos = 1 }.build()
+            toTimestamp = Timestamp.newBuilder().apply { seconds = 1 }.build()
+        }.build()
+
+        val responseObserver = mockk<StreamObserver<GetCurrentStatesResponse>> {
+            justRun { onNext(any()) }
+            justRun { onCompleted() }
+        }
+
+        // This is called on the receiver.
+        getCurrentStates(request, responseObserver)
+
+        val response1 = slot<GetCurrentStatesResponse>()
+        val response2 = slot<GetCurrentStatesResponse>()
+        verifySequence {
+            responseObserver.onNext(capture(response1))
+            responseObserver.onNext(capture(response2))
+            responseObserver.onCompleted()
+        }
+
+        onAdditionalVerification(request)
+
+        fun GetCurrentStatesResponse.validate(expectedBatch: CurrentStateEventBatch) {
+            assertThat(messageId, equalTo(expectedBatch.batchId))
+
+            assertThat(eventList.map { it.eventId }, contains(*expectedBatch.events.map { it.eventId }.toTypedArray()))
+            assertThat(eventList.map { it.timestamp }, contains(*expectedBatch.events.map { it.timestamp.toTimestamp() }.toTypedArray()))
+
+            val expectedSwitchEvents = expectedBatch.events.filterIsInstance<SwitchStateEvent>()
+            assertThat(eventList.map { it.switch.mrid }, contains(*expectedSwitchEvents.map { it.mRID }.toTypedArray()))
+            assertThat(eventList.map { it.switch.action.name }, contains(*expectedSwitchEvents.map { it.action.name }.toTypedArray()))
+            assertThat(eventList.map { it.switch.phases.name }, contains(*expectedSwitchEvents.map { it.phases.name }.toTypedArray()))
+        }
+
+        response1.captured.validate(currentStateEventBatches[0])
+        response2.captured.validate(currentStateEventBatches[1])
     }
 
 }

--- a/src/test/kotlin/com/zepben/evolve/streaming/mutations/UpdateNetworkStateServiceTest.kt
+++ b/src/test/kotlin/com/zepben/evolve/streaming/mutations/UpdateNetworkStateServiceTest.kt
@@ -12,7 +12,6 @@ import com.google.protobuf.Timestamp
 import com.zepben.evolve.cim.iec61970.base.core.PhaseCode
 import com.zepben.evolve.conn.grpc.GrpcException
 import com.zepben.evolve.services.common.translator.toLocalDateTime
-import com.zepben.evolve.services.common.translator.toTimestamp
 import com.zepben.evolve.streaming.data.*
 import com.zepben.protobuf.ns.SetCurrentStatesRequest
 import com.zepben.protobuf.ns.SetCurrentStatesResponse
@@ -30,7 +29,6 @@ import org.hamcrest.Matchers.*
 import org.junit.Rule
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
-import java.time.LocalDateTime
 import java.util.concurrent.CompletableFuture
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.Executors
@@ -51,7 +49,6 @@ internal class UpdateNetworkStateServiceTest {
     private val eventsSlot = slot<List<CurrentStateEvent>>()
     private val setCurrentStatesReturns = listOf(
         BatchSuccessful(1),
-        ProcessingPaused(1, LocalDateTime.now()),
         BatchFailure(
             1, true, listOf(
                 StateEventUnknownMrid("event id", "we couldn't find it"),
@@ -101,9 +98,6 @@ internal class UpdateNetworkStateServiceTest {
     internal fun setCurrentStates() {
         startGrpcServer()
         setCurrentStatesTest(SetCurrentStatesResponse.StatusCase.SUCCESS)
-        setCurrentStatesTest(SetCurrentStatesResponse.StatusCase.PAUSED) {
-            assertThat(it.paused.since, equalTo((setCurrentStatesReturns[1] as ProcessingPaused).since.toTimestamp()))
-        }
         setCurrentStatesTest(SetCurrentStatesResponse.StatusCase.FAILURE) { response ->
             response.failure.apply {
                 assertThat(partialFailure, equalTo(true))


### PR DESCRIPTION
# Description

Added new status messages to give clarity to how messages have been processed, and a new `rpc` to allowing sending statuses for backlog events.

# Associated tasks

blocked by:
* https://github.com/zepben/ewb-grpc/pull/122

blocking:
* https://github.com/zepben/ewb-network-routes/pull/169
* https://github.com/zepben/network-verifier-lib/pull/55

# Test Steps

Nothing to test really, new functions will be built on this stuff.

# Checklist

If any of these are not applicable, strikethrough the line `~like this~`. **Do not delete it!**. Let the reviewer decide if you should have done it.

### Code
- [x] I have performed a self review of my own code (including checking issues raised when creating the PR).
- [x] I have added/updated unit tests for these changes, and if not I have explained why they are not necessary.
- [x] I have commented my code in any hard-to-understand or hacky areas.
- [x] I have handled all new warnings generated by the compiler or IDE.
- [x] I have rebased onto the target branch (usually main).

### Documentation
~- [ ] I have updated the changelog.~
- [x] I have updated any documentation required for these changes.

# Breaking Changes
- [x] I have considered if this is a breaking change and will communicate it with other team members if so.

Breaking change only impacting yet to be released code.