### PR TITLE
DEV-2143 Fix gRPC initial connection test in GrpcChannelBuilder

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -7,6 +7,10 @@
 
 ### Fixes
 * GrpcChannelBuilder's initial connectivity test no longer fails due to a lack of permissions on a subset of services.
+* Updated to latest SDK:
+  - AddJumperEvent from and to changed to fromConnection and toConnection
+* AddJumperEvent now uses correct protobuf classes when converting
+* RemoveJumperEvent now uses correct protobuf classes when converting
 
 ## [0.24.0] - 2025-01-21
 ### Breaking Changes

--- a/changelog.md
+++ b/changelog.md
@@ -10,7 +10,7 @@
 * `AcLineSegment.perLengthSequenceImpedance` has been corrected to `perLengthImpedance`. This has been done in a non-breaking way, however the public resolver
   `Resolvers.perLengthSequenceImpedance` is now `Resolvers.perLengthImpedance`, correctly reflecting the CIM relationship.
 * Removed `getCurrentEquipmentForFeeder` implementation for `NetworkConsumer` as its functionality is now incorporated in `getEquipmentForContainers`.
-* Added `connectionTestTimeoutMs` field to `GrpcBuildArgs` with a default value of `5000`. This timeout is only applied to requests made in the initial connection tests. 
+* Added `connectionTestTimeoutMs` field to `GrpcBuildArgs` with a default value of `5000`. This timeout is only applied to requests made in the initial connection tests.
 
 ### New Features
 * Network state services for updating and querying network state events via gRPC.

--- a/changelog.md
+++ b/changelog.md
@@ -1,19 +1,8 @@
 # Zepben EWB SDK changelog
 ## [0.24.1] - UNRELEASED
 ### Breaking Changes
-* None.
-
-### New Features
-* None.
-
-### Enhancements
-* None.
 
 ### Fixes
-* None.
-
-### Notes
-* None.
 
 ## [0.24.0] - 2025-01-21
 ### Breaking Changes

--- a/changelog.md
+++ b/changelog.md
@@ -10,6 +10,7 @@
 * `AcLineSegment.perLengthSequenceImpedance` has been corrected to `perLengthImpedance`. This has been done in a non-breaking way, however the public resolver
   `Resolvers.perLengthSequenceImpedance` is now `Resolvers.perLengthImpedance`, correctly reflecting the CIM relationship.
 * Removed `getCurrentEquipmentForFeeder` implementation for `NetworkConsumer` as its functionality is now incorporated in `getEquipmentForContainers`.
+* Added `connectionTestTimeoutMs` field to `GrpcBuildArgs` with a default value of `5000`. This timeout is only applied to requests made in the initial connection tests. 
 
 ### New Features
 * Network state services for updating and querying network state events via gRPC.
@@ -51,7 +52,7 @@
 * gRPC now supports `FeederDirection.CONNECTOR`.
 
 ### Fixes
-* None.
+* GrpcChannelBuilder's initial connectivity test no longer fails due to a lack of permissions on a subset of services.
 
 ### Notes
 * `Cut` and `Clamp` have been added to the model, but no processing for them has been added to the tracing, so results will not be what you expect.

--- a/changelog.md
+++ b/changelog.md
@@ -1,8 +1,12 @@
 # Zepben EWB SDK changelog
 ## [0.24.1] - UNRELEASED
 ### Breaking Changes
+* Added `connectionTestTimeoutMs` field to `GrpcBuildArgs` with a default value of `5000`. This timeout is only applied to requests made in the initial connection tests.
+* Updated to ewb-grpc 0.34.1:
+  * Changed AddJumperEvent to not use reserved words.
 
 ### Fixes
+* GrpcChannelBuilder's initial connectivity test no longer fails due to a lack of permissions on a subset of services.
 
 ## [0.24.0] - 2025-01-21
 ### Breaking Changes
@@ -10,7 +14,6 @@
 * `AcLineSegment.perLengthSequenceImpedance` has been corrected to `perLengthImpedance`. This has been done in a non-breaking way, however the public resolver
   `Resolvers.perLengthSequenceImpedance` is now `Resolvers.perLengthImpedance`, correctly reflecting the CIM relationship.
 * Removed `getCurrentEquipmentForFeeder` implementation for `NetworkConsumer` as its functionality is now incorporated in `getEquipmentForContainers`.
-* Added `connectionTestTimeoutMs` field to `GrpcBuildArgs` with a default value of `5000`. This timeout is only applied to requests made in the initial connection tests.
 
 ### New Features
 * Network state services for updating and querying network state events via gRPC.
@@ -52,7 +55,6 @@
 * gRPC now supports `FeederDirection.CONNECTOR`.
 
 ### Fixes
-* GrpcChannelBuilder's initial connectivity test no longer fails due to a lack of permissions on a subset of services.
 
 ### Notes
 * `Cut` and `Clamp` have been added to the model, but no processing for them has been added to the tracing, so results will not be what you expect.

--- a/pom.xml
+++ b/pom.xml
@@ -74,7 +74,7 @@
         <dependency>
             <groupId>com.zepben.protobuf</groupId>
             <artifactId>evolve-grpc</artifactId>
-            <version>0.34.0</version>
+            <version>0.34.0-SNAPSHOT1</version>
         </dependency>
 
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -74,7 +74,7 @@
         <dependency>
             <groupId>com.zepben.protobuf</groupId>
             <artifactId>evolve-grpc</artifactId>
-            <version>0.34.0-SNAPSHOT1</version>
+            <version>0.35.0-SNAPSHOT1</version>
         </dependency>
 
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -74,7 +74,7 @@
         <dependency>
             <groupId>com.zepben.protobuf</groupId>
             <artifactId>evolve-grpc</artifactId>
-            <version>0.35.0-SNAPSHOT1</version>
+            <version>0.34.1</version>
         </dependency>
 
         <dependency>

