### PR TITLE
Do not find LvFeeders starting with open switches in the Site

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -38,6 +38,7 @@
   - AddJumperEvent from and to changed to fromConnection and toConnection
 * AddJumperEvent now uses correct protobuf classes when converting
 * RemoveJumperEvent now uses correct protobuf classes when converting
+* When finding `LvFeeders` in the `Site` we will now exclude `LvFeeders` that start with an open `Switch`
 
 ## [0.24.1] - 2025-01-23
 ### Breaking Changes

--- a/src/main/kotlin/com/zepben/evolve/testing/TestNetworkBuilder.kt
+++ b/src/main/kotlin/com/zepben/evolve/testing/TestNetworkBuilder.kt
@@ -636,8 +636,10 @@ open class TestNetworkBuilder {
                 normalHeadTerminal = headEquipment.getTerminal(sequenceNumber ?: headEquipment.numTerminals())!!
 
                 addEquipment(headEquipment)
+                addCurrentEquipment(headEquipment)
             }.also {
                 headEquipment.addContainer(it)
+                headEquipment.addCurrentContainer(it)
                 add(it)
             }
         }
@@ -648,8 +650,10 @@ open class TestNetworkBuilder {
                 normalHeadTerminal = headEquipment.getTerminal(sequenceNumber ?: headEquipment.numTerminals())!!
 
                 addEquipment(headEquipment)
+                addCurrentEquipment(headEquipment)
             }.also {
                 headEquipment.addContainer(it)
+                headEquipment.addCurrentContainer(it)
                 add(it)
             }
         }

--- a/src/test/kotlin/com/zepben/evolve/services/network/tracing/feeder/UtilTest.kt
+++ b/src/test/kotlin/com/zepben/evolve/services/network/tracing/feeder/UtilTest.kt
@@ -1,0 +1,53 @@
+package com.zepben.evolve.services.network.tracing.feeder
+
+import com.zepben.evolve.cim.iec61970.base.core.Equipment
+import com.zepben.evolve.cim.iec61970.base.core.Site
+import com.zepben.evolve.cim.iec61970.infiec61970.feeder.LvFeeder
+import com.zepben.evolve.services.network.getT
+import com.zepben.evolve.services.network.lvFeederStartPoints
+import com.zepben.evolve.services.network.tracing.networktrace.operators.NetworkStateOperators
+import com.zepben.evolve.testing.TestNetworkBuilder
+import org.hamcrest.MatcherAssert.assertThat
+import org.hamcrest.Matchers.containsInAnyOrder
+import org.junit.jupiter.api.Test
+
+class UtilTest {
+
+    @Test
+    fun `findLvFeeders excludes open switches`() {
+        //
+        // tx0 21 b1(lvf5) 21--c2--2
+        //     21 b3(lvf6) 21--c4--2
+        val site = Site()
+        val network = TestNetworkBuilder()
+            .fromPowerTransformer { addToSite(site) } // tx0
+            .toBreaker(isNormallyOpen = true, isOpen = true) { addToSite(site) }// b1
+            .toAcls() // c2
+            .branchFrom("tx0")
+            .toBreaker(isNormallyOpen = false, isOpen = false) { addToSite(site) }//b3
+            .toAcls() // c4
+            .addLvFeeder("b1") // lvf5
+            .addLvFeeder("b3") // lvf6
+            .network
+        val assignToLvFeeders = AssignToLvFeeders()
+
+        assignToLvFeeders.run(network, NetworkStateOperators.NORMAL, network.getT("b1", 2))
+        assignToLvFeeders.run(network, NetworkStateOperators.NORMAL, network.getT("b3", 2))
+        assignToLvFeeders.run(network, NetworkStateOperators.CURRENT, network.getT("b1", 2))
+        assignToLvFeeders.run(network, NetworkStateOperators.CURRENT, network.getT("b3", 2))
+
+        val lvf6 = network.get<LvFeeder>("lvf6")
+        val normalLvFeeders = setOf(site).findLvFeeders(network.lvFeederStartPoints, NetworkStateOperators.NORMAL)
+        assertThat(normalLvFeeders, containsInAnyOrder(lvf6))
+
+        val currentLvFeeders = setOf(site).findLvFeeders(network.lvFeederStartPoints, NetworkStateOperators.CURRENT)
+        assertThat(currentLvFeeders, containsInAnyOrder(lvf6))
+    }
+
+    private fun Equipment.addToSite(site: Site) {
+        site.addEquipment(this);
+        addContainer(site);
+        site.addCurrentEquipment(this)
+        addCurrentContainer(site)
+    }
+}

--- a/src/test/kotlin/com/zepben/evolve/services/network/tracing/feeder/UtilTest.kt
+++ b/src/test/kotlin/com/zepben/evolve/services/network/tracing/feeder/UtilTest.kt
@@ -1,3 +1,11 @@
+/*
+ * Copyright 2025 Zeppelin Bend Pty Ltd
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
 package com.zepben.evolve.services.network.tracing.feeder
 
 import com.zepben.evolve.cim.iec61970.base.core.Equipment


### PR DESCRIPTION
# Description

Fixes LvFeeders starting at open switches from being included when populating the normalEnergizedLvFeeders.

# Test Steps

Run it with a problematic network

# Checklist

If any of these are not applicable, strikethrough the line `~like this~`. **Do not delete it!**. Let the reviewer decide if you should have done it.

### Code
- [x] I have performed a self review of my own code (including checking issues raised when creating the PR).
- [x] I have added/updated unit tests for these changes, and if not I have explained why they are not necessary.
- [x] I have commented my code in any hard-to-understand or hacky areas.
- [x] I have handled all new warnings generated by the compiler or IDE.
- [x] I have rebased onto the target branch (usually main).

### Documentation
- [x] I have updated the changelog.
- [x] I have updated any documentation required for these changes.

# Breaking Changes
- [x] I have considered if this is a breaking change and will communicate it with other team members if so.

It's a fix