### PR TITLE
[DEV-1970] current state container enhancements

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,7 @@
 ## [0.24.0] - UNRELEASED
 ### Breaking Changes
 * Database readers and writes for each `BaseService` no longer accept a `MetadataCollection`, and will instead use the collection of the provided service.
+* Removed `getCurrentEquipmentForFeeder` implementation for `NetworkConsumer` as its functionality is now incorporated in `getEquipmentForContainers`.
 
 ### New Features
 * Network state services for updating and querying network state events via gRPC.
@@ -12,7 +13,8 @@
 * Added `connectWithAccessToken()` for connecting to a gRPC service using an access token with SSL/TLS.
 
 ### Enhancements
-* None.
+* Added the energized relationship for the current state of network between `Feeder` and `LvFeeder`.
+* Updated `NetworkConsumer.getEquipmentForContainers` to allow requesting normal, current or all equipments.
 
 ### Fixes
 * None.

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 
     <groupId>com.zepben</groupId>
     <artifactId>evolve-sdk</artifactId>
-    <version>0.24.0-SNAPSHOT9</version>
+    <version>0.24.0-SNAPSHOT9.LOCAL</version>
     <packaging>jar</packaging>
     <name>${project.groupId}:${project.artifactId}</name>
     <description>SDK for interaction with the evolve platform</description>
@@ -74,7 +74,7 @@
         <dependency>
             <groupId>com.zepben.protobuf</groupId>
             <artifactId>evolve-grpc</artifactId>
-            <version>0.33.0-SNAPSHOT2</version>
+            <version>0.33.0-SNAPSHOT3.LOCAL</version>
         </dependency>
 
         <dependency>

--- a/src/main/kotlin/com/zepben/evolve/cim/iec61970/base/core/Feeder.kt
+++ b/src/main/kotlin/com/zepben/evolve/cim/iec61970/base/core/Feeder.kt
@@ -31,6 +31,7 @@ class Feeder @JvmOverloads constructor(mRID: String = "") : EquipmentContainer(m
     var normalEnergizingSubstation: Substation? = null
     private var _currentEquipmentById: MutableMap<String?, Equipment>? = null
     private var _normalEnergizedLvFeedersById: MutableMap<String?, LvFeeder>? = null
+    private var _currentEnergizedLvFeedersById: MutableMap<String?, LvFeeder>? = null
 
     /**
      * Contained equipment using the current state of the network. The returned collection is read only.
@@ -120,8 +121,63 @@ class Feeder @JvmOverloads constructor(mRID: String = "") : EquipmentContainer(m
         return ret != null
     }
 
+    /**
+     * Clear all [LvFeeder]'s associated with this [Feeder] in the normal state of the network.
+     *
+     * @return This [LvFeeder] for fluent use.
+     */
     fun clearNormalEnergizedLvFeeders(): Feeder {
         _normalEnergizedLvFeedersById = null
+        return this
+    }
+
+    /**
+     * The LV feeders that are currently energized by the feeder. The returned collection is read only.
+     */
+    val currentEnergizedLvFeeders: Collection<LvFeeder> get() = _currentEnergizedLvFeedersById?.values.asUnmodifiable()
+
+    /**
+     * Get the number of entries in the current [LvFeeder] collection.
+     */
+    fun numCurrentEnergizedLvFeeders(): Int = _currentEnergizedLvFeedersById?.size ?: 0
+
+    /**
+     * Energized LV feeder using the current state of the network.
+     *
+     * @param mRID the mRID of the required current [LvFeeder]
+     * @return The [LvFeeder] with the specified [mRID] if it exists, otherwise null
+     */
+    fun getCurrentEnergizedLvFeeder(mRID: String): LvFeeder? = _currentEnergizedLvFeedersById?.get(mRID)
+
+    /**
+     * @param lvFeeder the LV feeder to associate with this feeder in the current state of the network.
+     */
+    fun addCurrentEnergizedLvFeeder(lvFeeder: LvFeeder): Feeder {
+        if (validateReference(lvFeeder, ::getCurrentEnergizedLvFeeder, "An LvFeeder"))
+            return this
+
+        _currentEnergizedLvFeedersById = _currentEnergizedLvFeedersById ?: mutableMapOf()
+        _currentEnergizedLvFeedersById!!.putIfAbsent(lvFeeder.mRID, lvFeeder)
+
+        return this
+    }
+
+    /**
+     * @param lvFeeder the LV feeder to disassociate from this HV/MV feeder in the current state of the network.
+     */
+    fun removeCurrentEnergizedLvFeeder(lvFeeder: LvFeeder): Boolean {
+        val ret = _currentEnergizedLvFeedersById?.remove(lvFeeder.mRID)
+        if (_currentEnergizedLvFeedersById.isNullOrEmpty()) _currentEnergizedLvFeedersById = null
+        return ret != null
+    }
+
+    /**
+     * Clear all [LvFeeder]'s associated with this [Feeder] in the current state of the network.
+     *
+     * @return This [LvFeeder] for fluent use.
+     */
+    fun clearCurrentEnergizedLvFeeders(): Feeder {
+        _currentEnergizedLvFeedersById = null
         return this
     }
 }