--- a/src/main/kotlin/com/zepben/evolve/streaming/data/CurrentStateEvent.kt
+++ b/src/main/kotlin/com/zepben/evolve/streaming/data/CurrentStateEvent.kt
@@ -205,7 +205,7 @@ class RemoveCutEvent(
             RemoveCutEvent(
                 event.eventId,
                 event.timestamp.toLocalDateTime(),
-                event.addCut.mrid
+                event.removeCut.mrid
             )
     }
 
@@ -319,7 +319,7 @@ class RemoveJumperEvent(
             RemoveJumperEvent(
                 event.eventId,
                 event.timestamp.toLocalDateTime(),
-                event.addCut.mrid
+                event.removeJumper.mrid
             )
     }
 

--- a/src/main/kotlin/com/zepben/evolve/streaming/data/CurrentStateEvent.kt
+++ b/src/main/kotlin/com/zepben/evolve/streaming/data/CurrentStateEvent.kt
@@ -262,8 +262,8 @@ class AddJumperEvent(
                 event.eventId,
                 event.timestamp.toLocalDateTime(),
                 event.addJumper.mrid,
-                JumperConnection.fromPb(event.addJumper.from),
-                JumperConnection.fromPb(event.addJumper.to)
+                JumperConnection.fromPb(event.addJumper.fromConnection),
+                JumperConnection.fromPb(event.addJumper.toConnection)
             )
     }
 
@@ -273,8 +273,8 @@ class AddJumperEvent(
     override fun toPb(): PBCurrentStateEvent = toPbBuilder().also { event ->
         event.addJumper = PBAddJumperEvent.newBuilder().also {
             it.mrid = mRID
-            it.from = from.toPb()
-            it.to = to.toPb()
+            it.fromConnection = from.toPb()
+            it.toConnection = to.toPb()
         }.build()
     }.build()
 

--- a/src/main/kotlin/com/zepben/evolve/streaming/data/SetCurrentStatesStatus.kt
+++ b/src/main/kotlin/com/zepben/evolve/streaming/data/SetCurrentStatesStatus.kt
@@ -135,6 +135,15 @@ sealed class StateEventFailure(val eventId: String, val message: String) {
 
 }
 
+class StateEventUnknownError(eventId: String, message: String) : StateEventFailure(eventId, message) {
+    companion object {
+        internal fun fromPb(pb: PBStateEventFailure): StateEventFailure =
+            StateEventUnknownMrid(pb.eventId, pb.message)
+    }
+
+    override fun toPb(): PBStateEventFailure = toPb { }
+
+}
 /**
  * The requested mRID was not found in the network.
  */

--- a/src/main/kotlin/com/zepben/evolve/streaming/get/QueryNetworkStateService.kt
+++ b/src/main/kotlin/com/zepben/evolve/streaming/get/QueryNetworkStateService.kt
@@ -14,6 +14,7 @@ import com.zepben.evolve.services.common.translator.toLocalDateTime
 import com.zepben.evolve.streaming.data.CurrentStateEvent
 import com.zepben.evolve.streaming.data.CurrentStateEventBatch
 import com.zepben.evolve.streaming.data.SetCurrentStatesStatus
+import com.zepben.protobuf.checkConnection.CheckConnectionRequest
 import com.zepben.protobuf.ns.GetCurrentStatesRequest
 import com.zepben.protobuf.ns.GetCurrentStatesResponse
 import com.zepben.protobuf.ns.QueryNetworkStateServiceGrpc
@@ -221,4 +222,8 @@ class QueryNetworkStateService(
         fun handle(error: GrpcException)
     }
 
+    override fun checkConnection(request: CheckConnectionRequest?, responseObserver: StreamObserver<Empty>) {
+        responseObserver.onNext(Empty.getDefaultInstance())
+        responseObserver.onCompleted()
+    }
 }

--- a/src/main/kotlin/com/zepben/evolve/streaming/get/QueryNetworkStateService.kt
+++ b/src/main/kotlin/com/zepben/evolve/streaming/get/QueryNetworkStateService.kt
@@ -14,7 +14,7 @@ import com.zepben.evolve.services.common.translator.toLocalDateTime
 import com.zepben.evolve.streaming.data.CurrentStateEvent
 import com.zepben.evolve.streaming.data.CurrentStateEventBatch
 import com.zepben.evolve.streaming.data.SetCurrentStatesStatus
-import com.zepben.protobuf.checkConnection.CheckConnectionRequest
+import com.zepben.protobuf.connection.CheckConnectionRequest
 import com.zepben.protobuf.ns.GetCurrentStatesRequest
 import com.zepben.protobuf.ns.GetCurrentStatesResponse
 import com.zepben.protobuf.ns.QueryNetworkStateServiceGrpc

--- a/src/main/kotlin/com/zepben/evolve/streaming/grpc/GrpcChannelBuilder.kt
+++ b/src/main/kotlin/com/zepben/evolve/streaming/grpc/GrpcChannelBuilder.kt
@@ -10,7 +10,6 @@ package com.zepben.evolve.streaming.grpc
 
 import com.google.protobuf.Empty
 import com.zepben.auth.client.ZepbenTokenFetcher
-import com.zepben.evolve.streaming.get.DiagramConsumerClient
 
 import com.zepben.protobuf.cc.CustomerConsumerGrpc
 import com.zepben.protobuf.checkConnection.checkConnection

--- a/src/main/kotlin/com/zepben/evolve/streaming/mutations/UpdateNetworkStateService.kt
+++ b/src/main/kotlin/com/zepben/evolve/streaming/mutations/UpdateNetworkStateService.kt
@@ -8,8 +8,10 @@
 
 package com.zepben.evolve.streaming.mutations
 
+import com.google.protobuf.Empty
 import com.zepben.evolve.conn.grpc.GrpcException
 import com.zepben.evolve.streaming.data.*
