### PR TITLE
DEV-1983 assign feeders from terminals

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -11,6 +11,8 @@
   use and read. See the documentation for usage details.
 * `SetDirection` now correctly applies the `BOTH` direction on all parts of the loop again, so if you were relying on the broken intermediate state, you will
   need to update your code.
+* `RemovePhases` now stops at open points like the `SetPhases` counterpart. If you were relying on the bug to remove phases through open points you will now
+  need to start additional traces from the other side of the open points to maintain this behaviour.
 * `SetDirection` now correctly sets directions for networks with `BusbarSection`.
 * `RemoveDirection` has been removed. It did not work reliably with dual fed networks with loops. You now need to clear direction using the new
   `ClearDirection` and reapply directions where appropriate using `SetDirection`.
@@ -18,7 +20,7 @@
 
 ### New Features
 * Network state services for updating and querying network state events via gRPC.
-* Client functionality for updating and querying network states via gRPC service stub. 
+* Client functionality for updating and querying network states via gRPC service stub.
 * `BaseService` now contains a `MetadataCollection` to tightly couple the metadata to the associated service.
 * Added `Services`, a new class which contains a copy of each `BaseService` supported by the SDK.
 * Added `connectWithAccessTokenInsecure()` for connecting to a gRPC service using an access token without SSL/TLS.
@@ -42,12 +44,17 @@
 * Added collection of `EndDeviceFunctionKind` to `EndDevice`
 * Added an unordered collection comparator.
 * Added the energized relationship for the current state of network between `Feeder` and `LvFeeder`.
-* Updated `NetworkConsumer`'s `getEquipmentForContainers`, `getEquipmentContainers` and `getEquipmentForLoop` to allow requesting normal, current or all 
-  equipments. 
+* Updated `NetworkConsumer`'s `getEquipmentForContainers`, `getEquipmentContainers` and `getEquipmentForLoop` to allow requesting normal, current or all
+  equipments.
+* You can now add sites to the `TestNetworkBuilder` via `addSite`.
+* You can now start the `AssignToFeeder` trace from a specified `Terminal` rather than all feeder heads.
+* When processing feeder assignments, all LV feeders belonging to a dist substation site will now be considered energized when the site is energized by a
+  feeder.
+* Major speed improvements have been made for `RemovePhases` when dealing with large networks with many nested loops.
 * `SetDirection` now supports networks with `BusbarSection` and will apply the `FeederDirection.CONNECTOR` value to their terminals.
 
 ### Fixes
-* None.
+* `RemovePhases` now stops at open points like the `SetPhases` counterpart.
 
 ### Notes
 * None.

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 
     <groupId>com.zepben</groupId>
     <artifactId>evolve-sdk</artifactId>
-    <version>0.24.0-NetworkTrace5</version>
+    <version>0.24.0-NetworkTrace3-feeder</version>
     <packaging>jar</packaging>
     <name>${project.groupId}:${project.artifactId}</name>
     <description>SDK for interaction with the evolve platform</description>

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 
     <groupId>com.zepben</groupId>
     <artifactId>evolve-sdk</artifactId>
-    <version>0.24.0-NetworkTrace3-feeder</version>
+    <version>0.24.0-NetworkTrace5</version>
     <packaging>jar</packaging>
     <name>${project.groupId}:${project.artifactId}</name>
     <description>SDK for interaction with the evolve platform</description>

--- a/src/main/kotlin/com/zepben/evolve/services/network/NetworkServiceUtils.kt
+++ b/src/main/kotlin/com/zepben/evolve/services/network/NetworkServiceUtils.kt
@@ -25,6 +25,7 @@ import com.zepben.evolve.cim.iec61968.infiec61968.infassetinfo.RelayInfo
 import com.zepben.evolve.cim.iec61968.metering.Meter
 import com.zepben.evolve.cim.iec61968.metering.UsagePoint
 import com.zepben.evolve.cim.iec61968.operations.OperationalRestriction
+import com.zepben.evolve.cim.iec61970.base.auxiliaryequipment.AuxiliaryEquipment
 import com.zepben.evolve.cim.iec61970.base.auxiliaryequipment.CurrentTransformer
 import com.zepben.evolve.cim.iec61970.base.auxiliaryequipment.FaultIndicator
 import com.zepben.evolve.cim.iec61970.base.auxiliaryequipment.PotentialTransformer
@@ -324,3 +325,29 @@ inline fun <R> whenNetworkServiceObject(
     is PerLengthPhaseImpedance -> isPerLengthPhaseImpedance(identifiedObject)
     else -> isOther(identifiedObject)
 }
+
+// TODO: Do we want to make the following public API?
+
+/**
+ * A map of all [AuxiliaryEquipment] in the [NetworkService] indexed by their terminals.
+ */
+internal val NetworkService.auxEquipmentByTerminal: Map<Terminal, List<AuxiliaryEquipment>>
+    get() = sequenceOf<AuxiliaryEquipment>()
+        .filter { it.terminal != null }
+        .groupBy { it.terminal!! }
+
+/**
+ * A set of all [ConductingEquipment] in the [NetworkService] that are at the top of a feeder.
+ */
+internal val NetworkService.feederStartPoints: Set<ConductingEquipment>
+    get() = sequenceOf<Feeder>()
+        .mapNotNull { it.normalHeadTerminal?.conductingEquipment }
+        .toSet()
+
+/**
+ * A set of all [ConductingEquipment] in the [NetworkService] that are at the top of an LV feeder.
+ */
+internal val NetworkService.lvFeederStartPoints: Set<ConductingEquipment>
+    get() = sequenceOf<LvFeeder>()
+        .mapNotNull { it.normalHeadTerminal?.conductingEquipment }
+        .toSet()

--- a/src/main/kotlin/com/zepben/evolve/services/network/tracing/feeder/AssignToFeeders.kt
+++ b/src/main/kotlin/com/zepben/evolve/services/network/tracing/feeder/AssignToFeeders.kt
@@ -14,10 +14,12 @@ import com.zepben.evolve.cim.iec61970.base.wires.PowerTransformer
 import com.zepben.evolve.cim.iec61970.base.wires.ProtectedSwitch
 import com.zepben.evolve.cim.iec61970.infiec61970.feeder.LvFeeder
 import com.zepben.evolve.services.network.NetworkService