--- a/src/main/kotlin/com/zepben/evolve/cim/iec61970/infiec61970/feeder/LvFeeder.kt
+++ b/src/main/kotlin/com/zepben/evolve/cim/iec61970/infiec61970/feeder/LvFeeder.kt
@@ -32,10 +32,11 @@ class LvFeeder @JvmOverloads constructor(mRID: String = "") : EquipmentContainer
         }
 
     private var _normalEnergizingFeedersById: MutableMap<String?, Feeder>? = null
+    private var _currentEnergizingFeedersById: MutableMap<String?, Feeder>? = null
     private var _currentEquipmentById: MutableMap<String?, Equipment>? = null
 
     /**
-     * The HV/MV feeders that energize this LV feeder. The returned collection is read only.
+     * The HV/MV feeders that normally energize this LV feeder. The returned collection is read only.
      */
     val normalEnergizingFeeders: Collection<Feeder> get() = _normalEnergizingFeedersById?.values.asUnmodifiable()
 
@@ -87,6 +88,62 @@ class LvFeeder @JvmOverloads constructor(mRID: String = "") : EquipmentContainer
      */
     fun clearNormalEnergizingFeeders(): LvFeeder {
         _normalEnergizingFeedersById = null
+        return this
+    }
+
+    /**
+     * The HV/MV feeders that currently energize this LV feeder. The returned collection is read only.
+     */
+    val currentEnergizingFeeders: Collection<Feeder> get() = _currentEnergizingFeedersById?.values.asUnmodifiable()
+
+    /**
+     * Get the number of entries in the current [Feeder] collection.
+     */
+    fun numCurrentEnergizingFeeders(): Int = _currentEnergizingFeedersById?.size ?: 0
+
+    /**
+     * Energizing feeder using the current state of the network.
+     *
+     * @param mRID the mRID of the required current [Feeder]
+     * @return The [Feeder] with the specified [mRID] if it exists, otherwise null
+     */
+    fun getCurrentEnergizingFeeder(mRID: String): Feeder? = _currentEnergizingFeedersById?.get(mRID)
+
+    /**
+     * Associate this [LvFeeder] with a [Feeder] in the current state of the network.
+     *
+     * @param feeder the HV/MV feeder to associate with this LV feeder in the current state of the network.
+     * @return This [LvFeeder] for fluent use.
+     */
+    fun addCurrentEnergizingFeeder(feeder: Feeder): LvFeeder {
+        if (validateReference(feeder, ::getCurrentEnergizingFeeder, "A Feeder"))
+            return this
+
+        _currentEnergizingFeedersById = _currentEnergizingFeedersById ?: mutableMapOf()
+        _currentEnergizingFeedersById!!.putIfAbsent(feeder.mRID, feeder)
+
+        return this
+    }
+
+    /**
+     * Disassociate this [LvFeeder] from a [Feeder] in the current state of the network.
+     *
+     * @param feeder the HV/MV feeder to disassociate from this LV feeder in the current state of the network.
+     * @return true if a matching feeder is removed from the collection.
+     */
+    fun removeCurrentEnergizingFeeder(feeder: Feeder): Boolean {
+        val ret = _currentEnergizingFeedersById?.remove(feeder.mRID)
+        if (_currentEnergizingFeedersById.isNullOrEmpty()) _currentEnergizingFeedersById = null
+        return ret != null
+    }
+
+    /**
+     * Clear all [Feeder]'s associated with this [LvFeeder] in the current state of the network.
+     *
+     * @return This [LvFeeder] for fluent use.
+     */
+    fun clearCurrentEnergizingFeeders(): LvFeeder {
+        _currentEnergizingFeedersById = null
         return this
     }
 

--- a/src/main/kotlin/com/zepben/evolve/services/common/ReferenceResolvers.kt
+++ b/src/main/kotlin/com/zepben/evolve/services/common/ReferenceResolvers.kt
@@ -200,6 +200,10 @@ internal object FeederToNormalEnergizedLvFeedersResolver : ReferenceResolver<Fee
     Feeder::class, LvFeeder::class, Feeder::addNormalEnergizedLvFeeder
 )
 