+import com.zepben.protobuf.checkConnection.CheckConnectionRequest
 import com.zepben.protobuf.ns.SetCurrentStatesRequest
 import com.zepben.protobuf.ns.SetCurrentStatesResponse
 import com.zepben.protobuf.ns.UpdateNetworkStateServiceGrpc
@@ -105,4 +107,8 @@ class UpdateNetworkStateService(
             }
         }
 
+    override fun checkConnection(request: CheckConnectionRequest?, responseObserver: StreamObserver<Empty>) {
+        responseObserver.onNext(Empty.getDefaultInstance())
+        responseObserver.onCompleted()
+    }
 }

--- a/src/main/kotlin/com/zepben/evolve/streaming/mutations/UpdateNetworkStateService.kt
+++ b/src/main/kotlin/com/zepben/evolve/streaming/mutations/UpdateNetworkStateService.kt
@@ -11,7 +11,7 @@ package com.zepben.evolve.streaming.mutations
 import com.google.protobuf.Empty
 import com.zepben.evolve.conn.grpc.GrpcException
 import com.zepben.evolve.streaming.data.*
-import com.zepben.protobuf.checkConnection.CheckConnectionRequest
+import com.zepben.protobuf.connection.CheckConnectionRequest
 import com.zepben.protobuf.ns.SetCurrentStatesRequest
 import com.zepben.protobuf.ns.SetCurrentStatesResponse
 import com.zepben.protobuf.ns.UpdateNetworkStateServiceGrpc

--- a/src/test/kotlin/com/zepben/evolve/streaming/grpc/GrpcChannelBuilderTest.kt
+++ b/src/test/kotlin/com/zepben/evolve/streaming/grpc/GrpcChannelBuilderTest.kt
@@ -20,9 +20,7 @@ import com.zepben.protobuf.dc.DiagramConsumerGrpc
 import com.zepben.protobuf.nc.NetworkConsumerGrpc
 import com.zepben.protobuf.ns.QueryNetworkStateServiceGrpc
 import com.zepben.protobuf.ns.UpdateNetworkStateServiceGrpc
-import com.zepben.testutils.exception.ExceptionMatcher
 import com.zepben.testutils.exception.ExpectException.Companion.expect
-import com.zepben.testutils.exception.ExpectExceptionError
 import io.grpc.*
 import io.grpc.netty.shaded.io.grpc.netty.NettyChannelBuilder
 import io.grpc.stub.ClientCalls
@@ -205,8 +203,8 @@ internal class GrpcChannelBuilderTest {
             "[DEBUG] NetworkConsumerClient: io.grpc.StatusRuntimeException: DATA_LOSS: Data loss message for testing\n" +
             "[DEBUG] CustomerConsumerClient: io.grpc.StatusRuntimeException: INVALID_ARGUMENT: Invalid argument message for testing\n" +
             "[DEBUG] DiagramConsumerClient: io.grpc.StatusRuntimeException: UNIMPLEMENTED: Method not found: zepben.protobuf.dc.DiagramConsumer/checkConnection\n" +
-            "[DEBUG] UpdateNetworkStateService: io.grpc.StatusRuntimeException: UNIMPLEMENTED: Method not found: zepben.protobuf.ns.UpdateNetworkStateClient/checkConnection\n" +
-            "[DEBUG] QueryNetworkStateService: io.grpc.StatusRuntimeException: UNIMPLEMENTED: Method not found: zepben.protobuf.ns.QueryNetworkStateClient/checkConnection"
+            "[DEBUG] UpdateNetworkStateClient: io.grpc.StatusRuntimeException: UNIMPLEMENTED: Method not found: zepben.protobuf.ns.UpdateNetworkStateClient/checkConnection\n" +
+            "[DEBUG] QueryNetworkStateClient: io.grpc.StatusRuntimeException: UNIMPLEMENTED: Method not found: zepben.protobuf.ns.QueryNetworkStateClient/checkConnection"
         )
     }
 
