### PR TITLE
Added support for add/remove of cut and jumper messages

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -41,8 +41,9 @@
 * Added `ctPrimary` and `minTargetDeadband` to `RegulatingContrl`.
 * Added an unordered collection comparator.
 * Added the energized relationship for the current state of network between `Feeder` and `LvFeeder`.
-* Updated `NetworkConsumer`'s `getEquipmentForContainers`, `getEquipmentContainers` and `getEquipmentForLoop` to allow requesting normal, current or all 
-  equipments. 
+* Updated `NetworkConsumer`'s `getEquipmentForContainers`, `getEquipmentContainers` and `getEquipmentForLoop` to allow requesting normal, current or all
+  equipments.
+* gRPC now supports `FeederDirection.CONNECTOR`.
 
 ### Fixes
 * None.

--- a/docs/docs/update-network-state-client.mdx
+++ b/docs/docs/update-network-state-client.mdx
@@ -117,7 +117,6 @@ import java.time.LocalDateTime;
 import java.util.List;
 
 var event1 = new SwitchStateEvent("event1", LocalDateTime.now(), "switch_id_1", SwitchAction.OPEN);
-var event2 = new SwitchStateEvent("event2", LocalDateTime.now(), "switch_id_2", SwitchAction.CLOSE);
 var response = client.setCurrentStates(1, List.of(event1));
 ```
 
@@ -129,7 +128,6 @@ import com.zepben.evolve.streaming.data.SwitchStateEvent
 import com.zepben.evolve.streaming.mutations.UpdateNetworkStateClient
 
 val event1 = SwitchStateEvent("event1", LocalDateTime.now(), "switch_id_1", SwitchAction.OPEN)
-val event2 = SwitchStateEvent("event2", LocalDateTime.now(), "switch_id_2", SwitchAction.CLOSE)
 val response = client.setCurrentStates(1, listOf(event1))
 ```
 