+internal object FeederToCurrentEnergizedLvFeedersResolver : ReferenceResolver<Feeder, LvFeeder> by KReferenceResolver(
+    Feeder::class, LvFeeder::class, Feeder::addCurrentEnergizedLvFeeder
+)
+
 internal object GeographicalRegionToSubGeographicalRegionResolver : ReferenceResolver<GeographicalRegion, SubGeographicalRegion> by KReferenceResolver(
     GeographicalRegion::class, SubGeographicalRegion::class, GeographicalRegion::addSubGeographicalRegion
 )
@@ -350,6 +354,10 @@ internal object LvFeederToNormalHeadTerminalResolver : ReferenceResolver<LvFeede
 
 internal object LvFeederToNormalEnergizingFeedersResolver : ReferenceResolver<LvFeeder, Feeder> by KReferenceResolver(
     LvFeeder::class, Feeder::class, LvFeeder::addNormalEnergizingFeeder
+)
+
+internal object LvFeederToCurrentEnergizingFeedersResolver : ReferenceResolver<LvFeeder, Feeder> by KReferenceResolver(
+    LvFeeder::class, Feeder::class, LvFeeder::addCurrentEnergizingFeeder
 )
 
 internal object PowerElectronicsConnectionToPowerElectronicsConnectionPhaseResolver :

--- a/src/main/kotlin/com/zepben/evolve/services/common/Resolvers.kt
+++ b/src/main/kotlin/com/zepben/evolve/services/common/Resolvers.kt
@@ -196,6 +196,10 @@ object Resolvers {
         BoundReferenceResolver(feeder, FeederToNormalEnergizedLvFeedersResolver, LvFeederToNormalEnergizingFeedersResolver)
 
     @JvmStatic
+    fun currentEnergizedLvFeeders(feeder: Feeder): BoundReferenceResolver<Feeder, LvFeeder> =
+        BoundReferenceResolver(feeder, FeederToCurrentEnergizedLvFeedersResolver, LvFeederToCurrentEnergizingFeedersResolver)
+
+    @JvmStatic
     fun subGeographicalRegions(geographicalRegion: GeographicalRegion): BoundReferenceResolver<GeographicalRegion, SubGeographicalRegion> =
         BoundReferenceResolver(geographicalRegion, GeographicalRegionToSubGeographicalRegionResolver, SubGeographicalRegionToGeographicalRegionResolver)
 
@@ -330,6 +334,10 @@ object Resolvers {
     @JvmStatic
     fun normalEnergizingFeeders(lvFeeder: LvFeeder): BoundReferenceResolver<LvFeeder, Feeder> =
         BoundReferenceResolver(lvFeeder, LvFeederToNormalEnergizingFeedersResolver, FeederToNormalEnergizedLvFeedersResolver)
+
+    @JvmStatic
+    fun currentEnergizingFeeders(lvFeeder: LvFeeder): BoundReferenceResolver<LvFeeder, Feeder> =
+        BoundReferenceResolver(lvFeeder, LvFeederToCurrentEnergizingFeedersResolver, FeederToCurrentEnergizedLvFeedersResolver)
 
     @JvmStatic
     fun powerElectronicsConnection(powerElectronicsUnit: PowerElectronicsUnit): BoundReferenceResolver<PowerElectronicsUnit, PowerElectronicsConnection> =

--- a/src/main/kotlin/com/zepben/evolve/services/network/NetworkServiceComparator.kt
+++ b/src/main/kotlin/com/zepben/evolve/services/network/NetworkServiceComparator.kt
@@ -414,6 +414,7 @@ class NetworkServiceComparator @JvmOverloads constructor(
 
             compareIdReferences(Feeder::normalHeadTerminal, Feeder::normalEnergizingSubstation)
             compareIdReferenceCollections(Feeder::normalEnergizedLvFeeders)
+            compareIdReferenceCollections(Feeder::currentEnergizedLvFeeders)
             if (options.compareFeederEquipment)
                 compareIdReferenceCollections(Feeder::currentEquipment)
         }
@@ -1121,6 +1122,7 @@ class NetworkServiceComparator @JvmOverloads constructor(
 
             compareIdReferences(LvFeeder::normalHeadTerminal)
             compareIdReferenceCollections(LvFeeder::normalEnergizingFeeders)
+            compareIdReferenceCollections(LvFeeder::currentEnergizingFeeders)
             if (options.compareFeederEquipment)
                 compareIdReferenceCollections(LvFeeder::currentEquipment)
         }

--- a/src/main/kotlin/com/zepben/evolve/services/network/translator/NetworkCimToProto.kt
+++ b/src/main/kotlin/com/zepben/evolve/services/network/translator/NetworkCimToProto.kt
@@ -1032,6 +1032,8 @@ fun toPb(cim: Feeder, pb: PBFeeder.Builder): PBFeeder.Builder =
 
         clearNormalEnergizedLvFeederMRIDs()
         cim.normalEnergizedLvFeeders.forEach { addNormalEnergizedLvFeederMRIDs(it.mRID) }
+        clearCurrentlyEnergizedLvFeedersMRIDs()
+        cim.currentEnergizedLvFeeders.forEach { addCurrentlyEnergizedLvFeedersMRIDs(it.mRID) }
 
         toPb(cim, ecBuilder)
     }
@@ -2528,6 +2530,8 @@ fun toPb(cim: LvFeeder, pb: PBLvFeeder.Builder): PBLvFeeder.Builder =
 
         clearNormalEnergizingFeederMRIDs()
         cim.normalEnergizingFeeders.forEach { addNormalEnergizingFeederMRIDs(it.mRID) }
+        clearCurrentlyEnergizingFeedersMRIDs()
+        cim.currentEnergizingFeeders.forEach { addCurrentlyEnergizingFeedersMRIDs(it.mRID) }
 
         toPb(cim, ecBuilder)
     }