@@ -363,83 +361,83 @@ internal class GrpcChannelBuilderTest {
         }
 
         mockkStatic(ClientCalls::class) {
-            mockkStatic(
-                NetworkConsumerGrpc::getCheckConnectionMethod,
-                CustomerConsumerGrpc::getCheckConnectionMethod,
-                DiagramConsumerGrpc::getCheckConnectionMethod,
-                UpdateNetworkStateServiceGrpc::getCheckConnectionMethod,
-                QueryNetworkStateServiceGrpc::getCheckConnectionMethod,
-            ) {
 
-                val networkConsumerGrpcMethodDesc = mockk<MethodDescriptor<checkConnection, Empty>>()
-                val customerConsumerGrpcMethodDesc = mockk<MethodDescriptor<checkConnection, Empty>>()
-                val diagramConsumerGrpcMethodDesc = mockk<MethodDescriptor<checkConnection, Empty>>()
-                val updateNetworkStateServiceGrpcMethodDesc = mockk<MethodDescriptor<checkConnection, Empty>>()
-                val queryNetworkStateServiceGrpcMethodDesc = mockk<MethodDescriptor<checkConnection, Empty>>()
+            val networkConsumerGrpcMethodDesc = mockk<MethodDescriptor<checkConnection, Empty>>()
+            val customerConsumerGrpcMethodDesc = mockk<MethodDescriptor<checkConnection, Empty>>()
+            val diagramConsumerGrpcMethodDesc = mockk<MethodDescriptor<checkConnection, Empty>>()
+            val updateNetworkStateServiceGrpcMethodDesc = mockk<MethodDescriptor<checkConnection, Empty>>()
+            val queryNetworkStateServiceGrpcMethodDesc = mockk<MethodDescriptor<checkConnection, Empty>>()
 
-                every { NetworkConsumerGrpc.getCheckConnectionMethod() } returns networkConsumerGrpcMethodDesc
-                every { CustomerConsumerGrpc.getCheckConnectionMethod() } returns customerConsumerGrpcMethodDesc
-                every { DiagramConsumerGrpc.getCheckConnectionMethod() } returns diagramConsumerGrpcMethodDesc
-                every { UpdateNetworkStateServiceGrpc.getCheckConnectionMethod() } returns updateNetworkStateServiceGrpcMethodDesc
-                every { QueryNetworkStateServiceGrpc.getCheckConnectionMethod() } returns queryNetworkStateServiceGrpcMethodDesc
+            val mockkedGrpcClientConnectionTests: Map<String, MethodDescriptor<checkConnection, Empty>> = mapOf(
+                "NetworkConsumerClient" to networkConsumerGrpcMethodDesc,
+                "CustomerConsumerClient" to customerConsumerGrpcMethodDesc,
+                "DiagramConsumerClient" to diagramConsumerGrpcMethodDesc,
+                "UpdateNetworkStateClient" to updateNetworkStateServiceGrpcMethodDesc,
+                "QueryNetworkStateClient" to queryNetworkStateServiceGrpcMethodDesc,
+            )
 
-                val networkConsumerClientCall = mockk<ClientCall<checkConnection, Empty>>()
-                val customerConsumerClientCall = mockk<ClientCall<checkConnection, Empty>>()
-                val diagramConsumerClientCall = mockk<ClientCall<checkConnection, Empty>>()
-                val updateNetworkStateServiceClientCall = mockk<ClientCall<checkConnection, Empty>>()
-                val queryNetworkStateServiceClientCall = mockk<ClientCall<checkConnection, Empty>>()
+            every { NetworkConsumerGrpc.getCheckConnectionMethod() } returns networkConsumerGrpcMethodDesc
+            every { CustomerConsumerGrpc.getCheckConnectionMethod() } returns customerConsumerGrpcMethodDesc
+            every { DiagramConsumerGrpc.getCheckConnectionMethod() } returns diagramConsumerGrpcMethodDesc
+            every { UpdateNetworkStateServiceGrpc.getCheckConnectionMethod() } returns updateNetworkStateServiceGrpcMethodDesc
+            every { QueryNetworkStateServiceGrpc.getCheckConnectionMethod() } returns queryNetworkStateServiceGrpcMethodDesc
 
-                every { channel.newCall(networkConsumerGrpcMethodDesc, any()) } returns networkConsumerClientCall
-                every { channel.newCall(customerConsumerGrpcMethodDesc, any()) } returns customerConsumerClientCall
-                every { channel.newCall(diagramConsumerGrpcMethodDesc, any()) } returns diagramConsumerClientCall
-                every { channel.newCall(updateNetworkStateServiceGrpcMethodDesc, any()) } returns updateNetworkStateServiceClientCall
-                every { channel.newCall(queryNetworkStateServiceGrpcMethodDesc, any()) } returns queryNetworkStateServiceClientCall
+            val networkConsumerClientCall = mockk<ClientCall<checkConnection, Empty>>()
+            val customerConsumerClientCall = mockk<ClientCall<checkConnection, Empty>>()
+            val diagramConsumerClientCall = mockk<ClientCall<checkConnection, Empty>>()
+            val updateNetworkStateServiceClientCall = mockk<ClientCall<checkConnection, Empty>>()
+            val queryNetworkStateServiceClientCall = mockk<ClientCall<checkConnection, Empty>>()
 
-                val networkConsumerResult = mockk<Empty>()
-                val customerConsumerResult = mockk<Empty>()
-                val diagramConsumerResult = mockk<Empty>()
-                val updateNetworkStateServiceResult = mockk<Empty>()
-                val queryNetworkStateServiceResult = mockk<Empty>()
+            every { channel.newCall(networkConsumerGrpcMethodDesc, any()) } returns networkConsumerClientCall
+            every { channel.newCall(customerConsumerGrpcMethodDesc, any()) } returns customerConsumerClientCall
+            every { channel.newCall(diagramConsumerGrpcMethodDesc, any()) } returns diagramConsumerClientCall
+            every { channel.newCall(updateNetworkStateServiceGrpcMethodDesc, any()) } returns updateNetworkStateServiceClientCall
+            every { channel.newCall(queryNetworkStateServiceGrpcMethodDesc, any()) } returns queryNetworkStateServiceClientCall
 
-                every { ClientCalls.blockingUnaryCall(networkConsumerClientCall, any<checkConnection>()) } returns networkConsumerResult
-                every { ClientCalls.blockingUnaryCall(customerConsumerClientCall, any<checkConnection>()) } returns customerConsumerResult
-                every { ClientCalls.blockingUnaryCall(diagramConsumerClientCall, any<checkConnection>()) } returns diagramConsumerResult
-                every { ClientCalls.blockingUnaryCall(updateNetworkStateServiceClientCall, any<checkConnection>()) } returns updateNetworkStateServiceResult
-                every { ClientCalls.blockingUnaryCall(queryNetworkStateServiceClientCall, any<checkConnection>()) } returns queryNetworkStateServiceResult
+            val networkConsumerResult = mockk<Empty>()
+            val customerConsumerResult = mockk<Empty>()
+            val diagramConsumerResult = mockk<Empty>()
+            val updateNetworkStateServiceResult = mockk<Empty>()
+            val queryNetworkStateServiceResult = mockk<Empty>()
+
+            every { ClientCalls.blockingUnaryCall(networkConsumerClientCall, any<checkConnection>()) } returns networkConsumerResult
+            every { ClientCalls.blockingUnaryCall(customerConsumerClientCall, any<checkConnection>()) } returns customerConsumerResult
+            every { ClientCalls.blockingUnaryCall(diagramConsumerClientCall, any<checkConnection>()) } returns diagramConsumerResult
+            every { ClientCalls.blockingUnaryCall(updateNetworkStateServiceClientCall, any<checkConnection>()) } returns updateNetworkStateServiceResult
+            every { ClientCalls.blockingUnaryCall(queryNetworkStateServiceClientCall, any<checkConnection>()) } returns queryNetworkStateServiceResult
 
 
-                responses[NetworkConsumerClient::class]?.let {
-                    every { ClientCalls.blockingUnaryCall(networkConsumerClientCall, any<checkConnection>()) } throws it
-                } ?: (every { ClientCalls.blockingUnaryCall(networkConsumerClientCall, any<checkConnection>()) } returns networkConsumerResult)
+            responses[NetworkConsumerClient::class]?.let {
+                every { ClientCalls.blockingUnaryCall(networkConsumerClientCall, any<checkConnection>()) } throws it
+            } ?: (every { ClientCalls.blockingUnaryCall(networkConsumerClientCall, any<checkConnection>()) } returns networkConsumerResult)
 
-                responses[CustomerConsumerClient::class]?.let {
-                    every { ClientCalls.blockingUnaryCall(customerConsumerClientCall, any<checkConnection>()) } throws it
-                } ?: (every { ClientCalls.blockingUnaryCall(customerConsumerClientCall, any<checkConnection>()) } returns customerConsumerResult)
+            responses[CustomerConsumerClient::class]?.let {
+                every { ClientCalls.blockingUnaryCall(customerConsumerClientCall, any<checkConnection>()) } throws it
+            } ?: (every { ClientCalls.blockingUnaryCall(customerConsumerClientCall, any<checkConnection>()) } returns customerConsumerResult)
 
-                responses[DiagramConsumerClient::class]?.let {
-                    every { ClientCalls.blockingUnaryCall(diagramConsumerClientCall, any<checkConnection>()) } throws it
-                } ?: (every { ClientCalls.blockingUnaryCall(diagramConsumerClientCall, any<checkConnection>()) } returns diagramConsumerResult)
+            responses[DiagramConsumerClient::class]?.let {
+                every { ClientCalls.blockingUnaryCall(diagramConsumerClientCall, any<checkConnection>()) } throws it
+            } ?: (every { ClientCalls.blockingUnaryCall(diagramConsumerClientCall, any<checkConnection>()) } returns diagramConsumerResult)
 
-                responses[UpdateNetworkStateClient::class]?.let {
-                    every { ClientCalls.blockingUnaryCall(updateNetworkStateServiceClientCall, any<checkConnection>()) } throws it
-                } ?: (every {
-                    ClientCalls.blockingUnaryCall(
-                        updateNetworkStateServiceClientCall,
-                        any<checkConnection>()
-                    )
-                } returns updateNetworkStateServiceResult)
+            responses[UpdateNetworkStateClient::class]?.let {
+                every { ClientCalls.blockingUnaryCall(updateNetworkStateServiceClientCall, any<checkConnection>()) } throws it
+            } ?: (every {
+                ClientCalls.blockingUnaryCall(
+                    updateNetworkStateServiceClientCall,
+                    any<checkConnection>()
+                )
+            } returns updateNetworkStateServiceResult)
 
-                responses[QueryNetworkStateClient::class]?.let {
-                    every { ClientCalls.blockingUnaryCall(queryNetworkStateServiceClientCall, any<checkConnection>()) } throws it
-                } ?: (every {
-                    ClientCalls.blockingUnaryCall(
-                        queryNetworkStateServiceClientCall,
-                        any<checkConnection>()
-                    )
-                } returns queryNetworkStateServiceResult)
+            responses[QueryNetworkStateClient::class]?.let {
+                every { ClientCalls.blockingUnaryCall(queryNetworkStateServiceClientCall, any<checkConnection>()) } throws it
+            } ?: (every {
+                ClientCalls.blockingUnaryCall(
+                    queryNetworkStateServiceClientCall,
+                    any<checkConnection>()
+                )
+            } returns queryNetworkStateServiceResult)
 
-            builder.testConnection(grpcChannel, grpcClientConnectionTests, debug, timeoutMs)
-            }
+            builder.testConnection(grpcChannel, mockkedGrpcClientConnectionTests, debug, timeoutMs)
         }
     }
 