+import com.zepben.evolve.services.network.auxEquipmentByTerminal
+import com.zepben.evolve.services.network.feederStartPoints
+import com.zepben.evolve.services.network.lvFeederStartPoints
 import com.zepben.evolve.services.network.tracing.networktrace.*
 import com.zepben.evolve.services.network.tracing.networktrace.conditions.Conditions.stopAtOpen
 import com.zepben.evolve.services.network.tracing.networktrace.operators.NetworkStateOperators
-import com.zepben.evolve.services.network.tracing.networktrace.operators.getFilteredContainers
 import com.zepben.evolve.services.network.tracing.traversal.StepContext
 
 /**
@@ -165,41 +167,3 @@ class AssignToFeeders {
     }
 
 }
-
-/**
- * A map of all [AuxiliaryEquipment] in the [NetworkService] indexed by their terminals.
- */
-// TODO [Review]: Where should this be located?
-val NetworkService.auxEquipmentByTerminal: Map<Terminal, List<AuxiliaryEquipment>>
-    get() = sequenceOf<AuxiliaryEquipment>()
-        .filter { it.terminal != null }
-        .groupBy { it.terminal!! }
-
-/**
- * A set of all [ConductingEquipment] in the [NetworkService] that are at the top of a feeder.
- */
-// TODO [Review]: Where should this be located?
-val NetworkService.feederStartPoints: Set<ConductingEquipment>
-    get() = sequenceOf<Feeder>()
-        .mapNotNull { it.normalHeadTerminal?.conductingEquipment }
-        .toSet()
-
-/**
- * A set of all [ConductingEquipment] in the [NetworkService] that are at the top of an LV feeder.
- */
-// TODO [Review]: Where should this be located?
-val NetworkService.lvFeederStartPoints: Set<ConductingEquipment>
-    get() = sequenceOf<LvFeeder>()
-        .mapNotNull { it.normalHeadTerminal?.conductingEquipment }
-        .toSet()
-
-/**
- * Find all LV feeders containing any [Equipment] in the [Site].
- */
-// TODO [Review]: Where should this be located?
-fun Collection<Site>.findLvFeeders(lvFeederStartPoints: Set<ConductingEquipment>, stateOperators: NetworkStateOperators): Iterable<LvFeeder> =
-    asSequence()
-        .flatMap { it.equipment }
-        .filter { it in lvFeederStartPoints }
-        .flatMap { equipment -> equipment.getFilteredContainers<LvFeeder>(stateOperators) }
-        .asIterable()

--- a/src/main/kotlin/com/zepben/evolve/services/network/tracing/feeder/AssignToLvFeeders.kt
+++ b/src/main/kotlin/com/zepben/evolve/services/network/tracing/feeder/AssignToLvFeeders.kt
@@ -9,14 +9,17 @@
 package com.zepben.evolve.services.network.tracing.feeder
 
 import com.zepben.evolve.cim.iec61970.base.auxiliaryequipment.AuxiliaryEquipment
-import com.zepben.evolve.cim.iec61970.base.core.ConductingEquipment
-import com.zepben.evolve.cim.iec61970.base.core.Terminal
+import com.zepben.evolve.cim.iec61970.base.core.*
 import com.zepben.evolve.cim.iec61970.base.wires.ProtectedSwitch
 import com.zepben.evolve.cim.iec61970.infiec61970.feeder.LvFeeder
 import com.zepben.evolve.services.network.NetworkService
-import com.zepben.evolve.services.network.tracing.networktrace.*
+import com.zepben.evolve.services.network.tracing.networktrace.NetworkTrace
+import com.zepben.evolve.services.network.tracing.networktrace.NetworkTraceActionType
+import com.zepben.evolve.services.network.tracing.networktrace.NetworkTraceStep
+import com.zepben.evolve.services.network.tracing.networktrace.Tracing
 import com.zepben.evolve.services.network.tracing.networktrace.conditions.Conditions.stopAtOpen
 import com.zepben.evolve.services.network.tracing.networktrace.operators.NetworkStateOperators