--- a/src/main/kotlin/com/zepben/evolve/services/network/translator/NetworkProtoToCim.kt
+++ b/src/main/kotlin/com/zepben/evolve/services/network/translator/NetworkProtoToCim.kt
@@ -1056,6 +1056,10 @@ fun toCim(pb: PBFeeder, networkService: NetworkService): Feeder =
             networkService.resolveOrDeferReference(Resolvers.normalEnergizedLvFeeders(this), normalEnergizedLvFeederMRID)
         }
 
+        pb.currentlyEnergizedLvFeedersMRIDsList.forEach { currentEnergizedLvFeederMRID ->
+            networkService.resolveOrDeferReference(Resolvers.currentEnergizedLvFeeders(this), currentEnergizedLvFeederMRID)
+        }
+
         toCim(pb.ec, this, networkService)
     }
 
@@ -2631,6 +2635,10 @@ fun toCim(pb: PBLvFeeder, networkService: NetworkService): LvFeeder =
         networkService.resolveOrDeferReference(Resolvers.normalHeadTerminal(this), pb.normalHeadTerminalMRID)
         pb.normalEnergizingFeederMRIDsList.forEach { normalEnergizingFeederMRID ->
             networkService.resolveOrDeferReference(Resolvers.normalEnergizingFeeders(this), normalEnergizingFeederMRID)
+        }
+
+        pb.currentlyEnergizingFeedersMRIDsList.forEach { currentEnergizingFeederMRID ->
+            networkService.resolveOrDeferReference(Resolvers.currentEnergizingFeeders(this), currentEnergizingFeederMRID)
         }
         toCim(pb.ec, this, networkService)
     }