--- a/src/test/kotlin/com/zepben/evolve/streaming/grpc/GrpcChannelBuilderTest.kt
+++ b/src/test/kotlin/com/zepben/evolve/streaming/grpc/GrpcChannelBuilderTest.kt
@@ -14,7 +14,7 @@ import com.zepben.auth.client.ZepbenTokenFetcher
 import com.zepben.auth.common.AuthMethod
 import com.zepben.evolve.streaming.get.*
 import com.zepben.evolve.streaming.mutations.UpdateNetworkStateClient
-import com.zepben.protobuf.checkConnection.CheckConnectionRequest
+import com.zepben.protobuf.connection.CheckConnectionRequest
 import com.zepben.testutils.exception.ExpectException.Companion.expect
 import io.grpc.*
 import io.grpc.netty.shaded.io.grpc.netty.NettyChannelBuilder
@@ -77,13 +77,13 @@ internal class GrpcChannelBuilderTest {
             } returns insecureChannel
 
             val builderSpy = spyk(GrpcChannelBuilder())
-            every { builderSpy.testConnection(any(), grpcClientConnectionTests, any(), any()) } just runs
+            every { builderSpy.testConnection(any(), GRPC_CLIENT_CONNECTION_TESTS, any(), any()) } just runs
 
             val grpcChannel = builderSpy.build()
 
             verifySequence {
                 builderSpy.build(DEFAULT_BUILD_ARGS)
-                builderSpy.testConnection(grpcChannel, grpcClientConnectionTests, true, 5000)
+                builderSpy.testConnection(grpcChannel, GRPC_CLIENT_CONNECTION_TESTS, true, 5000)
             }
         }
     }