+import com.zepben.evolve.services.network.tracing.networktrace.operators.getFilteredContainers
 import com.zepben.evolve.services.network.tracing.traversal.StepContext
 
 /**
@@ -26,89 +29,167 @@ import com.zepben.evolve.services.network.tracing.traversal.StepContext
  */
 class AssignToLvFeeders {
 
+    /**
+     * Assign equipment to LV feeders in the specified network, given an optional start terminal.
+     *
+     * @param network The [NetworkService] to process.
+     * @param startTerminal An optional [Terminal] to start from:
+     * * When a start terminal is provided, the trace will assign all LV feeders associated with the terminals equipment to all connected equipment.
+     * * If no start terminal is provided, all LV feeder head terminals in the network will be used instead, assigning their associated feeder.
+     *
+     * NOTE: When starting from each LV feeder head, each LV feeder will also be associated with its energizing feeder(s).
+     */
     @JvmOverloads
-    fun run(network: NetworkService, networkStateOperators: NetworkStateOperators = NetworkStateOperators.NORMAL) {
-        val terminalToAuxEquipment = network.sequenceOf<AuxiliaryEquipment>()
-            .filter { it.terminal != null }
-            .groupBy { it.terminal!! }
+    fun run(
+        network: NetworkService,
+        networkStateOperators: NetworkStateOperators = NetworkStateOperators.NORMAL,
+        startTerminal: Terminal? = null
+    ): Unit = AssignToLvFeedersInternal(networkStateOperators).run(network, startTerminal)
 
-        val lvFeederStartPoints = network.sequenceOf<LvFeeder>()
-            .mapNotNull { lvFeeder ->
-                lvFeeder.normalHeadTerminal?.conductingEquipment?.also { headEquipment ->
-                    headEquipment.normalFeeders.forEach { feeder ->
-                        feeder.addNormalEnergizedLvFeeder(lvFeeder)
-                        lvFeeder.addNormalEnergizingFeeder(feeder)
-                    }
-                }
-            }
-            .toSet()
-
-        network.sequenceOf<LvFeeder>().forEach { run(networkStateOperators, it, lvFeederStartPoints, terminalToAuxEquipment) }
-    }
-
-    private fun run(
-        stateOperators: NetworkStateOperators,
-        lvFeeder: LvFeeder,
-        feederStartPoints: Set<ConductingEquipment>,
-        terminalToAuxEquipment: Map<Terminal, List<AuxiliaryEquipment>>,
-    ) {
-        val headTerminal = lvFeeder.normalHeadTerminal ?: return
-        val traversal = createTrace(stateOperators, terminalToAuxEquipment, feederStartPoints, listOf(lvFeeder))
-        traversal.run(headTerminal, canStopOnStartItem = false)
-    }
-
-    private fun createTrace(
-        stateOperators: NetworkStateOperators,
-        terminalToAuxEquipment: Map<Terminal, List<AuxiliaryEquipment>>,
+    /**
+     * Assign equipment to LV feeders tracing out from the supplied terminal.
+     *
+     * @param terminal The [Terminal] to trace from.
+     * @param lvFeederStartPoints A set of all [ConductingEquipment] containing an LV feeder head terminal. Must contain a list of all LV
+     * feeder head equipment that may be traced to from [terminal].
+     * @param terminalToAuxEquipment A map of all [AuxiliaryEquipment] by their attached [Terminal] that can be traced from [terminal].
+     * @param lvFeedersToAssign The list of LV feeders to assign to all traced equipment.
+     */
+    @JvmOverloads
+    fun run(
+        terminal: Terminal?,
         lvFeederStartPoints: Set<ConductingEquipment>,
+        terminalToAuxEquipment: Map<Terminal, List<AuxiliaryEquipment>>,
         lvFeedersToAssign: List<LvFeeder>,
-    ): NetworkTrace<Unit> {
-        return Tracing.networkTrace(stateOperators, NetworkTraceActionType.ALL_STEPS)
-            .addCondition { stopAtOpen() }
-            .addStopCondition { (path), _ -> lvFeederStartPoints.contains(path.toEquipment) }
-            .addQueueCondition { (path), _, _, _ -> !reachedHv(path.toEquipment) }
-            .addStepAction { (path), context ->
-                process(stateOperators, path, context, terminalToAuxEquipment, lvFeederStartPoints, lvFeedersToAssign)
-            }
-    }
+        networkStateOperators: NetworkStateOperators = NetworkStateOperators.NORMAL
+    ): Unit = AssignToLvFeedersInternal(networkStateOperators).run(terminal, lvFeederStartPoints, terminalToAuxEquipment, lvFeedersToAssign)
 
-    private val reachedHv: (ConductingEquipment) -> Boolean = { ce ->
-        ce.baseVoltage?.let { it.nominalVoltage >= 1000 } ?: false
-    }
-
-    private fun process(
-        stateOperators: NetworkStateOperators,
-        stepPath: NetworkTraceStep.Path,
-        stepContext: StepContext,
-        terminalToAuxEquipment: Map<Terminal, Collection<AuxiliaryEquipment>>,
-        lvFeederStartPoints: Set<ConductingEquipment>,
-        lvFeedersToAssign: List<LvFeeder>
+    private class AssignToLvFeedersInternal(
+        val stateOperators: NetworkStateOperators
     ) {
-        if (stepPath.tracedInternally && !stepContext.isStartItem)
-            return
 
-        if (lvFeederStartPoints.contains(stepPath.toEquipment)) {
-            stepPath.toEquipment.normalFeeders.forEach { feeder ->
-                lvFeedersToAssign.forEach { lvFeeder ->
-                    feeder.addNormalEnergizedLvFeeder(lvFeeder)
-                    lvFeeder.addNormalEnergizingFeeder(feeder)
+        fun run(network: NetworkService, startTerminal: Terminal?) {
+            val terminalToAuxEquipment = network.auxEquipmentByTerminal
+            val lvFeederStartPoints = network.lvFeederStartPoints
+
+            if (startTerminal == null) {
+                network.sequenceOf<LvFeeder>().forEach { lvFeeder ->
+                    lvFeeder.normalHeadTerminal?.conductingEquipment?.also { headEquipment ->
+                        headEquipment.getFilteredContainers<Feeder>(stateOperators).forEach { feeder ->
+                            stateOperators.associateEnergizingFeeder(feeder, lvFeeder)
+                        }
+                    }
+
+                    // We can run from each LV feeder as we process them, as being associated with their energizing feeders is not a requirement of the trace.
+                    run(lvFeeder.normalHeadTerminal, lvFeederStartPoints, terminalToAuxEquipment, listOf(lvFeeder))
                 }
+            } else {
+                run(startTerminal, lvFeederStartPoints, terminalToAuxEquipment, startTerminal.lvFeeders)
             }
         }
 
-        terminalToAuxEquipment[stepPath.toTerminal]?.forEach { auxEq ->
-            lvFeedersToAssign.forEach { feeder -> stateOperators.associateEquipmentAndContainer(auxEq, feeder) }
+        fun run(
+            terminal: Terminal?,
+            lvFeederStartPoints: Set<ConductingEquipment>,
+            terminalToAuxEquipment: Map<Terminal, List<AuxiliaryEquipment>>,
+            lvFeedersToAssign: List<LvFeeder>
+        ) {
+            // If there is no terminal, or there are no LV feeders to assign, then we have nothing to do.
+            if ((terminal == null) || (lvFeedersToAssign.isEmpty()))
+                return
+
+            val traversal = createTrace(terminalToAuxEquipment, lvFeederStartPoints, lvFeedersToAssign)
+            traversal.run(terminal, false, canStopOnStartItem = false)
         }
 
-        lvFeedersToAssign.forEach { feeder -> stateOperators.associateEquipmentAndContainer(stepPath.toEquipment, feeder) }
+        private fun createTrace(
+            terminalToAuxEquipment: Map<Terminal, List<AuxiliaryEquipment>>,
+            lvFeederStartPoints: Set<ConductingEquipment>,
+            lvFeedersToAssign: List<LvFeeder>,
+        ): NetworkTrace<Boolean> {
+            fun reachedHv(ce: ConductingEquipment) = ce.baseVoltage?.let { it.nominalVoltage >= 1000 } == true
 
-        if (stepPath.toEquipment is ProtectedSwitch) {
-            stepPath.toEquipment.relayFunctions.flatMap { it.schemes }.mapNotNull { it.system }.forEach { system ->
-                lvFeedersToAssign.forEach {
-                    stateOperators.associateEquipmentAndContainer(system, it)
+            return Tracing.networkTrace(stateOperators, NetworkTraceActionType.ALL_STEPS, computeData = { _, _, nextPath ->
+                // Store if we found an LV feeder head in the `data` to prevent looking this up multiple times on each iteration.
+                lvFeederStartPoints.contains(nextPath.toEquipment)
+            })
+                .addCondition { stopAtOpen() }
+                .addStopCondition { (_, foundLvFeeder), _ -> foundLvFeeder }
+                // If we have found an LV feeder head, we want to step on it regardless of if it is HV or not. Sometime people configure their transformers with
+                // the base voltage of the HV voltage, which will exclude these otherwise, but we won't keep processing past it as they are also stop conditions
+                .addQueueCondition { (path, foundLvFeeder), nextContext, _, _ -> foundLvFeeder || !reachedHv(path.toEquipment) }
+                .addStepAction { (path, foundLvFeeder), context ->
+                    process(
+                        path,
+                        foundLvFeeder,
+                        context,
+                        terminalToAuxEquipment,
+                        lvFeederStartPoints,
+                        lvFeedersToAssign
+                    )
                 }
+        }
+
+        private fun process(
+            stepPath: NetworkTraceStep.Path,
+            foundLvFeeder: Boolean,
+            stepContext: StepContext,
+            terminalToAuxEquipment: Map<Terminal, Collection<AuxiliaryEquipment>>,
+            lvFeederStartPoints: Set<ConductingEquipment>,
+            lvFeedersToAssign: List<LvFeeder>
+        ) {
+            if (stepPath.tracedInternally && !stepContext.isStartItem)
+                return
+
+            // It might be tempting to check `stepContext.isStopping`, but that would also pick up open points between LV feeders which is not good.
+            if (foundLvFeeder) {
+                val foundLvFeeders = stepPath.toEquipment.findLvFeeders(lvFeederStartPoints)
+
+                // Energize the LV feeders are a processing by the energizing feeders of what we found.
+                lvFeedersToAssign.energizedBy(foundLvFeeders.flatMap { stateOperators.getEnergizingFeeders(it) })
+
+                // Energize the LV feeders we found by the energizing feeders we are processing
+                foundLvFeeders.energizedBy(lvFeedersToAssign.flatMap { stateOperators.getEnergizingFeeders(it) })
+            }
+
+            lvFeedersToAssign.associateEquipment(terminalToAuxEquipment[stepPath.toTerminal].orEmpty())
+            lvFeedersToAssign.associateEquipment(stepPath.toEquipment)
+
+            when (stepPath.toEquipment) {
+                is ProtectedSwitch -> lvFeedersToAssign.associateRelaySystems(stepPath.toEquipment)
             }
         }
+
+        private fun ConductingEquipment.findLvFeeders(lvFeederStartPoints: Set<ConductingEquipment>): Iterable<LvFeeder> {
+            // Check to see if the LV feeder head is part of a dist transformer site. If so, we want to find all LV feeders on any equipment
+            // in the site, not just the LV feeder of the head we found.
+            val sites = getFilteredContainers<Site>(stateOperators)
+            return if (sites.isNotEmpty())
+                sites.findLvFeeders(lvFeederStartPoints, stateOperators)
+            else
+                getFilteredContainers<LvFeeder>(stateOperators)
+        }
+
+
+        private val Terminal.lvFeeders: List<LvFeeder>
+            get() = conductingEquipment.getFilteredContainers<LvFeeder>(stateOperators).toList()
+
+        private fun Iterable<EquipmentContainer>.associateEquipment(equipment: Iterable<Equipment>) = forEach { feeder ->
+            equipment.forEach { stateOperators.associateEquipmentAndContainer(it, feeder) }
+        }
+
+        private fun Iterable<EquipmentContainer>.associateEquipment(equipment: Equipment) = forEach { feeder ->
+            stateOperators.associateEquipmentAndContainer(equipment, feeder)
+        }
+
+        private fun Iterable<EquipmentContainer>.associateRelaySystems(toEquipment: ProtectedSwitch) {
+            associateEquipment(toEquipment.relayFunctions.flatMap { it.schemes }.mapNotNull { it.system })
+        }
+
+        private fun Iterable<LvFeeder>.energizedBy(feeders: Iterable<Feeder>) = forEach { lvFeeder ->
+            feeders.forEach { stateOperators.associateEnergizingFeeder(it, lvFeeder) }
+        }
+
     }
 
 }

--- a/src/main/kotlin/com/zepben/evolve/services/network/tracing/feeder/AssignToLvFeeders.kt
+++ b/src/main/kotlin/com/zepben/evolve/services/network/tracing/feeder/AssignToLvFeeders.kt
@@ -13,13 +13,14 @@ import com.zepben.evolve.cim.iec61970.base.core.*
 import com.zepben.evolve.cim.iec61970.base.wires.ProtectedSwitch
 import com.zepben.evolve.cim.iec61970.infiec61970.feeder.LvFeeder
 import com.zepben.evolve.services.network.NetworkService
+import com.zepben.evolve.services.network.auxEquipmentByTerminal
+import com.zepben.evolve.services.network.lvFeederStartPoints
 import com.zepben.evolve.services.network.tracing.networktrace.NetworkTrace
 import com.zepben.evolve.services.network.tracing.networktrace.NetworkTraceActionType
 import com.zepben.evolve.services.network.tracing.networktrace.NetworkTraceStep
 import com.zepben.evolve.services.network.tracing.networktrace.Tracing
 import com.zepben.evolve.services.network.tracing.networktrace.conditions.Conditions.stopAtOpen
 import com.zepben.evolve.services.network.tracing.networktrace.operators.NetworkStateOperators
-import com.zepben.evolve.services.network.tracing.networktrace.operators.getFilteredContainers
 import com.zepben.evolve.services.network.tracing.traversal.StepContext
 
 /**

--- a/src/main/kotlin/com/zepben/evolve/services/network/tracing/feeder/Util.kt
+++ b/src/main/kotlin/com/zepben/evolve/services/network/tracing/feeder/Util.kt
@@ -8,8 +8,9 @@
 
 package com.zepben.evolve.services.network.tracing.feeder
 
-import com.zepben.evolve.cim.iec61970.base.core.Feeder
-import com.zepben.evolve.cim.iec61970.base.core.Terminal
+import com.zepben.evolve.cim.iec61970.base.core.*
+import com.zepben.evolve.cim.iec61970.infiec61970.feeder.LvFeeder
+import com.zepben.evolve.services.network.tracing.networktrace.operators.NetworkStateOperators
 
 
 internal fun Terminal.isFeederHeadTerminal(): Boolean =
@@ -19,3 +20,26 @@ internal fun Terminal.isFeederHeadTerminal(): Boolean =
             .filterIsInstance<Feeder>()
             .any { it.normalHeadTerminal == this }
     } == true
+
+/**
+ * Find all LV feeders containing any [Equipment] in the [Site].
+ */
+internal fun Collection<Site>.findLvFeeders(lvFeederStartPoints: Set<ConductingEquipment>, stateOperators: NetworkStateOperators): Iterable<LvFeeder> =
+    asSequence()
+        .flatMap { it.equipment }
+        .filter { it in lvFeederStartPoints }
+        .flatMap { equipment -> equipment.getFilteredContainers<LvFeeder>(stateOperators) }
+        .asIterable()
+
+/**
+ * Retrieves a collection of containers associated with the given equipment.
+ *
+ * @receiver The equipment for which to get the associated containers.
+ * @param T The type of containers to find.
+ * @param operators The [NetworkStateOperators] used to select the containers.
+ * @return A collection of containers of the specified type that contain the specified equipment.
+ */
+internal inline fun <reified T : EquipmentContainer> Equipment?.getFilteredContainers(operators: NetworkStateOperators): Collection<T> = when (this) {
+    null -> emptyList()
+    else -> operators.getContainers(this).filterIsInstance<T>()
+}

--- a/src/main/kotlin/com/zepben/evolve/services/network/tracing/networktrace/operators/EquipmentContainerStateOperators.kt
+++ b/src/main/kotlin/com/zepben/evolve/services/network/tracing/networktrace/operators/EquipmentContainerStateOperators.kt
@@ -172,17 +172,3 @@ private class CurrentEquipmentContainerStateOperators : EquipmentContainerStateO
         feeder.addCurrentEnergizedLvFeeder(lvFeeder)
     }
 }
-
-/**
- * Retrieves a collection of containers associated with the given equipment.
- *
- * @receiver The equipment for which to get the associated containers.
- * @param T The type of containers to find.
- * @param operators The [NetworkStateOperators] used to select the containers.
- * @return A collection of containers of the specified type that contain the specified equipment.
- */
-// TODO [Review]: Where should these be located?
-inline fun <reified T : EquipmentContainer> Equipment?.getFilteredContainers(operators: NetworkStateOperators): Collection<T> = when (this) {
-    null -> emptyList()
-    else -> operators.getContainers(this).filterIsInstance<T>()
-}

--- a/src/main/kotlin/com/zepben/evolve/services/network/tracing/networktrace/operators/EquipmentContainerStateOperators.kt
+++ b/src/main/kotlin/com/zepben/evolve/services/network/tracing/networktrace/operators/EquipmentContainerStateOperators.kt
@@ -152,11 +152,9 @@ private class CurrentEquipmentContainerStateOperators : EquipmentContainerStateO
 
     override fun getContainers(equipment: Equipment): Collection<EquipmentContainer> = equipment.currentContainers
 
-    //todo update to use current variant once added. Using normal is what happens at the moment, which is wrong.
-    override fun getEnergizingFeeders(lvFeeder: LvFeeder): Collection<Feeder> = lvFeeder.normalEnergizingFeeders
+    override fun getEnergizingFeeders(lvFeeder: LvFeeder): Collection<Feeder> = lvFeeder.currentEnergizingFeeders
 
-    //todo update to use current variant once added. Using normal is what happens at the moment, which is wrong.
-    override fun getEnergizedLvFeeders(feeder: Feeder): Collection<LvFeeder> = feeder.normalEnergizedLvFeeders
+    override fun getEnergizedLvFeeders(feeder: Feeder): Collection<LvFeeder> = feeder.currentEnergizedLvFeeders
 
     override fun addEquipmentToContainer(equipment: Equipment, container: EquipmentContainer) {
         container.addCurrentEquipment(equipment)
@@ -167,13 +165,11 @@ private class CurrentEquipmentContainerStateOperators : EquipmentContainerStateO
     }
 
     override fun addEnergizingFeederToLvFeeder(feeder: Feeder, lvFeeder: LvFeeder) {
-        //todo update to use current variant once added. Adding as normal is what happens at the moment, which is wrong.
-        lvFeeder.addNormalEnergizingFeeder(feeder)
+        lvFeeder.addCurrentEnergizingFeeder(feeder)
     }
 
     override fun addEnergizedLvFeederToFeeder(lvFeeder: LvFeeder, feeder: Feeder) {
-        //todo update to use current variant once added. Adding as normal is what happens at the moment, which is wrong.
-        feeder.addNormalEnergizedLvFeeder(lvFeeder)
+        feeder.addCurrentEnergizedLvFeeder(lvFeeder)
     }
 }
 

--- a/src/main/kotlin/com/zepben/evolve/testing/TestNetworkBuilder.kt
+++ b/src/main/kotlin/com/zepben/evolve/testing/TestNetworkBuilder.kt
@@ -8,10 +8,7 @@
 
 package com.zepben.evolve.testing
 
-import com.zepben.evolve.cim.iec61970.base.core.ConductingEquipment
-import com.zepben.evolve.cim.iec61970.base.core.Feeder
-import com.zepben.evolve.cim.iec61970.base.core.PhaseCode
-import com.zepben.evolve.cim.iec61970.base.core.Terminal
+import com.zepben.evolve.cim.iec61970.base.core.*
 import com.zepben.evolve.cim.iec61970.base.wires.*
 import com.zepben.evolve.cim.iec61970.infiec61970.feeder.LvFeeder
 import com.zepben.evolve.services.network.NetworkService
@@ -493,6 +490,19 @@ open class TestNetworkBuilder {
     }
 
     /**
+     * Create a new [Site] containing the specified equipment.
+     *
+     * @param equipmentMrids The mRID's of the equipment to add to the site.
+     * @param mRID Option mRID for the new [Site].
+     *
+     * @return This [TestNetworkBuilder] to allow for fluent use.
+     */
+    fun addSite(vararg equipmentMrids: String, mRID: String? = null): TestNetworkBuilder {
+        network.createSite(mRID, equipmentMrids)
+        return this
+    }
+
+    /**
      * Get the [NetworkService] after apply traced phasing, feeder directions, and HV/LV feeder assignment.
      *
      * Does not infer phasing.
@@ -641,6 +651,18 @@ open class TestNetworkBuilder {
             }.also {
                 headEquipment.addContainer(it)
                 add(it)
+            }
+        }
+
+    private fun NetworkService.createSite(mRID: String?, equipmentMrids: Array<out String>) =
+        mRID.orNextId("site").let { id ->
+            Site(id).also { site ->
+                equipmentMrids.map { network.get<Equipment>(it)!! }.forEach {
+                    site.addEquipment(it)
+                    it.addContainer(site)
+                }
+
+                add(site)
             }
         }
 

--- a/src/test/kotlin/com/zepben/evolve/services/network/tracing/feeder/AssignToLvFeedersTest.kt
+++ b/src/test/kotlin/com/zepben/evolve/services/network/tracing/feeder/AssignToLvFeedersTest.kt
@@ -19,6 +19,7 @@ import com.zepben.evolve.cim.iec61970.base.protection.ProtectionRelaySystem
 import com.zepben.evolve.cim.iec61970.base.wires.Breaker
 import com.zepben.evolve.cim.iec61970.base.wires.ProtectedSwitch
 import com.zepben.evolve.cim.iec61970.infiec61970.feeder.LvFeeder
+import com.zepben.evolve.services.network.lvFeederStartPoints
 import com.zepben.evolve.services.network.testdata.DownstreamFeederStartPointNetwork
 import com.zepben.evolve.services.network.testdata.DroppedPhasesNetwork
 import com.zepben.evolve.services.network.testdata.FeederStartPointBetweenConductorsNetwork

--- a/src/test/kotlin/com/zepben/evolve/services/network/tracing/feeder/AssignToLvFeedersTest.kt
+++ b/src/test/kotlin/com/zepben/evolve/services/network/tracing/feeder/AssignToLvFeedersTest.kt
@@ -16,6 +16,7 @@ import com.zepben.evolve.cim.iec61970.base.core.Feeder
 import com.zepben.evolve.cim.iec61970.base.protection.CurrentRelay
 import com.zepben.evolve.cim.iec61970.base.protection.ProtectionRelayScheme
 import com.zepben.evolve.cim.iec61970.base.protection.ProtectionRelaySystem
+import com.zepben.evolve.cim.iec61970.base.wires.Breaker
 import com.zepben.evolve.cim.iec61970.base.wires.ProtectedSwitch
 import com.zepben.evolve.cim.iec61970.infiec61970.feeder.LvFeeder
 import com.zepben.evolve.services.network.testdata.DownstreamFeederStartPointNetwork
@@ -36,6 +37,9 @@ internal class AssignToLvFeedersTest {
     @JvmField
     @RegisterExtension
     var systemErr: SystemLogExtension = SystemLogExtension.SYSTEM_ERR.captureLog().muteOnSuccess()
+
+    val hvBaseVoltage = BaseVoltage().apply { nominalVoltage = 11000 }
+    val lvBaseVoltage = BaseVoltage().apply { nominalVoltage = 400 }
 
     private val assignToLvFeeders = AssignToLvFeeders()
 
@@ -107,9 +111,6 @@ internal class AssignToLvFeedersTest {
 
     @Test
     internal fun stopsAtHvEquipment() {
-        val hvBaseVoltage = BaseVoltage().apply { nominalVoltage = 11000 }
-        val lvBaseVoltage = BaseVoltage().apply { nominalVoltage = 400 }
-
         val network = TestNetworkBuilder()
             .fromBreaker { baseVoltage = lvBaseVoltage } // b0
             .toAcls { baseVoltage = lvBaseVoltage } // c1
@@ -128,9 +129,6 @@ internal class AssignToLvFeedersTest {
 
     @Test
     internal fun includesTransformers() {
-        val hvBaseVoltage = BaseVoltage().apply { nominalVoltage = 11000 }
-        val lvBaseVoltage = BaseVoltage().apply { nominalVoltage = 400 }
-
         val network = TestNetworkBuilder()
             .fromBreaker { baseVoltage = lvBaseVoltage } // b0
             .toAcls { baseVoltage = lvBaseVoltage } // c1
@@ -150,9 +148,6 @@ internal class AssignToLvFeedersTest {
 
     @Test
     internal fun onlyPoweredViaHeadEquipment() {
-        val hvBaseVoltage = BaseVoltage().apply { nominalVoltage = 11000 }
-        val lvBaseVoltage = BaseVoltage().apply { nominalVoltage = 400 }
-
         val network = TestNetworkBuilder()
             .fromBreaker { baseVoltage = hvBaseVoltage } // b0
             .toAcls { baseVoltage = hvBaseVoltage } // c1
@@ -262,6 +257,99 @@ internal class AssignToLvFeedersTest {
         assignToLvFeeders.run(network, NetworkStateOperators.NORMAL)
 
         validateEquipment(lvFeeder.equipment, "b0", "prsys3")
+    }
+
+    @Test
+    internal fun `lv feeders detect back feeds for energizing feeders`() {
+        //
+        // 1 b0 21 tx1 21--c2--21--c3--21 tx4 21 b5 2
+        //
+        // NOTE: Transformer is deliberately set to use the hv voltage as their base voltage to ensure they are still processed.
+        //
+        val network = TestNetworkBuilder()
+            .fromBreaker { baseVoltage = hvBaseVoltage } // b0
+            .toPowerTransformer { baseVoltage = hvBaseVoltage }// tx1
+            .toAcls { baseVoltage = lvBaseVoltage } // c2
+            .toAcls { baseVoltage = lvBaseVoltage } // c3
+            .toPowerTransformer { baseVoltage = hvBaseVoltage } // tx4
+            .toBreaker { baseVoltage = hvBaseVoltage } // b5
+            .addFeeder("b0") // fdr6
+            .addLvFeeder("tx1") // lvf7
+            .addLvFeeder("tx4", 1) // lvf8
+            .addFeeder("b5", 1) // fdr9
+            .network
+
+        val feeder6: Feeder = network["fdr6"]!!
+        val feeder9: Feeder = network["fdr9"]!!
+        val lvFeeder7: LvFeeder = network["lvf7"]!!
+        val lvFeeder8: LvFeeder = network["lvf8"]!!
+
+        AssignToFeeders().run(network, NetworkStateOperators.NORMAL)
+        assignToLvFeeders.run(network, NetworkStateOperators.NORMAL)
+
+        assertThat(feeder6.normalEnergizedLvFeeders, containsInAnyOrder(lvFeeder7, lvFeeder8))
+        assertThat(feeder9.normalEnergizedLvFeeders, containsInAnyOrder(lvFeeder7, lvFeeder8))
+        assertThat(lvFeeder7.normalEnergizingFeeders, containsInAnyOrder(feeder6, feeder9))
+        assertThat(lvFeeder8.normalEnergizingFeeders, containsInAnyOrder(feeder6, feeder9))
+    }
+
+    @Test
+    internal fun `lv feeders detect back feeds for dist substation sites`() {
+        //
+        //                1--c2--21 b3 2
+        // 1 tx0 21--c1--2
+        //                1--c4--21 b5 21--c6--21 b7 2
+        //
+        val network = TestNetworkBuilder()
+            .fromPowerTransformer(endActions = listOf({ ratedU = hvBaseVoltage.nominalVoltage }, { ratedU = lvBaseVoltage.nominalVoltage })) // tx0
+            .toAcls { baseVoltage = lvBaseVoltage } // c1
+            .toAcls { baseVoltage = lvBaseVoltage } // c2
+            .toBreaker { baseVoltage = lvBaseVoltage } // b3
+            .fromAcls { baseVoltage = lvBaseVoltage } // c4
+            .toBreaker { baseVoltage = lvBaseVoltage } // b5
+            .toAcls { baseVoltage = lvBaseVoltage } // c6
+            .toBreaker { baseVoltage = lvBaseVoltage } // b7
+            .connect("c1", "c4", 2, 1)
+            .addLvFeeder("tx0") // lvf8
+            .addLvFeeder("b3") // lvf9
+            .addLvFeeder("b5") // lvf10
+            .addLvFeeder("b7", 1) // lvf11
+            .addSite("tx0", "c1", "c2", "b3", "c4", "b5") // site12
+            .network
+
+        val operators = NetworkStateOperators.NORMAL
+        val b7 = network.get<Breaker>("b7")!!
+
+        val feeder = Feeder()
+        val lvFeeder8 = network.get<LvFeeder>("lvf8")!!.also { operators.associateEnergizingFeeder(feeder, it) }
+        val lvFeeder9 = network.get<LvFeeder>("lvf9")!!.also { operators.associateEnergizingFeeder(feeder, it) }
+        val lvFeeder10 = network.get<LvFeeder>("lvf10")!!.also { operators.associateEnergizingFeeder(feeder, it) }
+
+        // We create an LV feeder to assign from b7 with its associated energizing feeder, which we will test is assigned to all LV feeders
+        // in the dist substation site, not just the one on b5.
+        val backFeed = Feeder()
+        val lvFeeder = LvFeeder().also { operators.associateEnergizingFeeder(backFeed, it) }
+
+        assignToLvFeeders.run(
+            b7.terminals.first(),
+            network.lvFeederStartPoints,
+            terminalToAuxEquipment = emptyMap(),
+            listOf(lvFeeder),
+            operators
+        )
+
+        // Make sure the LV feeder traced stopped at the first LV feeder head.
+        assertThat(lvFeeder.equipment.map { it.mRID }, containsInAnyOrder("b7", "c6", "b5"))
+
+        // Make sure both feeders are now considered to be energizing all LV feeders.
+        assertThat(feeder.normalEnergizedLvFeeders, containsInAnyOrder(lvFeeder, lvFeeder8, lvFeeder9, lvFeeder10))
+        assertThat(backFeed.normalEnergizedLvFeeders, containsInAnyOrder(lvFeeder, lvFeeder8, lvFeeder9, lvFeeder10))
+
+        // Make sure all LV feeders are now considered to be energized by both feeders.
+        assertThat(lvFeeder.normalEnergizingFeeders, containsInAnyOrder(feeder, backFeed))
+        assertThat(lvFeeder8.normalEnergizingFeeders, containsInAnyOrder(feeder, backFeed))
+        assertThat(lvFeeder9.normalEnergizingFeeders, containsInAnyOrder(feeder, backFeed))
+        assertThat(lvFeeder10.normalEnergizingFeeders, containsInAnyOrder(feeder, backFeed))
     }
 
     private fun validateEquipment(equipment: Collection<Equipment>, vararg expectedMRIDs: String) {

--- a/src/test/kotlin/com/zepben/evolve/services/network/tracing/networktrace/conditions/DirectionConditionTest.kt
+++ b/src/test/kotlin/com/zepben/evolve/services/network/tracing/networktrace/conditions/DirectionConditionTest.kt
@@ -1,3 +1,11 @@
+/*
+ * Copyright 2025 Zeppelin Bend Pty Ltd
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
 package com.zepben.evolve.services.network.tracing.networktrace.conditions
 
 import com.zepben.evolve.cim.iec61970.base.core.Terminal

--- a/src/test/kotlin/com/zepben/evolve/services/network/tracing/networktrace/conditions/EquipmentStepLimitConditionTest.kt
+++ b/src/test/kotlin/com/zepben/evolve/services/network/tracing/networktrace/conditions/EquipmentStepLimitConditionTest.kt
@@ -1,3 +1,11 @@
+/*
+ * Copyright 2025 Zeppelin Bend Pty Ltd
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
 package com.zepben.evolve.services.network.tracing.networktrace.conditions
 
 import com.zepben.evolve.services.network.tracing.networktrace.NetworkTraceStep

--- a/src/test/kotlin/com/zepben/evolve/services/network/tracing/networktrace/conditions/EquipmentTypeStepLimitConditionTest.kt
+++ b/src/test/kotlin/com/zepben/evolve/services/network/tracing/networktrace/conditions/EquipmentTypeStepLimitConditionTest.kt
@@ -1,3 +1,11 @@
+/*
+ * Copyright 2025 Zeppelin Bend Pty Ltd
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
 package com.zepben.evolve.services.network.tracing.networktrace.conditions
 
 import com.zepben.evolve.cim.iec61970.base.wires.Breaker

--- a/src/test/kotlin/com/zepben/evolve/services/network/tracing/networktrace/conditions/OpenConditionTest.kt
+++ b/src/test/kotlin/com/zepben/evolve/services/network/tracing/networktrace/conditions/OpenConditionTest.kt
@@ -1,3 +1,11 @@
+/*
+ * Copyright 2025 Zeppelin Bend Pty Ltd
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
 package com.zepben.evolve.services.network.tracing.networktrace.conditions
 
 import com.zepben.evolve.cim.iec61970.base.core.ConductingEquipment

--- a/src/test/kotlin/com/zepben/evolve/services/network/tracing/phases/PhaseValidator.kt
+++ b/src/test/kotlin/com/zepben/evolve/services/network/tracing/phases/PhaseValidator.kt
@@ -16,32 +16,27 @@ import com.zepben.evolve.cim.iec61970.base.wires.SinglePhaseKind
 import com.zepben.evolve.services.network.NetworkService
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.equalTo
-import org.hamcrest.Matchers.nullValue
 
 object PhaseValidator {
 
-    fun validatePhases(network: NetworkService, id: String, phaseCode: PhaseCode) {
-        validatePhases(network, id, phaseCode.singlePhases)
+    fun validatePhases(network: NetworkService, id: String, expectedPhases: PhaseCode, vararg otherExpectedPhases: PhaseCode) {
+        validatePhases(network, id, expectedPhases.singlePhases, *otherExpectedPhases.map { it.singlePhases }.toTypedArray())
     }
 
-    fun validatePhases(network: NetworkService, id: String, expectedPhases: List<SinglePhaseKind>) {
-        validatePhases(network, id, expectedPhases.toList(), expectedPhases.toList())
-    }
-
-    fun validatePhases(network: NetworkService, id: String, expectedPhases1: PhaseCode, expectedPhases2: PhaseCode) {
-        validatePhases(network, id, expectedPhases1.singlePhases, expectedPhases2.singlePhases)
-    }
-
-    fun validatePhases(network: NetworkService, id: String, expectedPhases1: List<SinglePhaseKind>, expectedPhases2: List<SinglePhaseKind>?) {
+    fun validatePhases(network: NetworkService, id: String, expectedPhases: List<SinglePhaseKind>, vararg otherExpectedPhases: List<SinglePhaseKind>) {
         when (val io: IdentifiedObject = network[id]!!) {
-            is Terminal -> validatePhases(io, expectedPhases1, expectedPhases2 ?: expectedPhases1)
+            is Terminal -> validatePhases(io, expectedPhases, otherExpectedPhases.firstOrNull() ?: expectedPhases)
             is ConductingEquipment -> {
-                validatePhases(io.getTerminal(1), expectedPhases1)
+                val checkPhases = if (io.numTerminals() > 1 && otherExpectedPhases.isEmpty()) {
+                    listOf(expectedPhases, expectedPhases)
+                } else
+                    listOf(expectedPhases, *otherExpectedPhases)
 
-                if (expectedPhases2 != null)
-                    validatePhases(io.getTerminal(2), expectedPhases2)
-                else
-                    assertThat(io.getTerminal(2), nullValue())
+                assertThat(io.numTerminals(), equalTo(checkPhases.size))
+
+                checkPhases.forEachIndexed { index, phases ->
+                    validatePhases(io.getTerminal(index + 1), phases)
+                }
             }
 
             else -> throw IllegalArgumentException()

--- a/src/test/kotlin/com/zepben/evolve/services/network/tracing/traversal/TraversalTest.kt
+++ b/src/test/kotlin/com/zepben/evolve/services/network/tracing/traversal/TraversalTest.kt
@@ -1,3 +1,11 @@
+/*
+ * Copyright 2025 Zeppelin Bend Pty Ltd
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
 package com.zepben.evolve.services.network.tracing.traversal
 
 import org.hamcrest.MatcherAssert.assertThat


### PR DESCRIPTION
* `RemovePhases` now stops at open points like the `SetPhases` counterpart, with major speed improvements. 
* When processing feeder assignments, all LV feeders belonging to a dist substation site will now be considered energized when the site is energized by a feeder. 
* You can now add sites to the `TestNetworkBuilder` via `addSite`. 
* You can now start the `AssignToFeeder` trace from a specified `Terminal` rather than all feeder heads. 