### PR TITLE
Dev 2233 dont trace lv feeders from open points

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -10,6 +10,8 @@
   need to update your code.
 * `RemovePhases` now stops at open points like the `SetPhases` counterpart. If you were relying on the bug to remove phases through open points you will now
   need to start additional traces from the other side of the open points to maintain this behaviour.
+* `LvFeeders` can now start at circuit head switches within the transformer site. Any switches that are members of the transformers site will have `LvFeeder`s 
+  created with the `normalHeadTerminal` being the downstream terminal of the `Switch`, and the `LvFeeder` will be energised by the same `Feeder` as the transformer.
 
 ### New Features
 * Network state services for updating and querying network state events via gRPC.
@@ -44,6 +46,7 @@
 
 ### Fixes
 * `RemovePhases` now stops at open points like the `SetPhases` counterpart.
+* `AssignToLvFeeder` will no longer trace out from an open/de-energised `normalHeadTerminal`.
 
 ### Notes
 * None.

--- a/src/main/kotlin/com/zepben/evolve/services/network/tracing/feeder/AssignToLvFeeders.kt
+++ b/src/main/kotlin/com/zepben/evolve/services/network/tracing/feeder/AssignToLvFeeders.kt
@@ -11,6 +11,7 @@ package com.zepben.evolve.services.network.tracing.feeder
 import com.zepben.evolve.cim.iec61970.base.auxiliaryequipment.AuxiliaryEquipment
 import com.zepben.evolve.cim.iec61970.base.core.*
 import com.zepben.evolve.cim.iec61970.base.wires.ProtectedSwitch
+import com.zepben.evolve.cim.iec61970.base.wires.Switch
 import com.zepben.evolve.cim.iec61970.infiec61970.feeder.LvFeeder
 import com.zepben.evolve.services.network.NetworkService
 import com.zepben.evolve.services.network.tracing.networktrace.NetworkTrace
@@ -98,8 +99,16 @@ class AssignToLvFeeders {
             if ((terminal == null) || (lvFeedersToAssign.isEmpty()))
                 return
 
+            // If we start at an open switch, don't assign anything.
+            terminal.conductingEquipment?.also {
+                if (it is Switch && stateOperators.isOpen(it)) {
+                    lvFeedersToAssign.associateEquipment(it)
+                    return
+                }
+            }
+
             val traversal = createTrace(terminalToAuxEquipment, lvFeederStartPoints, lvFeedersToAssign)
-            traversal.run(terminal, false, canStopOnStartItem = false)
+            traversal.run(terminal, false, canStopOnStartItem = true)
         }
 
         private fun createTrace(


### PR DESCRIPTION
# Description

Just stops us assigning to LvFeeders from open head equipment. Note I think this fix also needs to be made for AssignToFeeders, as we thought it was happening but I can't see how it is.

# Test Steps

Needs unit tests, but otherwise you just run up the jemena model and look at HIGH-MILLER (02) and it's corresponding backfeed LvFeeder of PLENTY-DUNDAS (01) - the LvFeeder for the equipment in-between should only be the HIGH-MILLER circuit.

# Checklist

If any of these are not applicable, strikethrough the line `~like this~`. **Do not delete it!**. Let the reviewer decide if you should have done it.

### Code
- [ ] I have performed a self review of my own code (including checking issues raised when creating the PR).
- [ ] I have added/updated unit tests for these changes, and if not I have explained why they are not necessary.
- [ ] I have commented my code in any hard-to-understand or hacky areas.
- [ ] I have handled all new warnings generated by the compiler or IDE.
- [ ] I have rebased onto the target branch (usually main).

### Documentation
- [ ] I have updated the changelog.
- [ ] I have updated any documentation required for these changes.

# Breaking Changes
- [ ] I have considered if this is a breaking change and will communicate it with other team members if so.

I've included the changelog entry for LvFeeders starting at switches.