@@ -113,13 +113,13 @@ internal class GrpcChannelBuilderTest {
         every { NettyChannelBuilder.forAddress("localhost", 50051).usePlaintext().maxInboundMessageSize(12).build() } returns insecureChannel
 
         val builderSpy = spyk(GrpcChannelBuilder())
-        every { builderSpy.testConnection(any(), grpcClientConnectionTests, any(), any()) } just runs
+        every { builderSpy.testConnection(any(), GRPC_CLIENT_CONNECTION_TESTS, any(), any()) } just runs
 
         val grpcChannel = builderSpy.build(GrpcBuildArgs(skipConnectionTest = false, debugConnectionTest = true, connectionTestTimeoutMs = 1234, maxInboundMessageSize = 12))
 
         verifySequence {
             builderSpy.build(GrpcBuildArgs(skipConnectionTest = false, debugConnectionTest = true, connectionTestTimeoutMs = 1234, maxInboundMessageSize = 12))
-            builderSpy.testConnection(grpcChannel, grpcClientConnectionTests, true, 1234)
+            builderSpy.testConnection(grpcChannel, GRPC_CLIENT_CONNECTION_TESTS, true, 1234)
         }
     }
 
@@ -166,7 +166,7 @@ internal class GrpcChannelBuilderTest {
             DiagramConsumerClient::class to null, //null returns GrpcResult mockk with wasSuccessful = true
         )
 
-        runTestConnection(responses) // TODO: This might be the one to fail fast on, UNKNOWN: Connection refused = token expired or etc?
+        runTestConnection(responses)
     }
 
     @Test
@@ -432,6 +432,6 @@ internal class GrpcChannelBuilderTest {
 
         val toIgnore = listOf("ThrowingGrpcClient")
 
-        assertThat(grpcClients.map { it.simpleName }.subtract(toIgnore), equalTo(grpcClientConnectionTests.keys))
+        assertThat(grpcClients.map { it.simpleName }.subtract(toIgnore), equalTo(GRPC_CLIENT_CONNECTION_TESTS.keys))
     }
 }

--- a/src/test/kotlin/com/zepben/evolve/streaming/grpc/GrpcChannelBuilderTest.kt
+++ b/src/test/kotlin/com/zepben/evolve/streaming/grpc/GrpcChannelBuilderTest.kt
@@ -14,12 +14,7 @@ import com.zepben.auth.client.ZepbenTokenFetcher
 import com.zepben.auth.common.AuthMethod
 import com.zepben.evolve.streaming.get.*
 import com.zepben.evolve.streaming.mutations.UpdateNetworkStateClient
-import com.zepben.protobuf.cc.CustomerConsumerGrpc
 import com.zepben.protobuf.checkConnection.checkConnection
-import com.zepben.protobuf.dc.DiagramConsumerGrpc
-import com.zepben.protobuf.nc.NetworkConsumerGrpc
-import com.zepben.protobuf.ns.QueryNetworkStateServiceGrpc
-import com.zepben.protobuf.ns.UpdateNetworkStateServiceGrpc
 import com.zepben.testutils.exception.ExpectException.Companion.expect
 import io.grpc.*
 import io.grpc.netty.shaded.io.grpc.netty.NettyChannelBuilder
@@ -376,12 +371,6 @@ internal class GrpcChannelBuilderTest {
                 "QueryNetworkStateClient" to queryNetworkStateServiceGrpcMethodDesc,
             )
 
-            every { NetworkConsumerGrpc.getCheckConnectionMethod() } returns networkConsumerGrpcMethodDesc
-            every { CustomerConsumerGrpc.getCheckConnectionMethod() } returns customerConsumerGrpcMethodDesc
-            every { DiagramConsumerGrpc.getCheckConnectionMethod() } returns diagramConsumerGrpcMethodDesc
-            every { UpdateNetworkStateServiceGrpc.getCheckConnectionMethod() } returns updateNetworkStateServiceGrpcMethodDesc
-            every { QueryNetworkStateServiceGrpc.getCheckConnectionMethod() } returns queryNetworkStateServiceGrpcMethodDesc
-
             val networkConsumerClientCall = mockk<ClientCall<checkConnection, Empty>>()
             val customerConsumerClientCall = mockk<ClientCall<checkConnection, Empty>>()
             val diagramConsumerClientCall = mockk<ClientCall<checkConnection, Empty>>()
@@ -406,7 +395,6 @@ internal class GrpcChannelBuilderTest {
             every { ClientCalls.blockingUnaryCall(updateNetworkStateServiceClientCall, any<checkConnection>()) } returns updateNetworkStateServiceResult
             every { ClientCalls.blockingUnaryCall(queryNetworkStateServiceClientCall, any<checkConnection>()) } returns queryNetworkStateServiceResult
 
-
             responses[NetworkConsumerClient::class]?.let {
                 every { ClientCalls.blockingUnaryCall(networkConsumerClientCall, any<checkConnection>()) } throws it
             } ?: (every { ClientCalls.blockingUnaryCall(networkConsumerClientCall, any<checkConnection>()) } returns networkConsumerResult)
@@ -421,21 +409,11 @@ internal class GrpcChannelBuilderTest {
 
             responses[UpdateNetworkStateClient::class]?.let {
                 every { ClientCalls.blockingUnaryCall(updateNetworkStateServiceClientCall, any<checkConnection>()) } throws it
-            } ?: (every {
-                ClientCalls.blockingUnaryCall(
-                    updateNetworkStateServiceClientCall,
-                    any<checkConnection>()
-                )
-            } returns updateNetworkStateServiceResult)
+            } ?: (every { ClientCalls.blockingUnaryCall(updateNetworkStateServiceClientCall, any<checkConnection>()) } returns updateNetworkStateServiceResult)
 
             responses[QueryNetworkStateClient::class]?.let {
                 every { ClientCalls.blockingUnaryCall(queryNetworkStateServiceClientCall, any<checkConnection>()) } throws it
-            } ?: (every {
-                ClientCalls.blockingUnaryCall(
-                    queryNetworkStateServiceClientCall,
-                    any<checkConnection>()
-                )
-            } returns queryNetworkStateServiceResult)
+            } ?: (every { ClientCalls.blockingUnaryCall(queryNetworkStateServiceClientCall, any<checkConnection>()) } returns queryNetworkStateServiceResult)
 
             builder.testConnection(grpcChannel, mockkedGrpcClientConnectionTests, debug, timeoutMs)
         }