@@ -187,6 +185,167 @@ val batches = sequenceOf(
 client.setCurrentStates(batches).forEach { response ->
     // Process your responses here. You will get a response per batch.
 }
+```
+
+</TabItem>
+</Tabs>
+
+#### Adding cuts
+
+You can add a cut to an AC line segment by passing an `AddCutEvent` to the `setCurrentStates` function. This can be done with both individual events, and
+batches of events as shown above.
+
+<Tabs
+    groupId="code-example"
+    defaultValue="java"
+    values={[
+        { label: "Java", value: "java", },
+        { label: "Kotlin", value: "kotlin", },
+    ]
+}>
+<TabItem value="java">
+
+```java
+import com.zepben.evolve.streaming.data.AddCutEvent;
+import com.zepben.evolve.streaming.mutations.UpdateNetworkStateClient;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+var event1 = new AddCutEvent("event1", LocalDateTime.now(), "cut_id_1", "acls_id_1");
+var response = client.setCurrentStates(1, List.of(event1));
+```
+
+</TabItem>
+<TabItem  value="kotlin">
+
+```kotlin
+import com.zepben.evolve.streaming.data.AddCutEvent
+import com.zepben.evolve.streaming.mutations.UpdateNetworkStateClient
+
+val event1 = AddCutEvent("event1", LocalDateTime.now(), "cut_id_1", "acls_id_1")
+val response = client.setCurrentStates(1, listOf(event1))
+```
+
+</TabItem>
+</Tabs>
+
+#### Removing cuts
+
+You can remove previously added cuts by passing a `RemoveCutEvent` to the `setCurrentStates` function. This can be done with both individual events, and batches
+of events as shown above.
+
+<Tabs
+    groupId="code-example"
+    defaultValue="java"
+    values={[
+        { label: "Java", value: "java", },
+        { label: "Kotlin", value: "kotlin", },
+    ]
+}>
+<TabItem value="java">
+
+```java
+import com.zepben.evolve.streaming.data.RemoveCutEvent;
+import com.zepben.evolve.streaming.mutations.UpdateNetworkStateClient;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+var event1 = new RemoveCutEvent("event1", LocalDateTime.now(), "cut_id_1");
+var response = client.setCurrentStates(1, List.of(event1));
+```
+
+</TabItem>
+<TabItem  value="kotlin">
+
+```kotlin
+import com.zepben.evolve.streaming.data.RemoveCutEvent
+import com.zepben.evolve.streaming.mutations.UpdateNetworkStateClient
+
+val event1 = RemoveCutEvent("event1", LocalDateTime.now(), "cut_id_1")
+val response = client.setCurrentStates(1, listOf(event1))
+```
+
+</TabItem>
+</Tabs>
+
+#### Adding jumpers
+
+You can add a jumper between two pieces of equipment by passing an `AddJumperEvent` to the `setCurrentStates` function. This can be done with both individual
+events, and batches of events as shown above.
+
+<Tabs
+    groupId="code-example"
+    defaultValue="java"
+    values={[
+        { label: "Java", value: "java", },
+        { label: "Kotlin", value: "kotlin", },
+    ]
+}>
+<TabItem value="java">
+
+```java
+import com.zepben.evolve.streaming.data.AddJumperEvent;
+import com.zepben.evolve.streaming.data.JumperConnection;
+import com.zepben.evolve.streaming.mutations.UpdateNetworkStateClient;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+var event1 = new AddJumperEvent("event1", LocalDateTime.now(), "jumper_id_1", new JumperConnection("acls_id_1"), new JumperConnection("acls_id_2"));
+var response = client.setCurrentStates(1, List.of(event1));
+```
+
+</TabItem>
+<TabItem  value="kotlin">
+
+```kotlin
+import com.zepben.evolve.streaming.data.AddJumperEvent
+import com.zepben.evolve.streaming.mutations.UpdateNetworkStateClient
+
+val event1 = AddJumperEvent("event1", LocalDateTime.now(), "jumper_id_1", JumperConnection("acls_id_1"), JumperConnection("acls_id_2"))
+val response = client.setCurrentStates(1, listOf(event1))
+```
+
+</TabItem>
+</Tabs>
+
+#### Removing jumpers
+
+You can remove previously added jumpers by passing a `RemoveJumperEvent` to the `setCurrentStates` function. This can be done with both individual events, and
+batches of events as shown above.
+
+<Tabs
+    groupId="code-example"
+    defaultValue="java"
+    values={[
+        { label: "Java", value: "java", },
+        { label: "Kotlin", value: "kotlin", },
+    ]
+}>
+<TabItem value="java">
+
+```java
+import com.zepben.evolve.streaming.data.RemoveJumperEvent;
+import com.zepben.evolve.streaming.mutations.UpdateNetworkStateClient;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+var event1 = new RemoveJumperEvent("event1", LocalDateTime.now(), "jumper_id_1");
+var response = client.setCurrentStates(1, List.of(event1));
+```
+
+</TabItem>
+<TabItem  value="kotlin">
+
+```kotlin
+import com.zepben.evolve.streaming.data.RemoveJumperEvent
+import com.zepben.evolve.streaming.mutations.UpdateNetworkStateClient
+
+val event1 = RemoveJumperEvent("event1", LocalDateTime.now(), "jumper_id_1")
+val response = client.setCurrentStates(1, listOf(event1))
 ```
 
 </TabItem>

--- a/pom.xml
+++ b/pom.xml
@@ -74,7 +74,7 @@
         <dependency>
             <groupId>com.zepben.protobuf</groupId>
             <artifactId>evolve-grpc</artifactId>
-            <version>0.34.0-SNAPSHOT1</version>
+            <version>0.34.0-SNAPSHOT2</version>
         </dependency>
 
         <dependency>

--- a/src/main/kotlin/com/zepben/evolve/streaming/data/CurrentStateEvent.kt
+++ b/src/main/kotlin/com/zepben/evolve/streaming/data/CurrentStateEvent.kt
@@ -11,12 +11,17 @@ package com.zepben.evolve.streaming.data
 import com.zepben.evolve.cim.iec61970.base.core.PhaseCode
 import com.zepben.evolve.services.common.translator.toLocalDateTime
 import com.zepben.evolve.services.common.translator.toTimestamp
-import java.time.LocalDateTime
-import com.zepben.protobuf.ns.data.CurrentStateEvent as PBCurrentStateEvent
-import com.zepben.protobuf.ns.data.SwitchStateEvent as PBSwitchStateEvent
-import com.zepben.protobuf.ns.data.SwitchAction as PBSwitchAction
-import com.zepben.protobuf.cim.iec61970.base.core.PhaseCode as PBPhaseCode
 import com.zepben.protobuf.ns.data.CurrentStateEvent.EventCase
+import java.time.LocalDateTime
+import com.zepben.protobuf.cim.iec61970.base.core.PhaseCode as PBPhaseCode
+import com.zepben.protobuf.ns.data.AddCutEvent as PBAddCutEvent
+import com.zepben.protobuf.ns.data.AddJumperEvent as PBAddJumperEvent
+import com.zepben.protobuf.ns.data.CurrentStateEvent as PBCurrentStateEvent
+import com.zepben.protobuf.ns.data.JumperConnection as PBJumperConnection
+import com.zepben.protobuf.ns.data.RemoveCutEvent as PBRemoveCutEvent
+import com.zepben.protobuf.ns.data.RemoveJumperEvent as PBRemoveJumperEvent
+import com.zepben.protobuf.ns.data.SwitchAction as PBSwitchAction
+import com.zepben.protobuf.ns.data.SwitchStateEvent as PBSwitchStateEvent
 
 /**
  * An event to apply to the current state of the network.
@@ -37,6 +42,10 @@ sealed class CurrentStateEvent(
         internal fun fromPb(event: PBCurrentStateEvent): CurrentStateEvent =
             when (event.eventCase) {
                 EventCase.SWITCH -> SwitchStateEvent.fromPb(event)
+                EventCase.ADDCUT -> AddCutEvent.fromPb(event)
+                EventCase.REMOVECUT -> RemoveCutEvent.fromPb(event)
+                EventCase.ADDJUMPER -> AddJumperEvent.fromPb(event)
+                EventCase.REMOVEJUMPER -> RemoveJumperEvent.fromPb(event)
                 else -> throw UnsupportedOperationException("'${event.eventCase}' is currently unsupported.")
             }
     }
@@ -49,7 +58,7 @@ sealed class CurrentStateEvent(
     protected fun toPbBuilder(): PBCurrentStateEvent.Builder =
         PBCurrentStateEvent.newBuilder().also { pb ->
             pb.eventId = eventId
-            timestamp.toTimestamp()?.let { pb.timestamp = it} ?: pb.clearTimestamp()
+            timestamp.toTimestamp()?.let { pb.timestamp = it } ?: pb.clearTimestamp()
             pb.timestamp = timestamp.toTimestamp()
         }
 
@@ -77,7 +86,7 @@ class SwitchStateEvent @JvmOverloads constructor(
         /**
          * Creates a [SwitchStateEvent] object from protobuf [PBCurrentStateEvent]
          */
-        internal fun fromPb(event: PBCurrentStateEvent): CurrentStateEvent =
+        internal fun fromPb(event: PBCurrentStateEvent): SwitchStateEvent =
             SwitchStateEvent(
                 event.eventId,
                 event.timestamp.toLocalDateTime(),
@@ -118,6 +127,229 @@ class SwitchStateEvent @JvmOverloads constructor(
 }
 
 /**
+ * An event to add a cut to the network.
+ *
+ * @property eventId An identifier of this event. This must be unique across requests to allow detection of
+ * duplicates when requesting events via dates vs those streamed via live updates.
+ * @property timestamp The timestamp when the event occurred. This is always handled as UTC (Coordinated Universal Time).
+ * @property mRID The mRID of the cut defined by this event. This should match any future remove instructions.
+ * @property aclsMRID The mRID of the AC line segment that was cut.
+ */
+class AddCutEvent(
+    eventId: String,
+    timestamp: LocalDateTime?,
+    val mRID: String,
+    val aclsMRID: String
+) : CurrentStateEvent(eventId, timestamp) {
+
+    companion object {
+        /**
+         * Creates a [AddCutEvent] object from protobuf [PBCurrentStateEvent]
+         */
+        internal fun fromPb(event: PBCurrentStateEvent): AddCutEvent =
+            AddCutEvent(
+                event.eventId,
+                event.timestamp.toLocalDateTime(),
+                event.addCut.mrid,
+                event.addCut.aclsMRID
+            )
+    }
+
+    /**
+     * Creates a protobuf [PBCurrentStateEvent] object with switch from [AddCutEvent]
+     */
+    override fun toPb(): PBCurrentStateEvent = toPbBuilder().also { event ->
+        event.addCut = PBAddCutEvent.newBuilder().also {
+            it.mrid = mRID
+            it.aclsMRID = aclsMRID
+        }.build()
+    }.build()
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (javaClass != other?.javaClass) return false
+
+        other as AddCutEvent
+
+        if (eventId != other.eventId) return false
+        if (timestamp != other.timestamp) return false
+        if (mRID != other.mRID) return false
+        if (aclsMRID != other.aclsMRID) return false
+
+        return true
+    }
+
+    override fun hashCode(): Int = listOf(eventId, timestamp, mRID, aclsMRID).hashCode()
+
+}
+
+/**
+ * An event to remove a cut from the network.
+ *
+ * @property eventId An identifier of this event. This must be unique across requests to allow detection of
+ * duplicates when requesting events via dates vs those streamed via live updates.
+ * @property timestamp The timestamp when the event occurred. This is always handled as UTC (Coordinated Universal Time).
+ * @property mRID The mRID of the cut to remove. This should match a previously added cut.
+ */
+class RemoveCutEvent(
+    eventId: String,
+    timestamp: LocalDateTime?,
+    val mRID: String
+) : CurrentStateEvent(eventId, timestamp) {
+
+    companion object {
+        /**
+         * Creates a [RemoveCutEvent] object from protobuf [PBCurrentStateEvent]
+         */
+        internal fun fromPb(event: PBCurrentStateEvent): RemoveCutEvent =
+            RemoveCutEvent(
+                event.eventId,
+                event.timestamp.toLocalDateTime(),
+                event.addCut.mrid
+            )
+    }
+
+    /**
+     * Creates a protobuf [PBCurrentStateEvent] object with switch from [RemoveCutEvent]
+     */
+    override fun toPb(): PBCurrentStateEvent = toPbBuilder().also { event ->
+        event.removeCut = PBRemoveCutEvent.newBuilder().also {
+            it.mrid = mRID
+        }.build()
+    }.build()
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (javaClass != other?.javaClass) return false
+
+        other as RemoveCutEvent
+
+        if (eventId != other.eventId) return false
+        if (timestamp != other.timestamp) return false
+        if (mRID != other.mRID) return false
+
+        return true
+    }
+
+    override fun hashCode(): Int = listOf(eventId, timestamp, mRID).hashCode()
+
+}
+
+/**
+ * An event to add a jumper to the network.
+ *
+ * @property eventId An identifier of this event. This must be unique across requests to allow detection of
+ * duplicates when requesting events via dates vs those streamed via live updates.
+ * @property timestamp The timestamp when the event occurred. This is always handled as UTC (Coordinated Universal Time).
+ * @property mRID The mRID of the jumper affected by this event.
+ * @property from Information on how this jumper is connected at one end of the jumper.
+ * @property to Information on how this jumper is connected at the other end of the jumper.
+ */
+class AddJumperEvent(
+    eventId: String,
+    timestamp: LocalDateTime?,
+    val mRID: String,
+    val from: JumperConnection,
+    val to: JumperConnection
+) : CurrentStateEvent(eventId, timestamp) {
+
+    companion object {
+        /**
+         * Creates a [AddJumperEvent] object from protobuf [PBCurrentStateEvent]
+         */
+        internal fun fromPb(event: PBCurrentStateEvent): AddJumperEvent =
+            AddJumperEvent(
+                event.eventId,
+                event.timestamp.toLocalDateTime(),
+                event.addJumper.mrid,
+                JumperConnection.fromPb(event.addJumper.from),
+                JumperConnection.fromPb(event.addJumper.to)
+            )
+    }
+
+    /**
+     * Creates a protobuf [PBCurrentStateEvent] object with switch from [AddJumperEvent]
+     */
+    override fun toPb(): PBCurrentStateEvent = toPbBuilder().also { event ->
+        event.addJumper = PBAddJumperEvent.newBuilder().also {
+            it.mrid = mRID
+            it.from = from.toPb()
+            it.to = to.toPb()
+        }.build()
+    }.build()
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (javaClass != other?.javaClass) return false
+
+        other as AddJumperEvent
+
+        if (eventId != other.eventId) return false
+        if (timestamp != other.timestamp) return false
+        if (mRID != other.mRID) return false
+        if (from != other.from) return false
+        if (to != other.to) return false
+
+        return true
+    }
+
+    override fun hashCode(): Int = listOf(eventId, timestamp, mRID, from, to).hashCode()
+
+}
+
+/**
+ * An event to remove a jumper from the network.
+ *
+ * @property eventId An identifier of this event. This must be unique across requests to allow detection of
+ * duplicates when requesting events via dates vs those streamed via live updates.
+ * @property timestamp The timestamp when the event occurred. This is always handled as UTC (Coordinated Universal Time).
+ * @property mRID The mRID of the jumper affected by this event.
+ */
+class RemoveJumperEvent(
+    eventId: String,
+    timestamp: LocalDateTime?,
+    val mRID: String
+) : CurrentStateEvent(eventId, timestamp) {
+
+    companion object {
+        /**
+         * Creates a [RemoveJumperEvent] object from protobuf [PBCurrentStateEvent]
+         */
+        internal fun fromPb(event: PBCurrentStateEvent): RemoveJumperEvent =
+            RemoveJumperEvent(
+                event.eventId,
+                event.timestamp.toLocalDateTime(),
+                event.addCut.mrid
+            )
+    }
+
+    /**
+     * Creates a protobuf [PBCurrentStateEvent] object with switch from [RemoveJumperEvent]
+     */
+    override fun toPb(): PBCurrentStateEvent = toPbBuilder().also { event ->
+        event.removeJumper = PBRemoveJumperEvent.newBuilder().also {
+            it.mrid = mRID
+        }.build()
+    }.build()
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (javaClass != other?.javaClass) return false
+
+        other as RemoveJumperEvent
+
+        if (eventId != other.eventId) return false
+        if (timestamp != other.timestamp) return false
+        if (mRID != other.mRID) return false
+
+        return true
+    }
+
+    override fun hashCode(): Int = listOf(eventId, timestamp, mRID).hashCode()
+
+}
+
+/**
  * Enum representing possible actions for a switch.
  */
 enum class SwitchAction {
@@ -135,4 +367,43 @@ enum class SwitchAction {
      * A request to close a switch.
      */
     CLOSE
+}
+
+/**
+ * Information about how a jumper is connected to the network.
+ *
+ * @property connectedMRID The mRID of the conducting equipment (or terminal) connected to this end of the jumper.
+ */
+class JumperConnection(
+    val connectedMRID: String
+) {
+
+    companion object {
+        /**
+         * Creates a [JumperConnection] object from protobuf [PBJumperConnection]
+         */
+        internal fun fromPb(connection: PBJumperConnection): JumperConnection =
+            JumperConnection(
+                connection.connectedMRID
+            )
+    }
+
+    /**
+     * Creates a protobuf [PBCurrentStateEvent] object with switch from [AddJumperEvent]
+     */
+    fun toPb(): PBJumperConnection = PBJumperConnection.newBuilder().also {
+        it.connectedMRID = connectedMRID
+    }.build()
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (javaClass != other?.javaClass) return false
+
+        other as JumperConnection
+
+        return connectedMRID == other.connectedMRID
+    }
+
+    override fun hashCode(): Int = listOf(connectedMRID).hashCode()
+
 }

--- a/src/test/kotlin/com/zepben/evolve/streaming/data/CurrentStateEventTest.kt
+++ b/src/test/kotlin/com/zepben/evolve/streaming/data/CurrentStateEventTest.kt
@@ -29,22 +29,18 @@ internal class CurrentStateEventTest {
 
     @Test
     internal fun `CurrentStateEvent from protobuf`() {
-        val stateEvent = CurrentStateEvent.fromPb(PBCurrentStateEvent.newBuilder().apply {
-            switch = PBSwitchStateEvent.newBuilder().build()
-        }.build())
-
-        assertThat(stateEvent, instanceOf(SwitchStateEvent::class.java))
+        convertsToExpectedClass<SwitchStateEvent> { switch = PBSwitchStateEvent.newBuilder().build() }
+        convertsToExpectedClass<AddCutEvent> { addCut = PBAddCutEvent.newBuilder().build() }
+        convertsToExpectedClass<RemoveCutEvent> { removeCut = PBRemoveCutEvent.newBuilder().build() }
+        convertsToExpectedClass<AddJumperEvent> { addJumper = PBAddJumperEvent.newBuilder().build() }
+        convertsToExpectedClass<RemoveJumperEvent> { removeJumper = PBRemoveJumperEvent.newBuilder().build() }
     }
 
     @Test
     internal fun `CurrentStateEvent from protobuf throws UnsupportedException for classes other than switch`() {
-        notSupportedState { addCut = PBAddCutEvent.newBuilder().build() }
-
-        notSupportedState { removeCut = PBRemoveCutEvent.newBuilder().build() }
-
-        notSupportedState { addJumper = PBAddJumperEvent.newBuilder().build() }
-
-        notSupportedState { removeJumper = PBRemoveJumperEvent.newBuilder().build() }
+        assertThrows<UnsupportedOperationException> {
+            CurrentStateEvent.fromPb(PBCurrentStateEvent.newBuilder().build())
+        }
     }
 
     @Test
@@ -78,10 +74,11 @@ internal class CurrentStateEventTest {
         }
     }
 
-    private fun notSupportedState(block: PBCurrentStateEvent.Builder.() -> Unit) {
-        assertThrows<UnsupportedOperationException> {
-            CurrentStateEvent.fromPb(PBCurrentStateEvent.newBuilder().apply(block).build())
-        }
+    private inline fun <reified T : Any> convertsToExpectedClass(block: PBCurrentStateEvent.Builder.() -> Unit) {
+        val stateEvent = CurrentStateEvent.fromPb(PBCurrentStateEvent.newBuilder().apply(block).build())
+
+        assertThat(stateEvent, instanceOf(T::class.java))
+
     }
 
 }


### PR DESCRIPTION
# Description

Added support for add/remove of cut and jumper messages to the network state services for updating and querying network state events via gRPC.

# Test Steps

None.

# Checklist

If any of these are not applicable, strikethrough the line `~like this~`. **Do not delete it!**. Let the reviewer decide if you should have done it.

### Code
- [x] I have performed a self review of my own code (including checking issues raised when creating the PR).
- [x] I have added/updated unit tests for these changes, and if not I have explained why they are not necessary.
- [x] I have commented my code in any hard-to-understand or hacky areas.
- [x] I have handled all new warnings generated by the compiler or IDE.
- [x] I have rebased onto the target branch (usually main).

### Documentation
~- [ ] I have updated the changelog.~ Covered by initial message about network state services.
- [x] I have updated any documentation required for these changes.

# Breaking Changes
- [x] I have considered if this is a breaking change and will communicate it with other team members if so.

New sealed classes that may need to be handled, but nothing other than the branch this change is for is actually using them.