--- a/src/main/kotlin/com/zepben/evolve/streaming/get/NetworkConsumerClient.kt
+++ b/src/main/kotlin/com/zepben/evolve/streaming/get/NetworkConsumerClient.kt
@@ -85,6 +85,7 @@ class NetworkConsumerClient(
      * @param equipmentContainer The [EquipmentContainer] to fetch equipment for.
      * @param includeEnergizingContainers The level of energizing containers to include equipment from.
      * @param includeEnergizedContainers The level of energized containers to include equipment from.
+     * @param networkState The network state of the equipment.
      *
      * @return A [GrpcResult] with a result of one of the following:
      * - When [GrpcResult.wasSuccessful], a map containing the retrieved objects keyed by mRID, accessible via [GrpcResult.value]. If an item was not found, or
@@ -96,9 +97,10 @@ class NetworkConsumerClient(
     fun getEquipmentForContainer(
         equipmentContainer: EquipmentContainer,
         includeEnergizingContainers: IncludedEnergizingContainers = IncludedEnergizingContainers.EXCLUDE_ENERGIZING_CONTAINERS,
-        includeEnergizedContainers: IncludedEnergizedContainers = IncludedEnergizedContainers.EXCLUDE_ENERGIZED_CONTAINERS
+        includeEnergizedContainers: IncludedEnergizedContainers = IncludedEnergizedContainers.EXCLUDE_ENERGIZED_CONTAINERS,
+        networkState: NetworkState = NetworkState.NORMAL_NETWORK_STATE
     ): GrpcResult<MultiObjectResult> =
-        getEquipmentForContainer(equipmentContainer.mRID, includeEnergizingContainers, includeEnergizedContainers)
+        getEquipmentForContainer(equipmentContainer.mRID, includeEnergizingContainers, includeEnergizedContainers, networkState)
 
     /**
      * Retrieve the [Equipment] for the [EquipmentContainer] represented by [mRID]
@@ -108,6 +110,7 @@ class NetworkConsumerClient(
      * @param mRID The mRID of the [EquipmentContainer] to fetch equipment for.
      * @param includeEnergizingContainers The level of energizing containers to include equipment from.
      * @param includeEnergizedContainers The level of energized containers to include equipment from.
+     * @param networkState The network state of the equipment.
      *
      * @return A [GrpcResult] with a result of one of the following:
      * - When [GrpcResult.wasSuccessful], a map containing the retrieved objects keyed by mRID, accessible via [GrpcResult.value]. If an item was not found, or
@@ -119,9 +122,10 @@ class NetworkConsumerClient(
     fun getEquipmentForContainer(
         mRID: String,
         includeEnergizingContainers: IncludedEnergizingContainers = IncludedEnergizingContainers.EXCLUDE_ENERGIZING_CONTAINERS,
-        includeEnergizedContainers: IncludedEnergizedContainers = IncludedEnergizedContainers.EXCLUDE_ENERGIZED_CONTAINERS
+        includeEnergizedContainers: IncludedEnergizedContainers = IncludedEnergizedContainers.EXCLUDE_ENERGIZED_CONTAINERS,
+        networkState: NetworkState = NetworkState.NORMAL_NETWORK_STATE
     ): GrpcResult<MultiObjectResult> =
-        getEquipmentForContainers(sequenceOf(mRID), includeEnergizingContainers, includeEnergizedContainers)
+        getEquipmentForContainers(sequenceOf(mRID), includeEnergizingContainers, includeEnergizedContainers, networkState)
 
     /**
      * Retrieve the [Equipment] for all [EquipmentContainer]s represented by [mRIDs]
@@ -131,6 +135,7 @@ class NetworkConsumerClient(
      * @param mRIDs The mRIDs of the [EquipmentContainer]s to fetch equipment for.
      * @param includeEnergizingContainers The level of energizing containers to include equipment from.
      * @param includeEnergizedContainers The level of energized containers to include equipment from.
+     * @param networkState The network state of the equipment.
      *
      * @return A [GrpcResult] with a result of one of the following:
      * - When [GrpcResult.wasSuccessful], a map containing the retrieved objects keyed by mRID, accessible via [GrpcResult.value]. If an item was not found, or
@@ -142,9 +147,10 @@ class NetworkConsumerClient(
     fun getEquipmentForContainers(
         mRIDs: Iterable<String>,
         includeEnergizingContainers: IncludedEnergizingContainers = IncludedEnergizingContainers.EXCLUDE_ENERGIZING_CONTAINERS,
-        includeEnergizedContainers: IncludedEnergizedContainers = IncludedEnergizedContainers.EXCLUDE_ENERGIZED_CONTAINERS
+        includeEnergizedContainers: IncludedEnergizedContainers = IncludedEnergizedContainers.EXCLUDE_ENERGIZED_CONTAINERS,
+        networkState: NetworkState = NetworkState.NORMAL_NETWORK_STATE
     ): GrpcResult<MultiObjectResult> =
-        getEquipmentForContainers(mRIDs.asSequence(), includeEnergizingContainers, includeEnergizedContainers)
+        getEquipmentForContainers(mRIDs.asSequence(), includeEnergizingContainers, includeEnergizedContainers, networkState)
 
     /**
      * Retrieve the [Equipment] for all [EquipmentContainer]s represented by [mRIDs]
@@ -154,6 +160,7 @@ class NetworkConsumerClient(
      * @param mRIDs The mRIDs of the [EquipmentContainer]s to fetch equipment for.
      * @param includeEnergizingContainers The level of energizing containers to include equipment from.
      * @param includeEnergizedContainers The level of energized containers to include equipment from.
+     * @param networkState The network state of the equipment.
      *
      * @return A [GrpcResult] with a result of one of the following:
      * - When [GrpcResult.wasSuccessful], a map containing the retrieved objects keyed by mRID, accessible via [GrpcResult.value]. If an item was not found, or
@@ -165,9 +172,10 @@ class NetworkConsumerClient(
     fun getEquipmentForContainers(
         mRIDs: Sequence<String>,
         includeEnergizingContainers: IncludedEnergizingContainers = IncludedEnergizingContainers.EXCLUDE_ENERGIZING_CONTAINERS,
-        includeEnergizedContainers: IncludedEnergizedContainers = IncludedEnergizedContainers.EXCLUDE_ENERGIZED_CONTAINERS
+        includeEnergizedContainers: IncludedEnergizedContainers = IncludedEnergizedContainers.EXCLUDE_ENERGIZED_CONTAINERS,
+        networkState: NetworkState = NetworkState.NORMAL_NETWORK_STATE
     ): GrpcResult<MultiObjectResult> =
-        handleMultiObjectRPC { processEquipmentForContainers(mRIDs, includeEnergizingContainers, includeEnergizedContainers) }
+        handleMultiObjectRPC { processEquipmentForContainers(mRIDs, includeEnergizingContainers, includeEnergizedContainers, networkState) }
 
     /**
      * Retrieve the [Equipment] for [operationalRestriction].
@@ -198,38 +206,6 @@ class NetworkConsumerClient(
      */
     fun getEquipmentForRestriction(mRID: String): GrpcResult<MultiObjectResult> =
         handleMultiObjectRPC { processRestriction(mRID) }
-
-    /**
-     * Retrieve the current [Equipment] for [feeder]. The current equipment is the equipment connected to the Feeder based on
-     * the current phasing and switching of the network.
-     *
-     * Exceptions that occur during retrieval will be caught and passed to all error handlers that have been registered against this client.
-     *
-     * @param feeder The [Feeder] to fetch current equipment for.
-     * @return A [GrpcResult] with a result of one of the following:
-     * - When [GrpcResult.wasSuccessful], a map containing the retrieved objects keyed by mRID, accessible via [GrpcResult.value]. If an item was not found, or
-     * couldn't be added to [service], it will be excluded from the map and its mRID will be present in [MultiObjectResult.failed] (see [BaseService.add]).
-     * - When [GrpcResult.wasFailure], the error that occurred retrieving or processing the object, accessible via [GrpcResult.thrown].
-     * Note the [NetworkConsumerClient] warning in this case.
-     */
-    fun getCurrentEquipmentForFeeder(feeder: Feeder): GrpcResult<MultiObjectResult> =
-        getCurrentEquipmentForFeeder(feeder.mRID)
-
-    /**
-     * Retrieve the current [Equipment] for the [Feeder] represented by [mRID]. The current equipment is the equipment connected to the Feeder based on
-     * the current phasing and switching of the network.
-     *
-     * Exceptions that occur during retrieval will be caught and passed to all error handlers that have been registered against this client.
-     *
-     * @param mRID The mRID of the [Feeder] to fetch current equipment for.
-     * @return A [GrpcResult] with a result of one of the following:
-     * - When [GrpcResult.wasSuccessful], a map containing the retrieved objects keyed by mRID, accessible via [GrpcResult.value]. If an item was not found, or
-     * couldn't be added to [service], it will be excluded from the map and its mRID will be present in [MultiObjectResult.failed] (see [BaseService.add]).
-     * - When [GrpcResult.wasFailure], the error that occurred retrieving or processing the object, accessible via [GrpcResult.thrown].
-     * Note the [NetworkConsumerClient] warning in this case.
-     */
-    fun getCurrentEquipmentForFeeder(mRID: String): GrpcResult<MultiObjectResult> =
-        handleMultiObjectRPC { processFeeder(mRID) }
 
     /**
      * Retrieve the [Terminal]s for [connectivityNode].
@@ -488,7 +464,8 @@ class NetworkConsumerClient(
     private fun processEquipmentForContainers(
         mRIDs: Sequence<String>,
         includeEnergizingContainers: IncludedEnergizingContainers,
-        includeEnergizedContainers: IncludedEnergizedContainers
+        includeEnergizedContainers: IncludedEnergizedContainers,
+        networkState: NetworkState
     ): Sequence<ExtractResult> {
         val extractResults = mutableListOf<ExtractResult>()
         val streamObserver = AwaitableStreamObserver<GetEquipmentForContainersResponse> { response ->
@@ -502,6 +479,7 @@ class NetworkConsumerClient(
 
         builder.includeEnergizingContainers = includeEnergizingContainers
         builder.includeEnergizedContainers = includeEnergizedContainers
+        builder.networkState = networkState
 
         batchSend(mRIDs, builder::addMrids) {
             if (builder.mridsList.isNotEmpty())
@@ -510,20 +488,6 @@ class NetworkConsumerClient(
         }
 
         request.onCompleted()
-        streamObserver.await()
-
-        return extractResults.asSequence()
-    }
-
-    private fun processFeeder(mRID: String): Sequence<ExtractResult> {
-        val extractResults = mutableListOf<ExtractResult>()
-        val streamObserver = AwaitableStreamObserver<GetCurrentEquipmentForFeederResponse> { response ->
-            response.identifiedObjectsList.forEach {
-                extractResults.add(extractIdentifiedObject(it))
-            }
-        }
-
-        stub.getCurrentEquipmentForFeeder(GetCurrentEquipmentForFeederRequest.newBuilder().setMrid(mRID).build(), streamObserver)
         streamObserver.await()
 
         return extractResults.asSequence()

--- a/src/test/kotlin/com/zepben/evolve/cim/iec61970/base/core/FeederTest.kt
+++ b/src/test/kotlin/com/zepben/evolve/cim/iec61970/base/core/FeederTest.kt
@@ -78,6 +78,20 @@ internal class FeederTest {
     }
 
     @Test
+    internal fun currentEnergizedLvFeeders() {
+        PrivateCollectionValidator.validateUnordered(
+            ::Feeder,
+            ::LvFeeder,
+            Feeder::currentEnergizedLvFeeders,
+            Feeder::numCurrentEnergizedLvFeeders,
+            Feeder::getCurrentEnergizedLvFeeder,
+            Feeder::addCurrentEnergizedLvFeeder,
+            Feeder::removeCurrentEnergizedLvFeeder,
+            Feeder::clearCurrentEnergizedLvFeeders
+        )
+    }
+
+    @Test
     internal fun `can set feeder head terminal on feeder without equipment`() {
         val terminal = Terminal()
         val terminal2 = Terminal()

--- a/src/test/kotlin/com/zepben/evolve/cim/iec61970/infiec61970/feeder/LvFeederTest.kt
+++ b/src/test/kotlin/com/zepben/evolve/cim/iec61970/infiec61970/feeder/LvFeederTest.kt
@@ -62,6 +62,20 @@ internal class LvFeederTest {
     }
 
     @Test
+    internal fun currentEnergizingFeeders() {
+        PrivateCollectionValidator.validateUnordered(
+            ::LvFeeder,
+            ::Feeder,
+            LvFeeder::currentEnergizingFeeders,
+            LvFeeder::numCurrentEnergizingFeeders,
+            LvFeeder::getCurrentEnergizingFeeder,
+            LvFeeder::addCurrentEnergizingFeeder,
+            LvFeeder::removeCurrentEnergizingFeeder,
+            LvFeeder::clearCurrentEnergizingFeeders
+        )
+    }
+
+    @Test
     internal fun currentEquipment() {
         PrivateCollectionValidator.validateUnordered(
             ::LvFeeder,

--- a/src/test/kotlin/com/zepben/evolve/services/network/testdata/FillFields.kt
+++ b/src/test/kotlin/com/zepben/evolve/services/network/testdata/FillFields.kt
@@ -480,17 +480,22 @@ fun Feeder.fillFields(service: NetworkService, includeRuntime: Boolean = true): 
     }
 
     if (includeRuntime) {
-        for (i in 0..1)
+        for (i in 0..1) {
             addNormalEnergizedLvFeeder(LvFeeder().also {
                 it.addNormalEnergizingFeeder(this)
                 service.add(it)
             })
 
-        for (i in 0..1)
+            addCurrentEnergizedLvFeeder(LvFeeder().also {
+                it.addCurrentEnergizingFeeder(this)
+                service.add(it)
+            })
+
             addCurrentEquipment(Junction().also {
                 it.addCurrentContainer(this)
                 service.add(it)
             })
+        }
     } else {
         equipment.forEach { it.removeContainer(this) }
         clearEquipment()
@@ -1484,17 +1489,22 @@ fun LvFeeder.fillFields(service: NetworkService, includeRuntime: Boolean = true)
     normalHeadTerminal = Terminal().also { service.add(it) }
 
     if (includeRuntime) {
-        for (i in 0..1)
+        for (i in 0..1) {
             addNormalEnergizingFeeder(Feeder().also {
                 it.addNormalEnergizedLvFeeder(this)
                 service.add(it)
             })
 
-        for (i in 0..1)
+            addCurrentEnergizingFeeder(Feeder().also {
+                it.addCurrentEnergizedLvFeeder(this)
+                service.add(it)
+            })
+
             addCurrentEquipment(Junction().also {
                 it.addCurrentContainer(this)
                 service.add(it)
             })
+        }
     } else {
         equipment.forEach { it.removeContainer(this) }
         clearEquipment()

--- a/src/test/kotlin/com/zepben/evolve/streaming/get/NetworkConsumerClientTest.kt
+++ b/src/test/kotlin/com/zepben/evolve/streaming/get/NetworkConsumerClientTest.kt
@@ -161,17 +161,19 @@ internal class NetworkConsumerClientTest {
     }
 
     @Test
-    internal fun `server receives linked container options`() {
+    internal fun `server receives container options for getEquipmentForContainers`() {
         consumerService.onGetEquipmentForContainers = spy { request, _ ->
             assertThat(request.mridsList, containsInAnyOrder("id"))
             assertThat(request.includeEnergizingContainers, equalTo(IncludedEnergizingContainers.INCLUDE_ENERGIZING_SUBSTATIONS))
             assertThat(request.includeEnergizedContainers, equalTo(IncludedEnergizedContainers.INCLUDE_ENERGIZED_LV_FEEDERS))
+            assertThat(request.networkState, equalTo(NetworkState.CURRENT_NETWORK_STATE))
         }
 
         consumerClient.getEquipmentForContainer(
             "id",
             includeEnergizingContainers = IncludedEnergizingContainers.INCLUDE_ENERGIZING_SUBSTATIONS,
-            includeEnergizedContainers = IncludedEnergizedContainers.INCLUDE_ENERGIZED_LV_FEEDERS
+            includeEnergizedContainers = IncludedEnergizedContainers.INCLUDE_ENERGIZED_LV_FEEDERS,
+            networkState = NetworkState.CURRENT_NETWORK_STATE
         )
 
         verify(consumerService.onGetEquipmentForContainers).invoke(any(), any())

--- a/src/test/kotlin/com/zepben/evolve/streaming/get/testservices/TestNetworkConsumerService.kt
+++ b/src/test/kotlin/com/zepben/evolve/streaming/get/testservices/TestNetworkConsumerService.kt
@@ -19,7 +19,6 @@ internal class TestNetworkConsumerService : NetworkConsumerGrpc.NetworkConsumerI
     lateinit var onGetIdentifiedObjects: (request: GetIdentifiedObjectsRequest, response: StreamObserver<GetIdentifiedObjectsResponse>) -> Unit
     lateinit var onGetNetworkHierarchy: (request: GetNetworkHierarchyRequest, response: StreamObserver<GetNetworkHierarchyResponse>) -> Unit
     lateinit var onGetEquipmentForContainers: (request: GetEquipmentForContainersRequest, response: StreamObserver<GetEquipmentForContainersResponse>) -> Unit
-    lateinit var onGetCurrentEquipmentForFeeder: (request: GetCurrentEquipmentForFeederRequest, response: StreamObserver<GetCurrentEquipmentForFeederResponse>) -> Unit
     lateinit var onGetEquipmentForRestriction: (request: GetEquipmentForRestrictionRequest, response: StreamObserver<GetEquipmentForRestrictionResponse>) -> Unit
     lateinit var onGetTerminalsForNode: (request: GetTerminalsForNodeRequest, response: StreamObserver<GetTerminalsForNodeResponse>) -> Unit
     lateinit var onGetMetadataRequest: (request: GetMetadataRequest, response: StreamObserver<GetMetadataResponse>) -> Unit
@@ -37,10 +36,6 @@ internal class TestNetworkConsumerService : NetworkConsumerGrpc.NetworkConsumerI
 
     override fun getEquipmentForContainers(response: StreamObserver<GetEquipmentForContainersResponse>): StreamObserver<GetEquipmentForContainersRequest> =
         TestStreamObserver(response, onGetEquipmentForContainers)
-
-    override fun getCurrentEquipmentForFeeder(request: GetCurrentEquipmentForFeederRequest, response: StreamObserver<GetCurrentEquipmentForFeederResponse>) {
-        runGrpc(request, response, onGetCurrentEquipmentForFeeder)
-    }
 
     override fun getEquipmentForRestriction(request: GetEquipmentForRestrictionRequest, response: StreamObserver<GetEquipmentForRestrictionResponse>) {
         runGrpc(request, response, onGetEquipmentForRestriction)


### PR DESCRIPTION
# Description

Pulled in current state container enhancement from grpc. Modified `NetworkConsumerClient` to support the rpc changes. Also, `Feeder` and `LvFeeder` CIM model have been added with their current network state association.

# Associated tasks
- https://github.com/zepben/ewb-grpc/pull/121


# Test Steps
None.

# Checklist

If any of these are not applicable, strikethrough the line `~like this~`. **Do not delete it!**. Let the reviewer decide if you should have done it.

### Code
- [x] I have performed a self review of my own code (including checking issues raised when creating the PR).
- [x] I have added/updated unit tests for these changes, and if not I have explained why they are not necessary.
- [x] I have commented my code in any hard-to-understand or hacky areas.
- [x] I have handled all new warnings generated by the compiler or IDE.
  New warning in Resolvers.kt about not having docstring.
- [x] I have rebased onto the target branch (usually main).

### Documentation
- [x] I have updated the changelog.
- ~[ ] I have updated any documentation required for these changes.~

# Breaking Changes
- [x] I have considered if this is a breaking change and will communicate it with other team members if so.

GRPC's `NetworkConsumerService` introduced breaking changes and it is applied to the `NetworkConsumerClient`.