--- a/src/test/kotlin/com/zepben/evolve/streaming/grpc/GrpcChannelBuilderTest.kt
+++ b/src/test/kotlin/com/zepben/evolve/streaming/grpc/GrpcChannelBuilderTest.kt
@@ -14,7 +14,7 @@ import com.zepben.auth.client.ZepbenTokenFetcher
 import com.zepben.auth.common.AuthMethod
 import com.zepben.evolve.streaming.get.*
 import com.zepben.evolve.streaming.mutations.UpdateNetworkStateClient
-import com.zepben.protobuf.checkConnection.checkConnection
+import com.zepben.protobuf.checkConnection.CheckConnectionRequest
 import com.zepben.testutils.exception.ExpectException.Companion.expect
 import io.grpc.*
 import io.grpc.netty.shaded.io.grpc.netty.NettyChannelBuilder
@@ -357,13 +357,13 @@ internal class GrpcChannelBuilderTest {
 
         mockkStatic(ClientCalls::class) {
 
-            val networkConsumerGrpcMethodDesc = mockk<MethodDescriptor<checkConnection, Empty>>()
-            val customerConsumerGrpcMethodDesc = mockk<MethodDescriptor<checkConnection, Empty>>()
-            val diagramConsumerGrpcMethodDesc = mockk<MethodDescriptor<checkConnection, Empty>>()
-            val updateNetworkStateServiceGrpcMethodDesc = mockk<MethodDescriptor<checkConnection, Empty>>()
-            val queryNetworkStateServiceGrpcMethodDesc = mockk<MethodDescriptor<checkConnection, Empty>>()
+            val networkConsumerGrpcMethodDesc = mockk<MethodDescriptor<CheckConnectionRequest, Empty>>()
+            val customerConsumerGrpcMethodDesc = mockk<MethodDescriptor<CheckConnectionRequest, Empty>>()
+            val diagramConsumerGrpcMethodDesc = mockk<MethodDescriptor<CheckConnectionRequest, Empty>>()
+            val updateNetworkStateServiceGrpcMethodDesc = mockk<MethodDescriptor<CheckConnectionRequest, Empty>>()
+            val queryNetworkStateServiceGrpcMethodDesc = mockk<MethodDescriptor<CheckConnectionRequest, Empty>>()
 
-            val mockkedGrpcClientConnectionTests: Map<String, MethodDescriptor<checkConnection, Empty>> = mapOf(
+            val mockkedGrpcClientConnectionTests: Map<String, MethodDescriptor<CheckConnectionRequest, Empty>> = mapOf(
                 "NetworkConsumerClient" to networkConsumerGrpcMethodDesc,
                 "CustomerConsumerClient" to customerConsumerGrpcMethodDesc,
                 "DiagramConsumerClient" to diagramConsumerGrpcMethodDesc,
@@ -371,11 +371,11 @@ internal class GrpcChannelBuilderTest {
                 "QueryNetworkStateClient" to queryNetworkStateServiceGrpcMethodDesc,
             )
 
-            val networkConsumerClientCall = mockk<ClientCall<checkConnection, Empty>>()
-            val customerConsumerClientCall = mockk<ClientCall<checkConnection, Empty>>()
-            val diagramConsumerClientCall = mockk<ClientCall<checkConnection, Empty>>()
-            val updateNetworkStateServiceClientCall = mockk<ClientCall<checkConnection, Empty>>()
-            val queryNetworkStateServiceClientCall = mockk<ClientCall<checkConnection, Empty>>()
+            val networkConsumerClientCall = mockk<ClientCall<CheckConnectionRequest, Empty>>()
+            val customerConsumerClientCall = mockk<ClientCall<CheckConnectionRequest, Empty>>()
+            val diagramConsumerClientCall = mockk<ClientCall<CheckConnectionRequest, Empty>>()
+            val updateNetworkStateServiceClientCall = mockk<ClientCall<CheckConnectionRequest, Empty>>()
+            val queryNetworkStateServiceClientCall = mockk<ClientCall<CheckConnectionRequest, Empty>>()
 
             every { channel.newCall(networkConsumerGrpcMethodDesc, any()) } returns networkConsumerClientCall
             every { channel.newCall(customerConsumerGrpcMethodDesc, any()) } returns customerConsumerClientCall
@@ -389,31 +389,31 @@ internal class GrpcChannelBuilderTest {
             val updateNetworkStateServiceResult = mockk<Empty>()
             val queryNetworkStateServiceResult = mockk<Empty>()
 
-            every { ClientCalls.blockingUnaryCall(networkConsumerClientCall, any<checkConnection>()) } returns networkConsumerResult
-            every { ClientCalls.blockingUnaryCall(customerConsumerClientCall, any<checkConnection>()) } returns customerConsumerResult
-            every { ClientCalls.blockingUnaryCall(diagramConsumerClientCall, any<checkConnection>()) } returns diagramConsumerResult
-            every { ClientCalls.blockingUnaryCall(updateNetworkStateServiceClientCall, any<checkConnection>()) } returns updateNetworkStateServiceResult
-            every { ClientCalls.blockingUnaryCall(queryNetworkStateServiceClientCall, any<checkConnection>()) } returns queryNetworkStateServiceResult
+            every { ClientCalls.blockingUnaryCall(networkConsumerClientCall, any<CheckConnectionRequest>()) } returns networkConsumerResult
+            every { ClientCalls.blockingUnaryCall(customerConsumerClientCall, any<CheckConnectionRequest>()) } returns customerConsumerResult
+            every { ClientCalls.blockingUnaryCall(diagramConsumerClientCall, any<CheckConnectionRequest>()) } returns diagramConsumerResult
+            every { ClientCalls.blockingUnaryCall(updateNetworkStateServiceClientCall, any<CheckConnectionRequest>()) } returns updateNetworkStateServiceResult
+            every { ClientCalls.blockingUnaryCall(queryNetworkStateServiceClientCall, any<CheckConnectionRequest>()) } returns queryNetworkStateServiceResult
 
             responses[NetworkConsumerClient::class]?.let {
-                every { ClientCalls.blockingUnaryCall(networkConsumerClientCall, any<checkConnection>()) } throws it
-            } ?: (every { ClientCalls.blockingUnaryCall(networkConsumerClientCall, any<checkConnection>()) } returns networkConsumerResult)
+                every { ClientCalls.blockingUnaryCall(networkConsumerClientCall, any<CheckConnectionRequest>()) } throws it
+            } ?: (every { ClientCalls.blockingUnaryCall(networkConsumerClientCall, any<CheckConnectionRequest>()) } returns networkConsumerResult)
 
             responses[CustomerConsumerClient::class]?.let {
-                every { ClientCalls.blockingUnaryCall(customerConsumerClientCall, any<checkConnection>()) } throws it
-            } ?: (every { ClientCalls.blockingUnaryCall(customerConsumerClientCall, any<checkConnection>()) } returns customerConsumerResult)
+                every { ClientCalls.blockingUnaryCall(customerConsumerClientCall, any<CheckConnectionRequest>()) } throws it
+            } ?: (every { ClientCalls.blockingUnaryCall(customerConsumerClientCall, any<CheckConnectionRequest>()) } returns customerConsumerResult)
 
             responses[DiagramConsumerClient::class]?.let {
-                every { ClientCalls.blockingUnaryCall(diagramConsumerClientCall, any<checkConnection>()) } throws it
-            } ?: (every { ClientCalls.blockingUnaryCall(diagramConsumerClientCall, any<checkConnection>()) } returns diagramConsumerResult)
+                every { ClientCalls.blockingUnaryCall(diagramConsumerClientCall, any<CheckConnectionRequest>()) } throws it
+            } ?: (every { ClientCalls.blockingUnaryCall(diagramConsumerClientCall, any<CheckConnectionRequest>()) } returns diagramConsumerResult)
 
             responses[UpdateNetworkStateClient::class]?.let {
-                every { ClientCalls.blockingUnaryCall(updateNetworkStateServiceClientCall, any<checkConnection>()) } throws it
-            } ?: (every { ClientCalls.blockingUnaryCall(updateNetworkStateServiceClientCall, any<checkConnection>()) } returns updateNetworkStateServiceResult)
+                every { ClientCalls.blockingUnaryCall(updateNetworkStateServiceClientCall, any<CheckConnectionRequest>()) } throws it
+            } ?: (every { ClientCalls.blockingUnaryCall(updateNetworkStateServiceClientCall, any<CheckConnectionRequest>()) } returns updateNetworkStateServiceResult)
 
             responses[QueryNetworkStateClient::class]?.let {
-                every { ClientCalls.blockingUnaryCall(queryNetworkStateServiceClientCall, any<checkConnection>()) } throws it
-            } ?: (every { ClientCalls.blockingUnaryCall(queryNetworkStateServiceClientCall, any<checkConnection>()) } returns queryNetworkStateServiceResult)
+                every { ClientCalls.blockingUnaryCall(queryNetworkStateServiceClientCall, any<CheckConnectionRequest>()) } throws it
+            } ?: (every { ClientCalls.blockingUnaryCall(queryNetworkStateServiceClientCall, any<CheckConnectionRequest>()) } returns queryNetworkStateServiceResult)
 
             builder.testConnection(grpcChannel, mockkedGrpcClientConnectionTests, debug, timeoutMs)
         }


### PR DESCRIPTION
# Description

I think this code works. PR TBA

# Other things
Also added a timeout. Defaults to 5 seconds per request so a total time to fail of 5 seconds per service tested (currently three).
 
# Associated tasks

List any other tasks / PRs that are required to be merged alongside this one (e.g. front end task for back end change or vice versa). If a PR exists, add a link. If not, just add an appropriate note here so reviewers know there is a dependency and will hold off merging until all things are ready.

# Test Steps

Explain in detail how your reviewer can test the changes proposed in this PR. If it cannot be tested, leave an explanation on why.

# Checklist

If any of these are not applicable, strikethrough the line `~like this~`. **Do not delete it!**. Let the reviewer decide if you should have done it.

### Code
- [ ] I have performed a self review of my own code (including checking issues raised when creating the PR).
- [ ] I have added/updated unit tests for these changes, and if not I have explained why they are not necessary.
- [ ] I have commented my code in any hard-to-understand or hacky areas.
- [ ] I have handled all new warnings generated by the compiler or IDE.
- [ ] I have rebased onto the target branch (usually main).

### Documentation
- [ ] I have updated the changelog.
- [ ] I have updated any documentation required for these changes.

# Breaking Changes
- [ ] I have considered if this is a breaking change and will communicate it with other team members if so.

Please leave a summary of the breaking changes here. This is useful for the reviewer, but also is useful for communication to the team when merged (e.g. you could copy and paste the summary into slack).

# Screenshots

Remove this section if the change cannot be shown through screenshots. Frontend changes should mostly include this section.
Screenshots can be copy-pasted into Github textboxes and a link will automatically be generated.
Remove this text if you choose to use this section.

| Before | After |
| --- | --- |
| ![image](image-link-here) | ![image](image-link-here) |
