### PR TITLE
DEV-2316 Support cuts and clamps in tracing

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -40,6 +40,9 @@
   * `CimDatabaseTables`, `BaseDatabaseTables`, `CustomerDatabaseTables`, `DiagramDatabaseTables`, `NetworkDatabaseTables`, `MetricsDatabaseTables`
 * Removed `Class.getFieldExt` extension function.
 * `InjectionJob.metadata` property is no longer a nullable type and is now a readonly val.
+* `AcLineSegment` now only supports adding 2 terminals by default. Mid-span terminals are now considered deprecated and models should migrate to using `Clamp`.
+   If you need to enable the old behaviour you can set `AcLineSegment.midSpanTerminalsEnabled` to `true`, however this will cause adding  a `Cut` or 
+   a `Clamp` to the `AcLineSegment` to fail.
 
 ### New Features
 * Added `ClearDirection` that clears feeder directions.
@@ -60,6 +63,7 @@
   only effects the gRPC threads.
 * `QueryNetworkStateClient.reportBatchStatus` can be used to send status responses for batches returned from the service via
   `QueryNetworkStateClient.getCurrentStates`.
+* Tracing models with `Cut` and `Clamp` are now supported via the new tracing API.
 
 ### Fixes
 * `RemovePhases` now stops at open points like the `SetPhases` counterpart.
@@ -91,7 +95,7 @@
 * RemoveJumperEvent now uses correct protobuf classes when converting
 
 ### Notes
-* Tracing models with `Cut` and `Clamp` are now supported via the new tracing API.
+* None.
 
 ## [0.24.0] - 2025-01-21
 ### Breaking Changes

--- a/changelog.md
+++ b/changelog.md
@@ -91,7 +91,7 @@
 * RemoveJumperEvent now uses correct protobuf classes when converting
 
 ### Notes
-* None.
+* Tracing models with `Cut` and `Clamp` are now supported via the new tracing API.
 
 ## [0.24.0] - 2025-01-21
 ### Breaking Changes

--- a/changelog.md
+++ b/changelog.md
@@ -43,6 +43,8 @@
 * `AcLineSegment` now only supports adding 2 terminals by default. Mid-span terminals are now considered deprecated and models should migrate to using `Clamp`.
    If you need to enable the old behaviour you can set `AcLineSegment.midSpanTerminalsEnabled` to `true`, however this will cause adding  a `Cut` or 
    a `Clamp` to the `AcLineSegment` to fail.
+* `Clamp` can now only have a single terminal added.
+* `Cut` can now only have a maximum of 2 terminals added.
 
 ### New Features
 * Added `ClearDirection` that clears feeder directions.

--- a/changelog.md
+++ b/changelog.md
@@ -50,7 +50,11 @@
 * Created a new `SqlTable` that doesn't support creating schema creation statements by default.
 
 ### Enhancements
-* You can now add sites to the `TestNetworkBuilder` via `addSite`.
+* The following enhancements have been made to the `TestNetworkBuilder`:
+  * You can now add sites via `addSite`.
+  * You can now add busbar sections natively with `fromBusbarSection` and `toBusbarSection`.
+  * The prefix for generated mRIDs for "other" equipment can be specified with the `defaultMridPrefix` argument in `fromOther` and `toOther`.
+  * The action block for `fromOther` now has a receiver of the created type, rather than the generic `ConductingEquipment`.
 * You can now start the `AssignToFeeder` trace from a specified `Terminal` rather than all feeder heads.
 * When processing feeder assignments, all LV feeders belonging to a dist substation site will now be considered energized when the site is energized by a
   feeder.

--- a/changelog.md
+++ b/changelog.md
@@ -72,11 +72,6 @@
 ### Fixes
 * `RemovePhases` now stops at open points like the `SetPhases` counterpart.
 * `AssignToFeeder` and `AssignToLvFeeder` will no longer trace from start terminals that belong to open switches.
-* GrpcChannelBuilder's initial connectivity test no longer fails due to a lack of permissions on a subset of services.
-* Updated to latest SDK:
-  - AddJumperEvent from and to changed to fromConnection and toConnection
-* AddJumperEvent now uses correct protobuf classes when converting
-* RemoveJumperEvent now uses correct protobuf classes when converting
 * When finding `LvFeeders` in the `Site` we will now exclude `LvFeeders` that start with an open `Switch`
 
 ## [0.24.1] - 2025-01-23

--- a/changelog.md
+++ b/changelog.md
@@ -40,11 +40,9 @@
   * `CimDatabaseTables`, `BaseDatabaseTables`, `CustomerDatabaseTables`, `DiagramDatabaseTables`, `NetworkDatabaseTables`, `MetricsDatabaseTables`
 * Removed `Class.getFieldExt` extension function.
 * `InjectionJob.metadata` property is no longer a nullable type and is now a readonly val.
-* `AcLineSegment` now only supports adding 2 terminals by default. Mid-span terminals are now considered deprecated and models should migrate to using `Clamp`.
-   If you need to enable the old behaviour you can set `AcLineSegment.midSpanTerminalsEnabled` to `true`, however this will cause adding  a `Cut` or 
-   a `Clamp` to the `AcLineSegment` to fail.
-* `Clamp` can now only have a single terminal added.
-* `Cut` can now only have a maximum of 2 terminals added.
+* `AcLineSegment` supports adding a maximum of 2 terminals. Mid-span terminals are no longer supported and models should migrate to using `Clamp`.
+* `Clamp` supports only adding a single terminal.
+* `Cut` supports adding a maximum of 2 terminals.
 
 ### New Features
 * Added `ClearDirection` that clears feeder directions.

--- a/src/main/kotlin/com/zepben/evolve/cim/iec61970/base/wires/AcLineSegment.kt
+++ b/src/main/kotlin/com/zepben/evolve/cim/iec61970/base/wires/AcLineSegment.kt
@@ -39,6 +39,7 @@ class AcLineSegment @JvmOverloads constructor(mRID: String = "") : Conductor(mRI
             field = value
         }
 
+    @Suppress("DEPRECATION")
     override val maxTerminals: Int
         get() = if (midSpanTerminalsEnabled) super.maxTerminals else 2
 
@@ -162,7 +163,10 @@ class AcLineSegment @JvmOverloads constructor(mRID: String = "") : Conductor(mRI
         return this
     }
 
+    @Suppress("DEPRECATION")
     private fun validateCut(cut: Cut): Boolean {
+        check(!midSpanTerminalsEnabled) { "Cannot add cuts to AcLineSegment with midSpanTerminalsEnabled set to true"}
+
         if (validateReference(cut, ::getCut, "A Cut"))
             return true
 
@@ -175,7 +179,10 @@ class AcLineSegment @JvmOverloads constructor(mRID: String = "") : Conductor(mRI
         return false
     }
 
+    @Suppress("DEPRECATION")
     private fun validateClamp(clamp: Clamp): Boolean {
+        check(!midSpanTerminalsEnabled) { "Cannot add clamps to AcLineSegment with midSpanTerminalsEnabled set to true"}
+
         if (validateReference(clamp, ::getClamp, "A Clamp"))
             return true
 

--- a/src/main/kotlin/com/zepben/evolve/cim/iec61970/base/wires/AcLineSegment.kt
+++ b/src/main/kotlin/com/zepben/evolve/cim/iec61970/base/wires/AcLineSegment.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Zeppelin Bend Pty Ltd
+ * Copyright 2025 Zeppelin Bend Pty Ltd
  *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
@@ -27,6 +27,20 @@ import com.zepben.evolve.services.common.extensions.*
  * @property clamps The clamps connected to the line segment.
  */
 class AcLineSegment @JvmOverloads constructor(mRID: String = "") : Conductor(mRID) {
+
+    @Deprecated("Mid-span terminals are deprecated. Use Clamps instead.")
+    var midSpanTerminalsEnabled: Boolean = false
+        set(value) {
+            if (value) {
+                check(cuts.isEmpty() && clamps.isEmpty()) { "Cannot enable mid-span terminals when cuts or clamps are present"}
+            } else {
+                check(terminals.size == 2) { "Cannot disable mid-span terminals on segments with more than 2 terminals"}
+            }
+            field = value
+        }
+
+    override val maxTerminals: Int
+        get() = if (midSpanTerminalsEnabled) super.maxTerminals else 2
 
     var perLengthImpedance: PerLengthImpedance? = null
     private var _cuts: MutableList<Cut>? = null

--- a/src/main/kotlin/com/zepben/evolve/cim/iec61970/base/wires/AcLineSegment.kt
+++ b/src/main/kotlin/com/zepben/evolve/cim/iec61970/base/wires/AcLineSegment.kt
@@ -28,20 +28,7 @@ import com.zepben.evolve.services.common.extensions.*
  */
 class AcLineSegment @JvmOverloads constructor(mRID: String = "") : Conductor(mRID) {
 
-    @Deprecated("Mid-span terminals are deprecated. Use Clamps instead.")
-    var midSpanTerminalsEnabled: Boolean = false
-        set(value) {
-            if (value) {
-                check(cuts.isEmpty() && clamps.isEmpty()) { "Cannot enable mid-span terminals when cuts or clamps are present"}
-            } else {
-                check(terminals.size == 2) { "Cannot disable mid-span terminals on segments with more than 2 terminals"}
-            }
-            field = value
-        }
-
-    @Suppress("DEPRECATION")
-    override val maxTerminals: Int
-        get() = if (midSpanTerminalsEnabled) super.maxTerminals else 2
+    override val maxTerminals: Int get() = 2
 
     var perLengthImpedance: PerLengthImpedance? = null
     private var _cuts: MutableList<Cut>? = null
@@ -163,10 +150,7 @@ class AcLineSegment @JvmOverloads constructor(mRID: String = "") : Conductor(mRI
         return this
     }
 
-    @Suppress("DEPRECATION")
     private fun validateCut(cut: Cut): Boolean {
-        check(!midSpanTerminalsEnabled) { "Cannot add cuts to AcLineSegment with midSpanTerminalsEnabled set to true"}
-
         if (validateReference(cut, ::getCut, "A Cut"))
             return true
 
@@ -179,10 +163,7 @@ class AcLineSegment @JvmOverloads constructor(mRID: String = "") : Conductor(mRI
         return false
     }
 
-    @Suppress("DEPRECATION")
     private fun validateClamp(clamp: Clamp): Boolean {
-        check(!midSpanTerminalsEnabled) { "Cannot add clamps to AcLineSegment with midSpanTerminalsEnabled set to true"}
-
         if (validateReference(clamp, ::getClamp, "A Clamp"))
             return true
 

--- a/src/main/kotlin/com/zepben/evolve/cim/iec61970/base/wires/Clamp.kt
+++ b/src/main/kotlin/com/zepben/evolve/cim/iec61970/base/wires/Clamp.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Zeppelin Bend Pty Ltd
+ * Copyright 2025 Zeppelin Bend Pty Ltd
  *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
@@ -23,4 +23,6 @@ class Clamp @JvmOverloads constructor(mRID: String = "") : ConductingEquipment(m
     var lengthFromTerminal1: Double? = null
     var acLineSegment: AcLineSegment? = null
 
+    override val maxTerminals: Int
+        get() = 1
 }

--- a/src/main/kotlin/com/zepben/evolve/cim/iec61970/base/wires/Clamp.kt
+++ b/src/main/kotlin/com/zepben/evolve/cim/iec61970/base/wires/Clamp.kt
@@ -23,6 +23,5 @@ class Clamp @JvmOverloads constructor(mRID: String = "") : ConductingEquipment(m
     var lengthFromTerminal1: Double? = null
     var acLineSegment: AcLineSegment? = null
 
-    override val maxTerminals: Int
-        get() = 1
+    override val maxTerminals: Int get() = 1
 }

--- a/src/main/kotlin/com/zepben/evolve/cim/iec61970/base/wires/Cut.kt
+++ b/src/main/kotlin/com/zepben/evolve/cim/iec61970/base/wires/Cut.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Zeppelin Bend Pty Ltd
+ * Copyright 2025 Zeppelin Bend Pty Ltd
  *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
@@ -21,6 +21,8 @@ package com.zepben.evolve.cim.iec61970.base.wires
  * @property acLineSegment The line segment to which the cut is applied.
  */
 class Cut @JvmOverloads constructor(mRID: String = "") : Switch(mRID) {
+
+    override val maxTerminals: Int get() = 2
 
     var lengthFromTerminal1: Double? = null
     var acLineSegment: AcLineSegment? = null

--- a/src/main/kotlin/com/zepben/evolve/database/sqlite/cim/network/NetworkCimReader.kt
+++ b/src/main/kotlin/com/zepben/evolve/database/sqlite/cim/network/NetworkCimReader.kt
@@ -1153,17 +1153,6 @@ internal class NetworkCimReader : CimReader<NetworkService>() {
                 resultSet.getNullableString(table.CONDUCTING_EQUIPMENT_MRID.queryIndex),
                 typeNameAndMRID()
             )
-
-            when (val casted = conductingEquipment) {
-                is AcLineSegment -> {
-                    if (casted.terminals.size == 2) {
-                        logger.warn("Enabling mid-span terminals for ${casted.typeNameAndMRID()}. Mid-span terminals are deprecated and models should migrate to using Clamps.")
-                        @Suppress("DEPRECATION")
-                        casted.midSpanTerminalsEnabled = true
-                    }
-                }
-            }
-
             conductingEquipment?.addTerminal(this)
             phases = PhaseCode.valueOf(resultSet.getString(table.PHASES.queryIndex))
         }

--- a/src/main/kotlin/com/zepben/evolve/database/sqlite/cim/network/NetworkCimReader.kt
+++ b/src/main/kotlin/com/zepben/evolve/database/sqlite/cim/network/NetworkCimReader.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Zeppelin Bend Pty Ltd
+ * Copyright 2025 Zeppelin Bend Pty Ltd
  *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
@@ -1153,6 +1153,17 @@ internal class NetworkCimReader : CimReader<NetworkService>() {
                 resultSet.getNullableString(table.CONDUCTING_EQUIPMENT_MRID.queryIndex),
                 typeNameAndMRID()
             )
+
+            when (val casted = conductingEquipment) {
+                is AcLineSegment -> {
+                    if (casted.terminals.size == 2) {
+                        logger.warn("Enabling mid-span terminals for ${casted.typeNameAndMRID()}. Mid-span terminals are deprecated and models should migrate to using Clamps.")
+                        @Suppress("DEPRECATION")
+                        casted.midSpanTerminalsEnabled = true
+                    }
+                }
+            }
+
             conductingEquipment?.addTerminal(this)
             phases = PhaseCode.valueOf(resultSet.getString(table.PHASES.queryIndex))
         }

--- a/src/main/kotlin/com/zepben/evolve/services/network/tracing/networktrace/NetworkTrace.kt
+++ b/src/main/kotlin/com/zepben/evolve/services/network/tracing/networktrace/NetworkTrace.kt
@@ -151,7 +151,7 @@ class NetworkTrace<T> private constructor(
      * @param phases Phases to trace; `null` to ignore phases.
      */
     fun addStartItem(start: Terminal, data: T, phases: PhaseCode? = null): NetworkTrace<T> {
-        val startPath = NetworkTraceStep.Path(start, start, startNominalPhasePath(phases))
+        val startPath = NetworkTraceStep.Path(start, start, null, startNominalPhasePath(phases))
         addStartItem(NetworkTraceStep(startPath, 0, 0, data))
         return this
     }

--- a/src/main/kotlin/com/zepben/evolve/services/network/tracing/networktrace/NetworkTrace.kt
+++ b/src/main/kotlin/com/zepben/evolve/services/network/tracing/networktrace/NetworkTrace.kt
@@ -84,7 +84,7 @@ class NetworkTrace<T> private constructor(
         computeData: ComputeData<T>,
     ) : this(
         networkStateOperators,
-        BasicQueueType(NetworkTraceQueueNext.basic(networkStateOperators::isInService, computeData.withActionType(actionType)), queue),
+        BasicQueueType(NetworkTraceQueueNext.Basic(NetworkTraceStepPathProvider(networkStateOperators), computeData.withActionType(actionType)), queue),
         null,
         actionType,
     )
@@ -98,7 +98,7 @@ class NetworkTrace<T> private constructor(
         computeNextT: ComputeDataWithPaths<T>,
     ) : this(
         networkStateOperators,
-        BasicQueueType(NetworkTraceQueueNext.basic(networkStateOperators::isInService, computeNextT.withActionType(actionType)), queue),
+        BasicQueueType(NetworkTraceQueueNext.Basic(NetworkTraceStepPathProvider(networkStateOperators), computeNextT.withActionType(actionType)), queue),
         null,
         actionType,
     )
@@ -114,7 +114,7 @@ class NetworkTrace<T> private constructor(
     ) : this(
         networkStateOperators,
         BranchingQueueType(
-            NetworkTraceQueueNext.branching(networkStateOperators::isInService, computeData.withActionType(actionType)),
+            NetworkTraceQueueNext.Branching(NetworkTraceStepPathProvider(networkStateOperators), computeData.withActionType(actionType)),
             queueFactory,
             branchQueueFactory
         ),
@@ -134,7 +134,7 @@ class NetworkTrace<T> private constructor(
     ) : this(
         networkStateOperators,
         BranchingQueueType(
-            NetworkTraceQueueNext.branching(networkStateOperators::isInService, computeNextT.withActionType(actionType)),
+            NetworkTraceQueueNext.Branching(NetworkTraceStepPathProvider(networkStateOperators), computeNextT.withActionType(actionType)),
             queueFactory,
             branchQueueFactory
         ),

--- a/src/main/kotlin/com/zepben/evolve/services/network/tracing/networktrace/NetworkTraceQueueNext.kt
+++ b/src/main/kotlin/com/zepben/evolve/services/network/tracing/networktrace/NetworkTraceQueueNext.kt
@@ -9,126 +9,80 @@
 package com.zepben.evolve.services.network.tracing.networktrace
 
 import com.zepben.evolve.annotations.ZepbenExperimental
-import com.zepben.evolve.cim.iec61970.base.core.ConductingEquipment
-import com.zepben.evolve.cim.iec61970.base.core.Terminal
-import com.zepben.evolve.cim.iec61970.base.wires.BusbarSection
-import com.zepben.evolve.services.network.tracing.connectivity.TerminalConnectivityConnected
-import com.zepben.evolve.services.network.tracing.networktrace.NetworkTraceStep.Path
 import com.zepben.evolve.services.network.tracing.traversal.StepContext
 import com.zepben.evolve.services.network.tracing.traversal.Traversal
 
-private typealias CheckInService = (ConductingEquipment) -> Boolean
+internal abstract class NetworkTraceQueueNext(private val pathProvider: NetworkTraceStepPathProvider) {
 
-internal object NetworkTraceQueueNext {
-    fun <T> basic(isInService: CheckInService, computeData: ComputeData<T>): Traversal.QueueNext<NetworkTraceStep<T>> {
-        return Traversal.QueueNext { item, context, queueItem ->
-            nextTraceSteps(isInService, item, context, computeData).forEach { queueItem(it) }
+    internal class Basic<T> : NetworkTraceQueueNext, Traversal.QueueNext<NetworkTraceStep<T>> {
+
+        private val getNextSteps: (item: NetworkTraceStep<T>, context: StepContext) -> Iterator<NetworkTraceStep<T>>
+
+        constructor(pathProvider: NetworkTraceStepPathProvider, computeData: ComputeData<T>) : super(pathProvider) {
+            getNextSteps = { item, context -> nextTraceSteps(item, context, computeData).iterator() }
+        }
+
+        @ZepbenExperimental
+        constructor(pathProvider: NetworkTraceStepPathProvider, computeData: ComputeDataWithPaths<T>) : super(pathProvider) {
+            getNextSteps = { item, context -> nextTraceSteps(item, context, computeData).iterator() }
+        }
+
+        override fun accept(item: NetworkTraceStep<T>, context: StepContext, queueItem: (NetworkTraceStep<T>) -> Boolean) {
+            getNextSteps(item, context).forEach { queueItem(it) }
         }
     }
 
-    @ZepbenExperimental
-    fun <T> basic(isInService: CheckInService, computeNextT: ComputeDataWithPaths<T>): Traversal.QueueNext<NetworkTraceStep<T>> {
-        return Traversal.QueueNext { item, context, queueItem ->
-            nextTraceSteps(isInService, item, context, computeNextT).forEach { queueItem(it) }
+    internal class Branching<T> : NetworkTraceQueueNext, Traversal.BranchingQueueNext<NetworkTraceStep<T>> {
+
+        private val getNextSteps: (item: NetworkTraceStep<T>, context: StepContext) -> List<NetworkTraceStep<T>>
+
+        constructor(pathProvider: NetworkTraceStepPathProvider, computeData: ComputeData<T>) : super(pathProvider) {
+            getNextSteps = { item, context -> nextTraceSteps(item, context, computeData).toList() }
+        }
+
+        @ZepbenExperimental
+        constructor(pathProvider: NetworkTraceStepPathProvider, computeData: ComputeDataWithPaths<T>) : super(pathProvider) {
+            getNextSteps = { item, context -> nextTraceSteps(item, context, computeData) }
+        }
+
+        override fun accept(
+            item: NetworkTraceStep<T>,
+            context: StepContext,
+            queueItem: (NetworkTraceStep<T>) -> Boolean,
+            queueBranch: (NetworkTraceStep<T>) -> Boolean
+        ) {
+            val nextSteps = getNextSteps(item, context)
+            if (nextSteps.size == 1) queueItem(nextSteps[0]) else nextSteps.forEach { queueBranch(it) }
         }
     }
 
-    fun <T> branching(isInService: CheckInService, computeData: ComputeData<T>): Traversal.BranchingQueueNext<NetworkTraceStep<T>> {
-        return Traversal.BranchingQueueNext { item, context, queueItem, queueBranch ->
-            queueNextStepsBranching(nextTraceSteps(isInService, item, context, computeData).toList(), queueItem, queueBranch)
-        }
-    }
-
-    @ZepbenExperimental
-    fun <T> branching(isInService: CheckInService, computeNextT: ComputeDataWithPaths<T>): Traversal.BranchingQueueNext<NetworkTraceStep<T>> {
-        return Traversal.BranchingQueueNext { item, context, queueItem, queueBranch ->
-            queueNextStepsBranching(nextTraceSteps(isInService, item, context, computeNextT), queueItem, queueBranch)
-        }
-    }
-
-    private fun <T> queueNextStepsBranching(
-        nextSteps: List<NetworkTraceStep<T>>,
-        queueItem: (NetworkTraceStep<T>) -> Boolean,
-        queueBranch: (NetworkTraceStep<T>) -> Boolean,
-    ) {
-        when {
-            nextSteps.size == 1 -> queueItem(nextSteps[0])
-            nextSteps.size > 1 -> nextSteps.forEach { queueBranch(it) }
-        }
-    }
-
-    private fun <T> nextTraceSteps(
-        isInService: CheckInService,
+    protected fun <T> nextTraceSteps(
         currentStep: NetworkTraceStep<T>,
         currentContext: StepContext,
         computeData: ComputeData<T>,
     ): Sequence<NetworkTraceStep<T>> {
         val nextNumTerminalSteps = currentStep.nextNumTerminalSteps()
         val nextNumEquipmentSteps = currentStep.nextNumEquipmentSteps()
-        return nextStepPaths(isInService, currentStep.path).map {
+        return pathProvider.nextPaths(currentStep.path).map {
             NetworkTraceStep(it, nextNumTerminalSteps, nextNumEquipmentSteps, computeData.computeNext(currentStep, currentContext, it))
         }
     }
 
     @ZepbenExperimental
-    private fun <T> nextTraceSteps(
-        isInService: CheckInService,
+    protected fun <T> nextTraceSteps(
         currentStep: NetworkTraceStep<T>,
         currentContext: StepContext,
         computeNextT: ComputeDataWithPaths<T>,
     ): List<NetworkTraceStep<T>> {
         val nextNumTerminalSteps = currentStep.nextNumTerminalSteps()
         val nextNumEquipmentSteps = currentStep.nextNumEquipmentSteps()
-        val nextPaths = nextStepPaths(isInService, currentStep.path).toList()
+        val nextPaths = pathProvider.nextPaths(currentStep.path).toList()
         return nextPaths.map {
             NetworkTraceStep(it, nextNumTerminalSteps, nextNumEquipmentSteps, computeNextT.computeNext(currentStep, currentContext, it, nextPaths))
         }
     }
 
-    private fun nextStepPaths(isInService: CheckInService, path: Path): Sequence<Path> {
-        val nextTerminals = nextTerminals(isInService, path)
-
-        return if (path.nominalPhasePaths.isNotEmpty()) {
-            val phasePaths = path.nominalPhasePaths.map { it.to }.toSet()
-            nextTerminals
-                .map { nextTerminal -> TerminalConnectivityConnected.terminalConnectivity(path.toTerminal, nextTerminal, phasePaths) }
-                .filter { it.nominalPhasePaths.isNotEmpty() }
-                .map { Path(path.toTerminal, it.toTerminal, it.nominalPhasePaths) }
-        } else {
-            nextTerminals.map { Path(path.toTerminal, it) }
-        }
-    }
-
-    private fun nextTerminals(isInService: CheckInService, path: Path): Sequence<Terminal> {
-        val nextTerminals = if (path.tracedInternally) {
-            // We need to step externally to connected terminals. However:
-            // Busbars are only modelled with a single terminal. So if we find any we need to step to them before the
-            // other (non busbar) equipment connected to the same connectivity node. Once the busbar has been
-            // visited we then step to the other non busbar terminals connected to the same connectivity node.
-            if (path.toTerminal.hasConnectedBusbars())
-                path.toTerminal.connectedTerminals().filter { it.conductingEquipment is BusbarSection }
-            else
-                path.toTerminal.connectedTerminals()
-        } else {
-            // If we just visited a busbar, we step to the other terminals that share the same connectivity node.
-            // Otherwise, we internally step to the other terminals on the equipment
-            if (path.toEquipment is BusbarSection) {
-                // We don't need to step to terminals that are busbars as they would have been queued at the same time this busbar step was.
-                // We also don't try and go back to the terminal we came from as we already visited it to get to this busbar.
-                path.toTerminal.connectedTerminals().filter { it != path.fromTerminal && it.conductingEquipment !is BusbarSection }
-            } else {
-                path.toTerminal.otherTerminals()
-            }
-        }
-
-        return nextTerminals.filter { terminal -> terminal.conductingEquipment?.let { isInService(it) } == true }
-    }
-
-    private fun Terminal.hasConnectedBusbars(): Boolean =
-        connectivityNode?.terminals?.any { it !== this && it.conductingEquipment is BusbarSection } ?: false
-
     private fun NetworkTraceStep<*>.nextNumTerminalSteps() = numTerminalSteps + 1
     private fun NetworkTraceStep<*>.nextNumEquipmentSteps() = if (path.tracedInternally) numEquipmentSteps + 1 else numEquipmentSteps
-
 
 }

--- a/src/main/kotlin/com/zepben/evolve/services/network/tracing/networktrace/NetworkTraceQueueNext.kt
+++ b/src/main/kotlin/com/zepben/evolve/services/network/tracing/networktrace/NetworkTraceQueueNext.kt
@@ -62,9 +62,9 @@ internal abstract class NetworkTraceQueueNext(private val pathProvider: NetworkT
         computeData: ComputeData<T>,
     ): Sequence<NetworkTraceStep<T>> {
         val nextNumTerminalSteps = currentStep.nextNumTerminalSteps()
-        val nextNumEquipmentSteps = currentStep.nextNumEquipmentSteps()
         return pathProvider.nextPaths(currentStep.path).map {
-            NetworkTraceStep(it, nextNumTerminalSteps, nextNumEquipmentSteps, computeData.computeNext(currentStep, currentContext, it))
+            val data = computeData.computeNext(currentStep, currentContext, it)
+            NetworkTraceStep(it, nextNumTerminalSteps, it.nextNumEquipmentSteps(currentStep.numEquipmentSteps), data)
         }
     }
 
@@ -75,14 +75,14 @@ internal abstract class NetworkTraceQueueNext(private val pathProvider: NetworkT
         computeNextT: ComputeDataWithPaths<T>,
     ): List<NetworkTraceStep<T>> {
         val nextNumTerminalSteps = currentStep.nextNumTerminalSteps()
-        val nextNumEquipmentSteps = currentStep.nextNumEquipmentSteps()
         val nextPaths = pathProvider.nextPaths(currentStep.path).toList()
         return nextPaths.map {
-            NetworkTraceStep(it, nextNumTerminalSteps, nextNumEquipmentSteps, computeNextT.computeNext(currentStep, currentContext, it, nextPaths))
+            val data = computeNextT.computeNext(currentStep, currentContext, it, nextPaths)
+            NetworkTraceStep(it, nextNumTerminalSteps, it.nextNumEquipmentSteps(currentStep.numEquipmentSteps), data)
         }
     }
 
     private fun NetworkTraceStep<*>.nextNumTerminalSteps() = numTerminalSteps + 1
-    private fun NetworkTraceStep<*>.nextNumEquipmentSteps() = if (path.tracedInternally) numEquipmentSteps + 1 else numEquipmentSteps
+    private fun NetworkTraceStep.Path.nextNumEquipmentSteps(currentNum: Int) = if (tracedExternally) currentNum + 1 else currentNum
 
 }

--- a/src/main/kotlin/com/zepben/evolve/services/network/tracing/networktrace/NetworkTraceStep.kt
+++ b/src/main/kotlin/com/zepben/evolve/services/network/tracing/networktrace/NetworkTraceStep.kt
@@ -11,8 +11,6 @@ package com.zepben.evolve.services.network.tracing.networktrace
 import com.zepben.evolve.cim.iec61970.base.core.ConductingEquipment
 import com.zepben.evolve.cim.iec61970.base.core.Terminal
 import com.zepben.evolve.cim.iec61970.base.wires.AcLineSegment
-import com.zepben.evolve.cim.iec61970.base.wires.Clamp
-import com.zepben.evolve.cim.iec61970.base.wires.Cut
 import com.zepben.evolve.services.network.tracing.connectivity.NominalPhasePath
 import com.zepben.evolve.services.network.tracing.networktrace.NetworkTraceStep.Type
 
@@ -50,26 +48,24 @@ class NetworkTraceStep<out T>(
      * A limitation of the network trace is that all terminals must have associated conducting equipment. This means that if the [fromTerminal]
      * or [toTerminal] have `null` conducting equipment an [IllegalStateException] will be thrown.
      *
+     * No validation is done on the [traversedAcLineSegment] against the [fromTerminal] and [toTerminal]. It assumes the creator knows what they are doing
+     * and thus avoids the overhead of validation as this class will have lots if instances created as part of a [NetworkTrace].
+     *
      * @property fromTerminal The terminal that was stepped from.
      * @property toTerminal The terminal that was stepped to.
+     * @property traversedAcLineSegment If the fromTerminal and toTerminal path was via an AcLineSegment, this is the segment that was traversed.
      * @property nominalPhasePaths A list of nominal phase paths traced in this step. If this is empty, phases have been ignored.
      * @property fromEquipment The conducting equipment associated with the [fromTerminal].
      * @property toEquipment The conducting equipment associated with the [toTerminal].
      * @property tracedInternally `true` if the from and to terminals belong to the same equipment; `false` otherwise.
      * @property tracedExternally `true` if the from and to terminals belong to different equipment; `false` otherwise.
+     * @property didTraverseAcLineSegment `true` if [traversedAcLineSegment] is not null; `false` otherwise.
      */
     data class Path(
         val fromTerminal: Terminal,
         val toTerminal: Terminal,
+        val traversedAcLineSegment: AcLineSegment? = null,
         val nominalPhasePaths: List<NominalPhasePath> = emptyList(),
-
-        // This will need to be added when we add clamps to the model. The proposed idea is that if an AcLineSegment has multiple clamps and your current
-        // path is one of the clamps, one of the next step paths will be another clamp on the AcLineSegment, essentially jumping over the AcLineSegment for the Path.
-        // If there is a cut on the AcLineSegment, you may need to know about it, primarily because the cut could create an open point between the clamps that needs
-        // to prevent queuing as part of an "open test".
-        // NOTE: Not sure if we will actually need this in the constructor as you could technically pull it back off the Cut or Clamp from / to equipment.
-        //       There is just a performance hit to compute that vs if you already have it when constructing the object.
-        // abstract val viaSegment: AcLineSegment? = null,
     ) {
         val fromEquipment: ConductingEquipment =
             fromTerminal.conductingEquipment ?: error("Network trace does not support terminals that do not have conducting equipment")
@@ -81,33 +77,7 @@ class NetworkTraceStep<out T>(
 
         val tracedExternally: Boolean get() = !tracedInternally
 
-        // TODO: We know if we traversed a segment when we compute the next terminal in NetworkTraceStepPathProvider. Should we store this on the step, so we don't need to compute it?
-        //       There would be some overhead in passing around a flag in a pair with the terminal until we build the step. Is that more than computing it once each step?
-        // TODO: Any reason not have have this as public API?
-        val traversedAcLineSegment: Boolean
-            get() =
-                when {
-                    tracedInternally -> false
-                    fromEquipment is AcLineSegment -> when (toEquipment) {
-                        is Clamp -> toEquipment.acLineSegment === fromEquipment
-                        is Cut -> toEquipment.acLineSegment === fromEquipment
-                        else -> false
-                    }
-
-                    fromEquipment is Cut -> when (toEquipment) {
-                        is AcLineSegment -> fromEquipment.acLineSegment === toEquipment
-                        is Clamp -> fromEquipment.acLineSegment === toEquipment.acLineSegment
-                        else -> false
-                    }
-
-                    fromEquipment is Clamp -> when (toEquipment) {
-                        is AcLineSegment -> fromEquipment.acLineSegment === toEquipment
-                        is Cut -> fromEquipment.acLineSegment === toEquipment.acLineSegment
-                        else -> false
-                    }
-
-                    else -> false
-                }
+        val didTraverseAcLineSegment: Boolean get() = traversedAcLineSegment != null
     }
 
     /**

--- a/src/main/kotlin/com/zepben/evolve/services/network/tracing/networktrace/NetworkTraceStepPathProvider.kt
+++ b/src/main/kotlin/com/zepben/evolve/services/network/tracing/networktrace/NetworkTraceStepPathProvider.kt
@@ -8,9 +8,14 @@
 
 package com.zepben.evolve.services.network.tracing.networktrace
 
+import com.zepben.evolve.cim.iec61970.base.core.Equipment
 import com.zepben.evolve.cim.iec61970.base.core.Terminal
+import com.zepben.evolve.cim.iec61970.base.wires.AcLineSegment
 import com.zepben.evolve.cim.iec61970.base.wires.BusbarSection
+import com.zepben.evolve.cim.iec61970.base.wires.Clamp
+import com.zepben.evolve.cim.iec61970.base.wires.Cut
 import com.zepben.evolve.services.network.tracing.connectivity.TerminalConnectivityConnected
+import com.zepben.evolve.services.network.tracing.networktrace.operators.InServiceStateOperators
 import com.zepben.evolve.services.network.tracing.networktrace.operators.NetworkStateOperators
 
 internal class NetworkTraceStepPathProvider(val stateOperators: NetworkStateOperators) {
@@ -30,30 +35,159 @@ internal class NetworkTraceStepPathProvider(val stateOperators: NetworkStateOper
     }
 
     private fun nextTerminals(path: NetworkTraceStep.Path): Sequence<Terminal> {
-        val nextTerminals = if (path.tracedInternally) {
-            // We need to step externally to connected terminals. However:
-            // Busbars are only modelled with a single terminal. So if we find any we need to step to them before the
-            // other (non busbar) equipment connected to the same connectivity node. Once the busbar has been
-            // visited we then step to the other non busbar terminals connected to the same connectivity node.
-            if (path.toTerminal.hasConnectedBusbars())
-                path.toTerminal.connectedTerminals().filter { it.conductingEquipment is BusbarSection }
-            else
-                path.toTerminal.connectedTerminals()
-        } else {
-            // If we just visited a busbar, we step to the other terminals that share the same connectivity node.
-            // Otherwise, we internally step to the other terminals on the equipment
-            if (path.toEquipment is BusbarSection) {
-                // We don't need to step to terminals that are busbars as they would have been queued at the same time this busbar step was.
-                // We also don't try and go back to the terminal we came from as we already visited it to get to this busbar.
-                path.toTerminal.connectedTerminals().filter { it != path.fromTerminal && it.conductingEquipment !is BusbarSection }
+        val nextTerminals = when (val toEquipment = path.toEquipment) {
+            is AcLineSegment -> nextTerminalsFromAcLineSegment(toEquipment, path)
+            is BusbarSection -> nextTerminalsFromBusbar(path)
+            is Clamp -> nextTerminalsFromClamp(toEquipment, path)
+            is Cut -> nextTerminalsFromCut(toEquipment, path)
+            else -> if (path.tracedInternally) {
+                nextExternalTerminals(path)
             } else {
                 path.toTerminal.otherTerminals()
             }
         }
 
-        return nextTerminals.filter { terminal -> terminal.conductingEquipment?.let { stateOperators.isInService(it) } == true }
+        return nextTerminals.filter { terminal -> stateOperators.isInService(terminal.conductingEquipment) }
+    }
+
+    private fun nextTerminalsFromAcLineSegment(segment: AcLineSegment, path: NetworkTraceStep.Path): Sequence<Terminal> {
+        // If the path traversed the segment, we need to step externally from the segment terminal.
+        // Otherwise, we traverse the segment
+        return if (path.tracedInternally || path.traversedAcLineSegment) {
+            nextExternalTerminals(path)
+        } else {
+            if (path.toTerminal.sequenceNumber == 1)
+                segment.traverseFromTerminalTowardsT2(path.toTerminal, 0.0)
+            else
+                segment.traverseFromTerminalTowardsT1(path.toTerminal, Double.MAX_VALUE)
+        }
+    }
+
+    // We don't need to step to terminals that are busbars as they would have been queued at the same time this busbar step was.
+    // We also don't try and go back to the terminal we came from as we already visited it to get to this busbar.
+    private fun nextTerminalsFromBusbar(path: NetworkTraceStep.Path): Sequence<Terminal> =
+        path.toTerminal.connectedTerminals().filter { it != path.fromTerminal && it.conductingEquipment !is BusbarSection }
+
+    private fun nextTerminalsFromClamp(clamp: Clamp, path: NetworkTraceStep.Path): Sequence<Terminal> {
+        // If the path was from traversing an AcLineSegment, we need to step externally to other equipment.
+        // Else if we stepped here externally not from a segment, we need to traverse the segment both ways.
+        return if (path.traversedAcLineSegment) {
+            nextExternalTerminals(path)
+        } else {
+            when (val segment = clamp.acLineSegment) {
+                null -> emptySequence()
+                else -> segment.traverseFromTerminalBothWays(path.toTerminal, clamp.lengthFromT1Or0)
+            }
+        }
+    }
+
+    private fun nextTerminalsFromCut(cut: Cut, path: NetworkTraceStep.Path): Sequence<Terminal> {
+        // If the path was from traversing an AcLineSegment, we need to step externally to other equipment, and internally on the cut.
+        // Else if we stepped here externally not from a segment, we need to traverse the segment plus step internally on the cut.
+        val nextTerminals = if (path.traversedAcLineSegment) {
+            nextExternalTerminals(path)
+        } else {
+            when (val segment = cut.acLineSegment) {
+                null -> emptySequence()
+                else -> {
+                    val towardsT2: Boolean = path.toTerminal.sequenceNumber != 1
+                    segment.traverseFromTerminal(path.toTerminal, cut.lengthFromT1Or0, towardsT2)
+                }
+            }
+        }
+
+        return if (path.tracedInternally) {
+            nextTerminals + nextExternalTerminals(path)
+        } else {
+            val cutOtherTerminal = cut.getTerminal(if (path.toTerminal.sequenceNumber == 1) 2 else 1)
+            nextTerminals + cutOtherTerminal.asSequenceOrEmpty()
+        }
+    }
+
+    private fun nextExternalTerminals(path: NetworkTraceStep.Path): Sequence<Terminal> {
+        // When we step externally to other terminals we need to consider:
+        // Busbars are only modelled with a single terminal. So if we find any we need to step to them before the
+        // other (non busbar) equipment connected to the same connectivity node. Once the busbar has been
+        // visited we then step to the other non busbar terminals connected to the same connectivity node.
+        return when {
+            path.toEquipment is BusbarSection -> nextTerminalsFromBusbar(path)
+            path.toTerminal.hasConnectedBusbars() -> path.toTerminal.connectedTerminals().filter { it.conductingEquipment is BusbarSection }
+            else -> path.toTerminal.connectedTerminals()
+        }
+    }
+
+    private fun AcLineSegment.traverseFromTerminalTowardsT1(fromTerminal: Terminal, lengthFromT1: Double): Sequence<Terminal> =
+        traverseFromTerminal(fromTerminal, lengthFromT1, false)
+
+    private fun AcLineSegment.traverseFromTerminalTowardsT2(fromTerminal: Terminal, lengthFromT1: Double): Sequence<Terminal> =
+        traverseFromTerminal(fromTerminal, lengthFromT1, true)
+
+    private fun AcLineSegment.traverseFromTerminalBothWays(fromTerminal: Terminal, lengthFromT1: Double): Sequence<Terminal> =
+        traverseFromTerminalTowardsT1(fromTerminal, lengthFromT1) + traverseFromTerminalTowardsT2(fromTerminal, lengthFromT1)
+
+    private fun AcLineSegment.traverseFromTerminal(fromTerminal: Terminal, lengthFromT1: Double, towardsSegmentT2: Boolean): Sequence<Terminal> {
+        // We need to ignore cuts that are not "in service" because that means they do not exist!
+        // We also make sure we filter out the cut or the clamp we are starting at, so we don't compare it in our checks
+        val cuts = cuts.filter { it != fromTerminal.conductingEquipment && stateOperators.isInService(it) }
+        val clamps = clamps.filter { it != fromTerminal.conductingEquipment && stateOperators.isInService(it) }
+
+        // Can do a simple return if we don't need to do any special cuts/clamps processing
+        if (cuts.isEmpty() && clamps.isEmpty())
+            return fromTerminal.otherTerminals()
+
+        val nextCut = when {
+            towardsSegmentT2 -> cuts.filter { it.lengthFromT1Or0 > lengthFromT1 }.minByOrNull { it.lengthFromT1Or0 }
+            else -> cuts.filter { it.lengthFromT1Or0 < lengthFromT1 }.maxByOrNull { it.lengthFromT1Or0 }
+        }
+
+        val nextTerminalLengthFromTerminal1: Double = when {
+            towardsSegmentT2 -> nextCut?.lengthFromTerminal1 ?: Double.MAX_VALUE
+            else -> nextCut?.lengthFromTerminal1 ?: 0.0
+        }
+
+        val clampsBeforeNextTerminal = when {
+            towardsSegmentT2 -> clamps.asSequence().filter { it.lengthFromT1Or0 in lengthFromT1..nextTerminalLengthFromTerminal1 }
+            else -> clamps.asSequence().filter { it.lengthFromT1Or0 in nextTerminalLengthFromTerminal1..lengthFromT1 }
+        }
+
+        val nextTerminal = when {
+            nextCut == null -> getTerminal(if (towardsSegmentT2) 2 else 1)
+            else -> nextCut.getTerminal(if (towardsSegmentT2) 1 else 2)
+        }
+
+        return clampsBeforeNextTerminal.mapNotNull { it.getTerminal(1) } + nextTerminal.asSequenceOrEmpty()
     }
 
     private fun Terminal.hasConnectedBusbars(): Boolean =
         connectivityNode?.terminals?.any { it !== this && it.conductingEquipment is BusbarSection } ?: false
+
+
+    // todo: We know if we traversed when we compute the next terminal. Should we store this on the step so we don't need to compute it?
+    private val NetworkTraceStep.Path.traversedAcLineSegment: Boolean get() =
+        when {
+            tracedInternally -> false
+            fromEquipment is AcLineSegment -> when (toEquipment) {
+                is Clamp -> toEquipment.acLineSegment === fromEquipment
+                is Cut -> toEquipment.acLineSegment === fromEquipment
+                else -> false
+            }
+            fromEquipment is Cut -> when (toEquipment) {
+                is AcLineSegment -> fromEquipment.acLineSegment === toEquipment
+                is Clamp -> fromEquipment.acLineSegment === toEquipment.acLineSegment
+                else -> false
+            }
+            fromEquipment is Clamp -> when (toEquipment) {
+                is AcLineSegment -> fromEquipment.acLineSegment === toEquipment
+                is Cut -> fromEquipment.acLineSegment === toEquipment.acLineSegment
+                else -> false
+            }
+            else -> false
+        }
+
+    private val Cut.lengthFromT1Or0: Double get() = lengthFromTerminal1 ?: 0.0
+    private val Clamp.lengthFromT1Or0: Double get() = lengthFromTerminal1 ?: 0.0
+
+    private fun Terminal?.asSequenceOrEmpty(): Sequence<Terminal> = if (this != null) sequenceOf(this) else emptySequence()
+
+    private fun InServiceStateOperators.isInService(equipment: Equipment?): Boolean = equipment?.let { isInService(it) } ?: false
 }

--- a/src/main/kotlin/com/zepben/evolve/services/network/tracing/networktrace/NetworkTraceStepPathProvider.kt
+++ b/src/main/kotlin/com/zepben/evolve/services/network/tracing/networktrace/NetworkTraceStepPathProvider.kt
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2025 Zeppelin Bend Pty Ltd
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+package com.zepben.evolve.services.network.tracing.networktrace
+
+import com.zepben.evolve.cim.iec61970.base.core.Terminal
+import com.zepben.evolve.cim.iec61970.base.wires.BusbarSection
+import com.zepben.evolve.services.network.tracing.connectivity.TerminalConnectivityConnected
+import com.zepben.evolve.services.network.tracing.networktrace.operators.NetworkStateOperators
+
+internal class NetworkTraceStepPathProvider(val stateOperators: NetworkStateOperators) {
+
+    fun nextPaths(path: NetworkTraceStep.Path): Sequence<NetworkTraceStep.Path> {
+        val nextTerminals = nextTerminals(path)
+
+        return if (path.nominalPhasePaths.isNotEmpty()) {
+            val phasePaths = path.nominalPhasePaths.map { it.to }.toSet()
+            nextTerminals
+                .map { nextTerminal -> TerminalConnectivityConnected.terminalConnectivity(path.toTerminal, nextTerminal, phasePaths) }
+                .filter { it.nominalPhasePaths.isNotEmpty() }
+                .map { NetworkTraceStep.Path(path.toTerminal, it.toTerminal, it.nominalPhasePaths) }
+        } else {
+            nextTerminals.map { NetworkTraceStep.Path(path.toTerminal, it) }
+        }
+    }
+
+    private fun nextTerminals(path: NetworkTraceStep.Path): Sequence<Terminal> {
+        val nextTerminals = if (path.tracedInternally) {
+            // We need to step externally to connected terminals. However:
+            // Busbars are only modelled with a single terminal. So if we find any we need to step to them before the
+            // other (non busbar) equipment connected to the same connectivity node. Once the busbar has been
+            // visited we then step to the other non busbar terminals connected to the same connectivity node.
+            if (path.toTerminal.hasConnectedBusbars())
+                path.toTerminal.connectedTerminals().filter { it.conductingEquipment is BusbarSection }
+            else
+                path.toTerminal.connectedTerminals()
+        } else {
+            // If we just visited a busbar, we step to the other terminals that share the same connectivity node.
+            // Otherwise, we internally step to the other terminals on the equipment
+            if (path.toEquipment is BusbarSection) {
+                // We don't need to step to terminals that are busbars as they would have been queued at the same time this busbar step was.
+                // We also don't try and go back to the terminal we came from as we already visited it to get to this busbar.
+                path.toTerminal.connectedTerminals().filter { it != path.fromTerminal && it.conductingEquipment !is BusbarSection }
+            } else {
+                path.toTerminal.otherTerminals()
+            }
+        }
+
+        return nextTerminals.filter { terminal -> terminal.conductingEquipment?.let { stateOperators.isInService(it) } == true }
+    }
+
+    private fun Terminal.hasConnectedBusbars(): Boolean =
+        connectivityNode?.terminals?.any { it !== this && it.conductingEquipment is BusbarSection } ?: false
+}

--- a/src/test/kotlin/com/zepben/evolve/services/network/testdata/stupid/StupidlyLargeNetwork.kt
+++ b/src/test/kotlin/com/zepben/evolve/services/network/testdata/stupid/StupidlyLargeNetwork.kt
@@ -224,37 +224,6 @@ object StupidlyLargeNetwork {
         networkService.connect(createTerminal(networkService, node1, PhaseCode.C, 1), "cn_2")
         networkService.connect(createTerminal(networkService, node1, PhaseCode.B, 2), "cn_2")
 
-        @Suppress("DEPRECATION") val multiTerminalAcLineSegment1 =
-            AcLineSegment("multiTerminalAcLineSegment1").apply { name = "multiTerminalAcLineSegment1"; assetInfo = oh2; midSpanTerminalsEnabled = true }
-        @Suppress("DEPRECATION") val multiTerminalAcLineSegment2 =
-            AcLineSegment("multiTerminalAcLineSegment2").apply { assetInfo = oh2; length = Double.NaN; midSpanTerminalsEnabled = true }
-        val multiTerminalNode1 = Junction("multiTerminalNode1").apply { name = "multiTerminalNode1" }
-        val multiTerminalNode2 = Junction("multiTerminalNode2").apply { name = "multiTerminalNode2" }
-        val multiTerminalNode3 = Junction("multiTerminalNode3").apply { name = "multiTerminalNode3" }
-
-        networkService.connect(
-            createTerminal(networkService, multiTerminalAcLineSegment1, PhaseCode.A, 1),
-            createTerminal(networkService, multiTerminalAcLineSegment2, PhaseCode.A, 1)
-        )
-        networkService.connect(
-            createTerminal(networkService, multiTerminalAcLineSegment1, PhaseCode.A, 2),
-            createTerminal(networkService, multiTerminalNode1, PhaseCode.A, 1)
-        )
-        networkService.connect(
-            createTerminal(networkService, multiTerminalAcLineSegment1, PhaseCode.A, 3),
-            createTerminal(networkService, multiTerminalNode2, PhaseCode.A, 1)
-        )
-        networkService.connect(
-            createTerminal(networkService, multiTerminalAcLineSegment1, PhaseCode.A, 4),
-            createTerminal(networkService, multiTerminalNode3, PhaseCode.A, 1)
-        )
-
-        networkService.add(multiTerminalAcLineSegment1)
-        networkService.add(multiTerminalAcLineSegment2)
-        networkService.add(multiTerminalNode1)
-        networkService.add(multiTerminalNode2)
-        networkService.add(multiTerminalNode3)
-
         val transformerWithTypeNone = PowerTransformer("transformerWithTypeNone")
         val transformerWithTypeDist = PowerTransformer("transformerWithTypeDist")
         val transformerWithTypeIso = PowerTransformer("transformerWithTypeIso")

--- a/src/test/kotlin/com/zepben/evolve/services/network/testdata/stupid/StupidlyLargeNetwork.kt
+++ b/src/test/kotlin/com/zepben/evolve/services/network/testdata/stupid/StupidlyLargeNetwork.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Zeppelin Bend Pty Ltd
+ * Copyright 2025 Zeppelin Bend Pty Ltd
  *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
@@ -224,8 +224,10 @@ object StupidlyLargeNetwork {
         networkService.connect(createTerminal(networkService, node1, PhaseCode.C, 1), "cn_2")
         networkService.connect(createTerminal(networkService, node1, PhaseCode.B, 2), "cn_2")
 
-        val multiTerminalAcLineSegment1 = AcLineSegment("multiTerminalAcLineSegment1").apply { name = "multiTerminalAcLineSegment1"; assetInfo = oh2 }
-        val multiTerminalAcLineSegment2 = AcLineSegment("multiTerminalAcLineSegment2").apply { assetInfo = oh2; length = Double.NaN }
+        @Suppress("DEPRECATION") val multiTerminalAcLineSegment1 =
+            AcLineSegment("multiTerminalAcLineSegment1").apply { name = "multiTerminalAcLineSegment1"; assetInfo = oh2; midSpanTerminalsEnabled = true }
+        @Suppress("DEPRECATION") val multiTerminalAcLineSegment2 =
+            AcLineSegment("multiTerminalAcLineSegment2").apply { assetInfo = oh2; length = Double.NaN; midSpanTerminalsEnabled = true }
         val multiTerminalNode1 = Junction("multiTerminalNode1").apply { name = "multiTerminalNode1" }
         val multiTerminalNode2 = Junction("multiTerminalNode2").apply { name = "multiTerminalNode2" }
         val multiTerminalNode3 = Junction("multiTerminalNode3").apply { name = "multiTerminalNode3" }

--- a/src/test/kotlin/com/zepben/evolve/services/network/tracing/networktrace/NetworkTraceQueueNextTest.kt
+++ b/src/test/kotlin/com/zepben/evolve/services/network/tracing/networktrace/NetworkTraceQueueNextTest.kt
@@ -1,0 +1,134 @@
+/*
+ * Copyright 2025 Zeppelin Bend Pty Ltd
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+package com.zepben.evolve.services.network.tracing.networktrace
+
+import com.zepben.evolve.services.network.tracing.traversal.StepContext
+import io.mockk.every
+import io.mockk.mockk
+import org.hamcrest.MatcherAssert.assertThat
+import org.hamcrest.Matchers.equalTo
+import org.hamcrest.Matchers.hasSize
+import org.junit.jupiter.api.Test
+
+class NetworkTraceQueueNextTest {
+
+    private val pathProvider = mockk<NetworkTraceStepPathProvider>()
+    private val dataComputer = mockk<ComputeData<String>>()
+    private val queuer = TestQueuer<String>()
+    private val branchingQueuer = TestQueuer<String>()
+
+    @Test
+    fun `queues next basic`() {
+        val queueNext = NetworkTraceQueueNext.Basic(pathProvider, dataComputer)
+
+        val seedPath = mockk<NetworkTraceStep.Path>()
+        val seedStep = mockk<NetworkTraceStep<String>> {
+            every { path } returns seedPath
+            every { numEquipmentSteps } returns 1
+            every { numTerminalSteps } returns 3
+        }
+        val seedContext = mockk<StepContext>()
+
+        val nextPath1 = mockk<NetworkTraceStep.Path> { every { tracedExternally } returns true }
+        val nextPath2 = mockk<NetworkTraceStep.Path> { every { tracedExternally } returns false }
+        every { pathProvider.nextPaths(seedPath) } returns sequenceOf(nextPath1, nextPath2)
+
+        every { dataComputer.computeNext(seedStep, seedContext, nextPath1) } returns "Foo"
+        every { dataComputer.computeNext(seedStep, seedContext, nextPath2) } returns "Bar"
+
+        queueNext.accept(seedStep, seedContext, queuer)
+
+        assertThat(queuer.queued, hasSize(2))
+
+        val nextStep1 = queuer.queued[0]
+        assertThat(nextStep1.path, equalTo(nextPath1))
+        assertThat(nextStep1.data, equalTo("Foo"))
+        assertThat(nextStep1.numTerminalSteps, equalTo(4))
+        assertThat(nextStep1.numEquipmentSteps, equalTo(2))
+
+        val nextStep2 = queuer.queued[1]
+        assertThat(nextStep2.path, equalTo(nextPath2))
+        assertThat(nextStep2.data, equalTo("Bar"))
+        assertThat(nextStep2.numTerminalSteps, equalTo(4))
+        assertThat(nextStep2.numEquipmentSteps, equalTo(1))
+    }
+
+    @Test
+    fun `calls branching queuer when queuing more than 1 path on branching queue next`() {
+        val queueNext = NetworkTraceQueueNext.Branching(pathProvider, dataComputer)
+
+        val seedPath = mockk<NetworkTraceStep.Path>()
+        val seedStep = mockk<NetworkTraceStep<String>> {
+            every { path } returns seedPath
+            every { numEquipmentSteps } returns 1
+            every { numTerminalSteps } returns 3
+        }
+        val seedContext = mockk<StepContext>()
+
+        val nextPath1 = mockk<NetworkTraceStep.Path> { every { tracedExternally } returns true }
+        val nextPath2 = mockk<NetworkTraceStep.Path> { every { tracedExternally } returns false }
+        every { pathProvider.nextPaths(seedPath) } returns sequenceOf(nextPath1, nextPath2)
+
+        every { dataComputer.computeNext(seedStep, seedContext, nextPath1) } returns "Foo"
+        every { dataComputer.computeNext(seedStep, seedContext, nextPath2) } returns "Bar"
+
+        queueNext.accept(seedStep, seedContext, queuer, branchingQueuer)
+
+        assertThat(queuer.queued, hasSize(0))
+        assertThat(branchingQueuer.queued, hasSize(2))
+
+        val nextStep1 = branchingQueuer.queued[0]
+        assertThat(nextStep1.path, equalTo(nextPath1))
+        assertThat(nextStep1.data, equalTo("Foo"))
+        assertThat(nextStep1.numTerminalSteps, equalTo(4))
+        assertThat(nextStep1.numEquipmentSteps, equalTo(2))
+
+        val nextStep2 = branchingQueuer.queued[1]
+        assertThat(nextStep2.path, equalTo(nextPath2))
+        assertThat(nextStep2.data, equalTo("Bar"))
+        assertThat(nextStep2.numTerminalSteps, equalTo(4))
+        assertThat(nextStep2.numEquipmentSteps, equalTo(1))
+    }
+
+    @Test
+    fun `calls straight queuer when queuing a single path on branching queue next`() {
+        val queueNext = NetworkTraceQueueNext.Branching(pathProvider, dataComputer)
+
+        val seedPath = mockk<NetworkTraceStep.Path>()
+        val seedStep = mockk<NetworkTraceStep<String>> {
+            every { path } returns seedPath
+            every { numEquipmentSteps } returns 1
+            every { numTerminalSteps } returns 3
+        }
+        val seedContext = mockk<StepContext>()
+
+        val nextPath1 = mockk<NetworkTraceStep.Path> { every { tracedExternally } returns true }
+        every { pathProvider.nextPaths(seedPath) } returns sequenceOf(nextPath1)
+
+        every { dataComputer.computeNext(seedStep, seedContext, nextPath1) } returns "Foo"
+
+        queueNext.accept(seedStep, seedContext, queuer, branchingQueuer)
+
+        assertThat(queuer.queued, hasSize(1))
+        assertThat(branchingQueuer.queued, hasSize(0))
+
+        val nextStep1 = queuer.queued[0]
+        assertThat(nextStep1.path, equalTo(nextPath1))
+        assertThat(nextStep1.data, equalTo("Foo"))
+        assertThat(nextStep1.numTerminalSteps, equalTo(4))
+        assertThat(nextStep1.numEquipmentSteps, equalTo(2))
+    }
+
+    private class TestQueuer<T> : (NetworkTraceStep<T>) -> Boolean {
+        val queued = mutableListOf<NetworkTraceStep<T>>()
+        override fun invoke(step: NetworkTraceStep<T>): Boolean {
+            return queued.add(step)
+        }
+    }
+}

--- a/src/test/kotlin/com/zepben/evolve/services/network/tracing/networktrace/NetworkTraceStepPathProviderTest.kt
+++ b/src/test/kotlin/com/zepben/evolve/services/network/tracing/networktrace/NetworkTraceStepPathProviderTest.kt
@@ -11,6 +11,10 @@ package com.zepben.evolve.services.network.tracing.networktrace
 import com.zepben.evolve.cim.iec61970.base.core.ConductingEquipment
 import com.zepben.evolve.cim.iec61970.base.core.PhaseCode
 import com.zepben.evolve.cim.iec61970.base.core.Terminal
+import com.zepben.evolve.cim.iec61970.base.wires.AcLineSegment
+import com.zepben.evolve.cim.iec61970.base.wires.Breaker
+import com.zepben.evolve.cim.iec61970.base.wires.Clamp
+import com.zepben.evolve.cim.iec61970.base.wires.Cut
 import com.zepben.evolve.services.network.NetworkService
 import com.zepben.evolve.services.network.tracing.connectivity.NominalPhasePath
 import com.zepben.evolve.services.network.tracing.networktrace.operators.NetworkStateOperators
@@ -133,7 +137,226 @@ class NetworkTraceStepPathProviderTest {
         assertThat(nextPaths, containsInAnyOrder(bbs1.t1..b3.t1, bbs1.t1..b4.t1, bbs1.t1..b5.t1, bbs1.t1..b6.t1))
     }
 
+    @Test
+    fun `traversing segment with clamps from t1 includes all clamp steps`() {
+        val network = aclsWithClampsNetwork()
+
+        val breaker: Breaker = network["b0"]!!
+        val segment: AcLineSegment = network["c1"]!!
+        val clamp1: Clamp = network["clamp1"]!!
+        val clamp2: Clamp = network["clamp2"]!!
+
+        val currentPath = breaker.t2..segment.t1
+        val nextPaths = pathProvider.nextPaths(currentPath).toList()
+        assertThat(nextPaths, containsInAnyOrder(segment.t1..clamp1.t1, segment.t1..clamp2.t1, segment.t1..segment.t2))
+    }
+
+    @Test
+    fun `traversing segment with clamps from t2 includes all clamps steps`() {
+        val network = aclsWithClampsNetwork()
+
+        val breaker: Breaker = network["b2"]!!
+        val segment: AcLineSegment = network["c1"]!!
+        val clamp1: Clamp = network["clamp1"]!!
+        val clamp2: Clamp = network["clamp2"]!!
+
+        val currentPath = breaker.t1..segment.t2
+        val nextPaths = pathProvider.nextPaths(currentPath).toList()
+        assertThat(nextPaths, containsInAnyOrder(segment.t2..clamp2.t1, segment.t2..clamp1.t1, segment.t2..segment.t1))
+    }
+
+    @Test
+    fun `non traverse step to segment t1 traverses towards t2 stopping at cut`() {
+        val network = aclsWithClampsAndCutsNetwork()
+
+        val b0: Breaker = network["b0"]!!
+        val segment: AcLineSegment = network["c1"]!!
+        val clamp1: Clamp = network["clamp1"]!!
+        val cut1: Cut = network["cut1"]!!
+
+        val currentPath = b0.t2..segment.t1
+        val nextPaths = pathProvider.nextPaths(currentPath).toList()
+        assertThat(nextPaths, containsInAnyOrder(segment.t1..clamp1.t1, segment.t1..cut1.t1))
+    }
+
+    @Test
+    fun `non traverse step to segment t2 traverses towards t1 stopping at cut`() {
+        val network = aclsWithClampsAndCutsNetwork()
+
+        val b2: Breaker = network["b2"]!!
+        val segment: AcLineSegment = network["c1"]!!
+        val clamp4: Clamp = network["clamp4"]!!
+        val cut2: Cut = network["cut2"]!!
+
+        val currentPath = b2.t1..segment.t2
+        val nextPaths = pathProvider.nextPaths(currentPath).toList()
+        assertThat(nextPaths, containsInAnyOrder(segment.t2..clamp4.t1, segment.t2..cut2.t2))
+    }
+
+    @Test
+    fun `traverse step to cut t1 steps externally and across cut`() {
+        val network = aclsWithClampsAndCutsNetwork()
+
+        val segment: AcLineSegment = network["c1"]!!
+        val cut1: Cut = network["cut1"]!!
+        val c4: AcLineSegment = network["c4"]!!
+
+        val currentPath = segment.t1..cut1.t1
+        val nextPaths = pathProvider.nextPaths(currentPath).toList()
+        assertThat(nextPaths, containsInAnyOrder(cut1.t1..cut1.t2, cut1.t1..c4.t1))
+    }
+
+    @Test
+    fun `traverse step to cut t2 steps externally and across cut`() {
+        val network = aclsWithClampsAndCutsNetwork()
+
+        val segment: AcLineSegment = network["c1"]!!
+        val cut2: Cut = network["cut2"]!!
+        val c9: AcLineSegment = network["c9"]!!
+
+        val currentPath = segment.t2..cut2.t2
+        val nextPaths = pathProvider.nextPaths(currentPath).toList()
+        assertThat(nextPaths, containsInAnyOrder(cut2.t2..cut2.t1, cut2.t2..c9.t1))
+    }
+
+    @Test
+    fun `non traverse step to cut t1 traverses segment towards t1 and internally through cut to t2`() {
+        val network = aclsWithClampsAndCutsNetwork()
+
+        val segment: AcLineSegment = network["c1"]!!
+        val clamp1: Clamp = network["clamp1"]!!
+        val cut1: Cut = network["cut1"]!!
+        val c4: AcLineSegment = network["c4"]!!
+
+        val currentPath = c4.t1..cut1.t1
+        val nextPaths = pathProvider.nextPaths(currentPath).toList()
+        assertThat(nextPaths, containsInAnyOrder(cut1.t1..clamp1.t1, cut1.t1..segment.t1, cut1.t1..cut1.t2))
+    }
+
+    @Test
+    fun `non traverse step to cut t2 traverses segment towards t2 and internally through cut to t1`() {
+        val network = aclsWithClampsAndCutsNetwork()
+
+        val segment: AcLineSegment = network["c1"]!!
+        val clamp4: Clamp = network["clamp4"]!!
+        val cut2: Cut = network["cut2"]!!
+        val c9: AcLineSegment = network["c9"]!!
+
+        val currentPath = c9.t1..cut2.t2
+        val nextPaths = pathProvider.nextPaths(currentPath).toList()
+        assertThat(nextPaths, containsInAnyOrder(cut2.t2..clamp4.t1, cut2.t2..segment.t2, cut2.t2..cut2.t1))
+    }
+
+    @Test
+    fun `non traverse step to clamp traverses segment in both directions`() {
+        val network = aclsWithClampsAndCutsNetwork()
+
+        val segment: AcLineSegment = network["c1"]!!
+        val clamp1: Clamp = network["clamp1"]!!
+        val cut1: Cut = network["cut1"]!!
+        val c3: AcLineSegment = network["c3"]!!
+
+        val currentPath = c3.t1..clamp1.t1
+        val nextPaths = pathProvider.nextPaths(currentPath).toList()
+        assertThat(nextPaths, containsInAnyOrder(clamp1.t1..segment.t1, clamp1.t1..cut1.t1))
+    }
+
+    @Test
+    fun `traverse step to clamp traces externally and does not traverse back along segment`() {
+        val network = aclsWithClampsAndCutsNetwork()
+
+        val segment: AcLineSegment = network["c1"]!!
+        val clamp1: Clamp = network["clamp1"]!!
+        val c3: AcLineSegment = network["c3"]!!
+
+        val currentPath = segment.t1..clamp1.t1
+        val nextPaths = pathProvider.nextPaths(currentPath).toList()
+        assertThat(nextPaths, containsInAnyOrder(clamp1.t1..c3.t1))
+    }
+
+    @Test
+    fun `non traverse step to clamp between cuts traverses segment both ways stopping at cuts`() {
+        val network = aclsWithClampsAndCutsNetwork()
+
+        val c6: AcLineSegment = network["c6"]!!
+        val clamp2: Clamp = network["clamp2"]!!
+        val clamp3: Clamp = network["clamp3"]!!
+        val cut1: Cut = network["cut1"]!!
+        val cut2: Cut = network["cut2"]!!
+
+        val currentPath = c6.t1..clamp2.t1
+        val nextPaths = pathProvider.nextPaths(currentPath).toList()
+        assertThat(nextPaths, containsInAnyOrder(clamp2.t1..cut1.t2, clamp2.t1..clamp3.t1, clamp2.t1..cut2.t1))
+    }
+
+    @Test
+    fun `non traverse external step to cut t2 between cuts traverses segment towards t2 stopping at next cut and steps internally to cut t1`() {
+        val network = aclsWithClampsAndCutsNetwork()
+
+        val c5: AcLineSegment = network["c5"]!!
+        val clamp2: Clamp = network["clamp2"]!!
+        val clamp3: Clamp = network["clamp3"]!!
+        val cut1: Cut = network["cut1"]!!
+        val cut2: Cut = network["cut2"]!!
+
+        val currentPath = c5.t1..cut1.t2
+        val nextPaths = pathProvider.nextPaths(currentPath).toList()
+        assertThat(nextPaths, containsInAnyOrder(cut1.t2..clamp2.t1, cut1.t2..clamp3.t1, cut1.t2..cut2.t1, cut1.t2..cut1.t1))
+    }
+
+    @Test
+    fun `non traverse external step to cut t1 between cuts traverses segment towards t1 stopping at next cut and steps internally to cut t2`() {
+        val network = aclsWithClampsAndCutsNetwork()
+
+        val c8: AcLineSegment = network["c8"]!!
+        val clamp2: Clamp = network["clamp2"]!!
+        val clamp3: Clamp = network["clamp3"]!!
+        val cut1: Cut = network["cut1"]!!
+        val cut2: Cut = network["cut2"]!!
+
+        val currentPath = c8.t1..cut2.t1
+        val nextPaths = pathProvider.nextPaths(currentPath).toList()
+        assertThat(nextPaths, containsInAnyOrder(cut2.t1..clamp3.t1, cut2.t1..clamp2.t1, cut2.t1..cut1.t2, cut2.t1..cut2.t2))
+    }
+
+    @Test
+    fun `internal step to cut t2 between cuts steps externally and traverses segment towards t2 stopping at next cut`() {
+        val network = aclsWithClampsAndCutsNetwork()
+
+        val c5: AcLineSegment = network["c5"]!!
+        val clamp2: Clamp = network["clamp2"]!!
+        val clamp3: Clamp = network["clamp3"]!!
+        val cut1: Cut = network["cut1"]!!
+        val cut2: Cut = network["cut2"]!!
+
+        val currentPath = cut1.t1..cut1.t2
+        val nextPaths = pathProvider.nextPaths(currentPath).toList()
+        assertThat(nextPaths, containsInAnyOrder(cut1.t2..clamp2.t1, cut1.t2..clamp3.t1, cut1.t2..cut2.t1, cut1.t2..c5.t1))
+    }
+
+    @Test
+    fun `internal step to cut t1 between cuts steps externally and traverses segment towards t1 stopping at next cut`() {
+        val network = aclsWithClampsAndCutsNetwork()
+
+        val c8: AcLineSegment = network["c8"]!!
+        val clamp2: Clamp = network["clamp2"]!!
+        val clamp3: Clamp = network["clamp3"]!!
+        val cut1: Cut = network["cut1"]!!
+        val cut2: Cut = network["cut2"]!!
+
+        val currentPath = cut2.t2..cut2.t1
+        val nextPaths = pathProvider.nextPaths(currentPath).toList()
+        assertThat(nextPaths, containsInAnyOrder(cut2.t1..clamp2.t1, cut2.t1..clamp3.t1, cut2.t1..cut1.t2, cut2.t1..c8.t1))
+    }
+
     private fun busbarNetwork(): NetworkService {
+        //         1
+        //         b0
+        //  bbs1 1-2-1 bbs2
+        //  -----|   |-----
+        //  1    1   1    1
+        //  b3   b4  b5   b6
+        //  2    2   2    2
         val network = TestNetworkBuilder()
             .fromBreaker() // b0
             .toBusbarSection() // bbs1
@@ -161,6 +384,101 @@ class NetworkTraceStepPathProviderTest {
         assertThat(b0.t2.connectivityNode?.terminals, containsInAnyOrder(b0.t2, bbs1.t1, bbs2.t1, b3.t1, b4.t1, b5.t1, b6.t1))
 
         return network
+    }
+
+    private fun aclsWithClampsNetwork(): NetworkService {
+        //
+        //           clamp1
+        //           |
+        // 1 b0 21---*--c1--*---21 b2 2
+        //                  |
+        //                  clamp2
+        //
+        val network = TestNetworkBuilder()
+            .fromBreaker() // b0
+            .toAcls() // c1
+            .toBreaker() // b2
+            .network
+
+        val segment: AcLineSegment = network["c1"]!!
+
+        segment.withClamp(network, 1.0)
+        segment.withClamp(network, 2.0)
+
+        return network
+    }
+
+    private fun aclsWithClampsAndCutsNetwork(): NetworkService {
+        //
+        //          2                     2
+        //          c3          2         c7          2
+        //          1           c5        1           c9
+        //          1 clamp1    1         1 clamp3    1
+        //          |           |         |           |
+        // 1 b0 21--*--*1 cut1 2*--*--c1--*--*1 cut2 2*--*--21 b2 2
+        //             |           |         |           |
+        //             1           1 clamp2  1           1 clamp4
+        //             c4          1         c8          1
+        //             2           c6        2           c10
+        //                         2                     2
+        //
+        val network = TestNetworkBuilder()
+            .fromBreaker() // b0
+            .toAcls() // c1
+            .toBreaker() // b2
+            .fromAcls() // c3
+            .fromAcls() // c4
+            .fromAcls() // c5
+            .fromAcls() // c6
+            .fromAcls() // c7
+            .fromAcls() // c8
+            .fromAcls() // c9
+            .fromAcls() // c10
+            .network
+
+        val segment: AcLineSegment = network["c1"]!!
+
+        val clamp1 = segment.withClamp(network, 1.0)
+        val cut1 = segment.withCut(network, 2.0)
+        val clamp2 = segment.withClamp(network, 3.0)
+        val clamp3 = segment.withClamp(network, 4.0)
+        val cut2 = segment.withCut(network, 5.0)
+        val clamp4 = segment.withClamp(network, 6.0)
+
+        network.connect(clamp1.t1, network.get<ConductingEquipment>("c3")!!.t1)
+        network.connect(cut1.t1, network.get<ConductingEquipment>("c4")!!.t1)
+        network.connect(cut1.t2, network.get<ConductingEquipment>("c5")!!.t1)
+        network.connect(clamp2.t1, network.get<ConductingEquipment>("c6")!!.t1)
+        network.connect(clamp3.t1, network.get<ConductingEquipment>("c7")!!.t1)
+        network.connect(cut2.t1, network.get<ConductingEquipment>("c8")!!.t1)
+        network.connect(cut2.t2, network.get<ConductingEquipment>("c9")!!.t1)
+        network.connect(clamp4.t1, network.get<ConductingEquipment>("c10")!!.t1)
+
+        return network
+    }
+
+    private fun AcLineSegment.withClamp(network: NetworkService, lengthFromTerminal1: Double): Clamp {
+        val clamp = Clamp("clamp${numClamps() + 1}").apply {
+            addTerminal(Terminal("$mRID-t1"))
+            this.lengthFromTerminal1 = lengthFromTerminal1
+        }
+
+        addClamp(clamp)
+        network.add(clamp)
+
+        return clamp
+    }
+
+    private fun AcLineSegment.withCut(network: NetworkService, lengthFromTerminal1: Double): Cut {
+        val cut = Cut("cut${numCuts() + 1}").apply {
+            addTerminal(Terminal("$mRID-t1"))
+            addTerminal(Terminal("$mRID-t2"))
+            this.lengthFromTerminal1 = lengthFromTerminal1
+        }
+
+        addCut(cut)
+        network.add(cut)
+        return cut
     }
 
     private operator fun Terminal.rangeTo(other: Terminal): NetworkTraceStep.Path = NetworkTraceStep.Path(this, other)

--- a/src/test/kotlin/com/zepben/evolve/services/network/tracing/networktrace/NetworkTraceStepPathProviderTest.kt
+++ b/src/test/kotlin/com/zepben/evolve/services/network/tracing/networktrace/NetworkTraceStepPathProviderTest.kt
@@ -1,0 +1,167 @@
+/*
+ * Copyright 2025 Zeppelin Bend Pty Ltd
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+package com.zepben.evolve.services.network.tracing.networktrace
+
+import com.zepben.evolve.cim.iec61970.base.core.ConductingEquipment
+import com.zepben.evolve.cim.iec61970.base.core.PhaseCode
+import com.zepben.evolve.cim.iec61970.base.core.Terminal
+import com.zepben.evolve.services.network.NetworkService
+import com.zepben.evolve.services.network.tracing.connectivity.NominalPhasePath
+import com.zepben.evolve.services.network.tracing.networktrace.operators.NetworkStateOperators
+import com.zepben.evolve.testing.TestNetworkBuilder
+import org.hamcrest.MatcherAssert.assertThat
+import org.hamcrest.Matchers.containsInAnyOrder
+import org.junit.jupiter.api.Test
+import com.zepben.evolve.cim.iec61970.base.wires.SinglePhaseKind as SPK
+
+class NetworkTraceStepPathProviderTest {
+
+    private val pathProvider = NetworkTraceStepPathProvider(NetworkStateOperators.NORMAL)
+
+    @Test
+    fun `current external path steps internally`() {
+        val network = TestNetworkBuilder()
+            .fromAcls() // c0
+            .toJunction(numTerminals = 3) // j1
+            .network
+
+        val c0: ConductingEquipment = network["c0"]!!
+        val j1: ConductingEquipment = network["j1"]!!
+
+        val currentPath = c0.t2..j1.t1
+        val nextPaths = pathProvider.nextPaths(currentPath).toList()
+
+        assertThat(nextPaths, containsInAnyOrder(j1.t1..j1.t2, j1.t1..j1.t3))
+    }
+
+    @Test
+    fun `current internal path steps externally`() {
+        val network = TestNetworkBuilder()
+            .fromJunction() // j0
+            .toAcls() // c1
+            .fromAcls() // c2
+            .connect("j0", "c2", 2, 1)
+            .network
+
+        val j0: ConductingEquipment = network["j0"]!!
+        val c1: ConductingEquipment = network["c1"]!!
+        val c2: ConductingEquipment = network["c2"]!!
+
+        val currentPath = j0.t1..j0.t2
+        val nextPaths = pathProvider.nextPaths(currentPath).toList()
+
+        assertThat(nextPaths, containsInAnyOrder(j0.t2..c1.t1, j0.t2..c2.t1))
+    }
+
+    @Test
+    fun `only steps to in service equipment`() {
+        val network = TestNetworkBuilder()
+            .fromJunction() // j0
+            .toAcls() // c1
+            .fromAcls { normallyInService = false } // c2
+            .connect("j0", "c2", 2, 1)
+            .network
+
+        val j0: ConductingEquipment = network["j0"]!!
+        val c1: ConductingEquipment = network["c1"]!!
+
+        val currentPath = j0.t1..j0.t2
+        val nextPaths = pathProvider.nextPaths(currentPath).toList()
+
+        // Should not step to c2 because it is not in service
+        assertThat(nextPaths, containsInAnyOrder(j0.t2..c1.t1))
+    }
+
+    @Test
+    fun `only includes followed phases`() {
+        val network = TestNetworkBuilder()
+            .fromAcls() // c0
+            .toPowerTransformer(listOf(PhaseCode.ABC, PhaseCode.A, PhaseCode.B, PhaseCode.C)) // tx1
+            .network
+
+        val c0: ConductingEquipment = network["c0"]!!
+        val tx1: ConductingEquipment = network["tx1"]!!
+
+        val currentPath = NetworkTraceStep.Path(c0.t2, tx1.t1, listOf(NominalPhasePath(SPK.A, SPK.A), NominalPhasePath(SPK.B, SPK.B)))
+        val nextPaths = pathProvider.nextPaths(currentPath).toList()
+
+        assertThat(
+            nextPaths,
+            containsInAnyOrder(
+                NetworkTraceStep.Path(tx1.t1, tx1.t2, listOf(NominalPhasePath(SPK.A, SPK.A))),
+                NetworkTraceStep.Path(tx1.t1, tx1.t3, listOf(NominalPhasePath(SPK.B, SPK.B)))
+            )
+        )
+    }
+
+    @Test
+    fun `stepping externally to connectivity node with busbars only goes to busbars`() {
+        val network = busbarNetwork()
+
+        val b0: ConductingEquipment = network["b0"]!!
+        val bbs1: ConductingEquipment = network["bbs1"]!!
+        val bbs2: ConductingEquipment = network["bbs2"]!!
+
+        val currentPath = b0.t1..b0.t2
+        val nextPaths = pathProvider.nextPaths(currentPath).toList()
+
+        // Should only contain steps to busbars
+        assertThat(nextPaths, containsInAnyOrder(b0.t2..bbs1.t1, b0.t2..bbs2.t1))
+    }
+
+    @Test
+    fun `stepping externally from busbars does not step to busbars or original from terminal`() {
+        val network = busbarNetwork()
+
+        val bbs1: ConductingEquipment = network["bbs1"]!!
+        val b0: ConductingEquipment = network["b0"]!!
+        val b3: ConductingEquipment = network["b3"]!!
+        val b4: ConductingEquipment = network["b4"]!!
+        val b5: ConductingEquipment = network["b5"]!!
+        val b6: ConductingEquipment = network["b6"]!!
+
+        val currentPath = b0.t2..bbs1.t1
+        val nextPaths = pathProvider.nextPaths(currentPath).toList()
+
+        // Should not contain bbs2 and should not step back to b0
+        assertThat(nextPaths, containsInAnyOrder(bbs1.t1..b3.t1, bbs1.t1..b4.t1, bbs1.t1..b5.t1, bbs1.t1..b6.t1))
+    }
+
+    private fun busbarNetwork(): NetworkService {
+        val network = TestNetworkBuilder()
+            .fromBreaker() // b0
+            .toBusbarSection() // bbs1
+            .branchFrom("b0", 2)
+            .toBusbarSection() // bbs2
+            .branchFrom("bbs1", 1)
+            .toBreaker() // b3
+            .branchFrom("bbs1", 1)
+            .toBreaker() // b4
+            .branchFrom("bbs2", 1)
+            .toBreaker() // b5
+            .branchFrom("bbs2", 1)
+            .toBreaker() // b6
+            .network
+
+        val bbs1: ConductingEquipment = network["bbs1"]!!
+        val bbs2: ConductingEquipment = network["bbs2"]!!
+        val b0: ConductingEquipment = network["b0"]!!
+        val b3: ConductingEquipment = network["b3"]!!
+        val b4: ConductingEquipment = network["b4"]!!
+        val b5: ConductingEquipment = network["b5"]!!
+        val b6: ConductingEquipment = network["b6"]!!
+
+        // Make sure all the terminals that should be considered in the next paths are connected to the same connectivity node
+        assertThat(b0.t2.connectivityNode?.terminals, containsInAnyOrder(b0.t2, bbs1.t1, bbs2.t1, b3.t1, b4.t1, b5.t1, b6.t1))
+
+        return network
+    }
+
+    private operator fun Terminal.rangeTo(other: Terminal): NetworkTraceStep.Path = NetworkTraceStep.Path(this, other)
+}

--- a/src/test/kotlin/com/zepben/evolve/services/network/tracing/networktrace/NetworkTraceStepPathProviderTest.kt
+++ b/src/test/kotlin/com/zepben/evolve/services/network/tracing/networktrace/NetworkTraceStepPathProviderTest.kt
@@ -30,6 +30,11 @@ class NetworkTraceStepPathProviderTest {
 
     @Test
     fun `current external path steps internally`() {
+        //
+        //             2
+        //  1--c0--2 1 j1
+        //             3
+        //
         val network = TestNetworkBuilder()
             .fromAcls() // c0
             .toJunction(numTerminals = 3) // j1
@@ -46,6 +51,12 @@ class NetworkTraceStepPathProviderTest {
 
     @Test
     fun `current internal path steps externally`() {
+        //
+        //  1 j0 21--c1--2
+        //       1
+        //       c2
+        //       2
+        //
         val network = TestNetworkBuilder()
             .fromJunction() // j0
             .toAcls() // c1
@@ -65,6 +76,12 @@ class NetworkTraceStepPathProviderTest {
 
     @Test
     fun `only steps to in service equipment`() {
+        //
+        //  1 j0 21--c1--2
+        //       1
+        //       c2 (not in service)
+        //       2
+        //
         val network = TestNetworkBuilder()
             .fromJunction() // j0
             .toAcls() // c1
@@ -84,6 +101,11 @@ class NetworkTraceStepPathProviderTest {
 
     @Test
     fun `only includes followed phases`() {
+        //
+        //            2 (A)
+        //  1--c0--21 tx1 3 (B)
+        //            4 (C)
+        //
         val network = TestNetworkBuilder()
             .fromAcls() // c0
             .toPowerTransformer(listOf(PhaseCode.ABC, PhaseCode.A, PhaseCode.B, PhaseCode.C)) // tx1
@@ -100,6 +122,7 @@ class NetworkTraceStepPathProviderTest {
             containsInAnyOrder(
                 NetworkTraceStep.Path(tx1.t1, tx1.t2, listOf(NominalPhasePath(SPK.A, SPK.A))),
                 NetworkTraceStep.Path(tx1.t1, tx1.t3, listOf(NominalPhasePath(SPK.B, SPK.B)))
+                // Should not contain tx1 terminal 4 because it's not in the phase paths
             )
         )
     }
@@ -352,6 +375,10 @@ class NetworkTraceStepPathProviderTest {
     @Suppress("DEPRECATION")
     @Test
     fun `supports legacy AcLineSegment with multiple terminals`() {
+        //
+        //              3
+        //  1 b0 21--c1-*-2
+        //
         val network = TestNetworkBuilder()
             .fromBreaker() // b0
             .toAcls() // c1
@@ -408,9 +435,9 @@ class NetworkTraceStepPathProviderTest {
     private fun aclsWithClampsNetwork(): NetworkService {
         //
         //           clamp1
-        //           |
+        //           1
         // 1 b0 21---*--c1--*---21 b2 2
-        //                  |
+        //                  1
         //                  clamp2
         //
         val network = TestNetworkBuilder()
@@ -500,5 +527,8 @@ class NetworkTraceStepPathProviderTest {
         return cut
     }
 
+    /**
+     * Allows for shorthand notation to create a NetworkTraceStep.Path between 2 terminals. E.g. `j0.t2..c1.t1`
+     */
     private operator fun Terminal.rangeTo(other: Terminal): NetworkTraceStep.Path = NetworkTraceStep.Path(this, other)
 }

--- a/src/test/kotlin/com/zepben/evolve/services/network/tracing/networktrace/NetworkTraceStepPathProviderTest.kt
+++ b/src/test/kotlin/com/zepben/evolve/services/network/tracing/networktrace/NetworkTraceStepPathProviderTest.kt
@@ -349,6 +349,25 @@ class NetworkTraceStepPathProviderTest {
         assertThat(nextPaths, containsInAnyOrder(cut2.t1..clamp2.t1, cut2.t1..clamp3.t1, cut2.t1..cut1.t2, cut2.t1..c8.t1))
     }
 
+    @Suppress("DEPRECATION")
+    @Test
+    fun `supports legacy AcLineSegment with multiple terminals`() {
+        val network = TestNetworkBuilder()
+            .fromBreaker() // b0
+            .toAcls() // c1
+            .network
+
+        val b0: Breaker = network["b0"]!!
+        val c1: AcLineSegment = network["c1"]!!
+        c1.midSpanTerminalsEnabled = true
+        c1.addTerminal(Terminal())
+
+        val currentPath = b0.t2..c1.t1
+        val nextPaths = pathProvider.nextPaths(currentPath).toList()
+
+        assertThat(nextPaths, containsInAnyOrder(c1.t1..c1.t2, c1.t1..c1.t3))
+    }
+
     private fun busbarNetwork(): NetworkService {
         //         1
         //         b0

--- a/src/test/kotlin/com/zepben/evolve/services/network/tracing/networktrace/NetworkTraceStepPathProviderTest.kt
+++ b/src/test/kotlin/com/zepben/evolve/services/network/tracing/networktrace/NetworkTraceStepPathProviderTest.kt
@@ -114,14 +114,14 @@ class NetworkTraceStepPathProviderTest {
         val c0: ConductingEquipment = network["c0"]!!
         val tx1: ConductingEquipment = network["tx1"]!!
 
-        val currentPath = NetworkTraceStep.Path(c0.t2, tx1.t1, listOf(NominalPhasePath(SPK.A, SPK.A), NominalPhasePath(SPK.B, SPK.B)))
+        val currentPath = NetworkTraceStep.Path(c0.t2, tx1.t1, null, listOf(NominalPhasePath(SPK.A, SPK.A), NominalPhasePath(SPK.B, SPK.B)))
         val nextPaths = pathProvider.nextPaths(currentPath).toList()
 
         assertThat(
             nextPaths,
             containsInAnyOrder(
-                NetworkTraceStep.Path(tx1.t1, tx1.t2, listOf(NominalPhasePath(SPK.A, SPK.A))),
-                NetworkTraceStep.Path(tx1.t1, tx1.t3, listOf(NominalPhasePath(SPK.B, SPK.B)))
+                NetworkTraceStep.Path(tx1.t1, tx1.t2, null, listOf(NominalPhasePath(SPK.A, SPK.A))),
+                NetworkTraceStep.Path(tx1.t1, tx1.t3, null, listOf(NominalPhasePath(SPK.B, SPK.B)))
                 // Should not contain tx1 terminal 4 because it's not in the phase paths
             )
         )
@@ -171,7 +171,7 @@ class NetworkTraceStepPathProviderTest {
 
         val currentPath = breaker.t2..segment.t1
         val nextPaths = pathProvider.nextPaths(currentPath).toList()
-        assertThat(nextPaths, containsInAnyOrder(segment.t1..clamp1.t1, segment.t1..clamp2.t1, segment.t1..segment.t2))
+        assertThat(nextPaths, containsInAnyOrder(segment.t1..<clamp1.t1, segment.t1..<clamp2.t1, segment.t1..<segment.t2))
     }
 
     @Test
@@ -185,7 +185,7 @@ class NetworkTraceStepPathProviderTest {
 
         val currentPath = breaker.t1..segment.t2
         val nextPaths = pathProvider.nextPaths(currentPath).toList()
-        assertThat(nextPaths, containsInAnyOrder(segment.t2..clamp2.t1, segment.t2..clamp1.t1, segment.t2..segment.t1))
+        assertThat(nextPaths, containsInAnyOrder(segment.t2..<clamp2.t1, segment.t2..<clamp1.t1, segment.t2..<segment.t1))
     }
 
     @Test
@@ -199,7 +199,7 @@ class NetworkTraceStepPathProviderTest {
 
         val currentPath = b0.t2..segment.t1
         val nextPaths = pathProvider.nextPaths(currentPath).toList()
-        assertThat(nextPaths, containsInAnyOrder(segment.t1..clamp1.t1, segment.t1..cut1.t1))
+        assertThat(nextPaths, containsInAnyOrder(segment.t1..<clamp1.t1, segment.t1..<cut1.t1))
     }
 
     @Test
@@ -213,7 +213,7 @@ class NetworkTraceStepPathProviderTest {
 
         val currentPath = b2.t1..segment.t2
         val nextPaths = pathProvider.nextPaths(currentPath).toList()
-        assertThat(nextPaths, containsInAnyOrder(segment.t2..clamp4.t1, segment.t2..cut2.t2))
+        assertThat(nextPaths, containsInAnyOrder(segment.t2..<clamp4.t1, segment.t2..<cut2.t2))
     }
 
     @Test
@@ -224,7 +224,7 @@ class NetworkTraceStepPathProviderTest {
         val cut1: Cut = network["cut1"]!!
         val c4: AcLineSegment = network["c4"]!!
 
-        val currentPath = segment.t1..cut1.t1
+        val currentPath = segment.t1..<cut1.t1
         val nextPaths = pathProvider.nextPaths(currentPath).toList()
         assertThat(nextPaths, containsInAnyOrder(cut1.t1..cut1.t2, cut1.t1..c4.t1))
     }
@@ -237,7 +237,7 @@ class NetworkTraceStepPathProviderTest {
         val cut2: Cut = network["cut2"]!!
         val c9: AcLineSegment = network["c9"]!!
 
-        val currentPath = segment.t2..cut2.t2
+        val currentPath = segment.t2..<cut2.t2
         val nextPaths = pathProvider.nextPaths(currentPath).toList()
         assertThat(nextPaths, containsInAnyOrder(cut2.t2..cut2.t1, cut2.t2..c9.t1))
     }
@@ -253,7 +253,7 @@ class NetworkTraceStepPathProviderTest {
 
         val currentPath = c4.t1..cut1.t1
         val nextPaths = pathProvider.nextPaths(currentPath).toList()
-        assertThat(nextPaths, containsInAnyOrder(cut1.t1..clamp1.t1, cut1.t1..segment.t1, cut1.t1..cut1.t2))
+        assertThat(nextPaths, containsInAnyOrder(cut1.t1..<clamp1.t1, cut1.t1..<segment.t1, cut1.t1..cut1.t2))
     }
 
     @Test
@@ -267,7 +267,7 @@ class NetworkTraceStepPathProviderTest {
 
         val currentPath = c9.t1..cut2.t2
         val nextPaths = pathProvider.nextPaths(currentPath).toList()
-        assertThat(nextPaths, containsInAnyOrder(cut2.t2..clamp4.t1, cut2.t2..segment.t2, cut2.t2..cut2.t1))
+        assertThat(nextPaths, containsInAnyOrder(cut2.t2..<clamp4.t1, cut2.t2..<segment.t2, cut2.t2..cut2.t1))
     }
 
     @Test
@@ -281,7 +281,7 @@ class NetworkTraceStepPathProviderTest {
 
         val currentPath = c3.t1..clamp1.t1
         val nextPaths = pathProvider.nextPaths(currentPath).toList()
-        assertThat(nextPaths, containsInAnyOrder(clamp1.t1..segment.t1, clamp1.t1..cut1.t1))
+        assertThat(nextPaths, containsInAnyOrder(clamp1.t1..<segment.t1, clamp1.t1..<cut1.t1))
     }
 
     @Test
@@ -292,7 +292,7 @@ class NetworkTraceStepPathProviderTest {
         val clamp1: Clamp = network["clamp1"]!!
         val c3: AcLineSegment = network["c3"]!!
 
-        val currentPath = segment.t1..clamp1.t1
+        val currentPath = segment.t1..<clamp1.t1
         val nextPaths = pathProvider.nextPaths(currentPath).toList()
         assertThat(nextPaths, containsInAnyOrder(clamp1.t1..c3.t1))
     }
@@ -309,7 +309,7 @@ class NetworkTraceStepPathProviderTest {
 
         val currentPath = c6.t1..clamp2.t1
         val nextPaths = pathProvider.nextPaths(currentPath).toList()
-        assertThat(nextPaths, containsInAnyOrder(clamp2.t1..cut1.t2, clamp2.t1..clamp3.t1, clamp2.t1..cut2.t1))
+        assertThat(nextPaths, containsInAnyOrder(clamp2.t1..<cut1.t2, clamp2.t1..<clamp3.t1, clamp2.t1..<cut2.t1))
     }
 
     @Test
@@ -324,7 +324,7 @@ class NetworkTraceStepPathProviderTest {
 
         val currentPath = c5.t1..cut1.t2
         val nextPaths = pathProvider.nextPaths(currentPath).toList()
-        assertThat(nextPaths, containsInAnyOrder(cut1.t2..clamp2.t1, cut1.t2..clamp3.t1, cut1.t2..cut2.t1, cut1.t2..cut1.t1))
+        assertThat(nextPaths, containsInAnyOrder(cut1.t2..<clamp2.t1, cut1.t2..<clamp3.t1, cut1.t2..<cut2.t1, cut1.t2..cut1.t1))
     }
 
     @Test
@@ -339,7 +339,7 @@ class NetworkTraceStepPathProviderTest {
 
         val currentPath = c8.t1..cut2.t1
         val nextPaths = pathProvider.nextPaths(currentPath).toList()
-        assertThat(nextPaths, containsInAnyOrder(cut2.t1..clamp3.t1, cut2.t1..clamp2.t1, cut2.t1..cut1.t2, cut2.t1..cut2.t2))
+        assertThat(nextPaths, containsInAnyOrder(cut2.t1..<clamp3.t1, cut2.t1..<clamp2.t1, cut2.t1..<cut1.t2, cut2.t1..cut2.t2))
     }
 
     @Test
@@ -354,7 +354,7 @@ class NetworkTraceStepPathProviderTest {
 
         val currentPath = cut1.t1..cut1.t2
         val nextPaths = pathProvider.nextPaths(currentPath).toList()
-        assertThat(nextPaths, containsInAnyOrder(cut1.t2..clamp2.t1, cut1.t2..clamp3.t1, cut1.t2..cut2.t1, cut1.t2..c5.t1))
+        assertThat(nextPaths, containsInAnyOrder(cut1.t2..<clamp2.t1, cut1.t2..<clamp3.t1, cut1.t2..<cut2.t1, cut1.t2..c5.t1))
     }
 
     @Test
@@ -369,7 +369,7 @@ class NetworkTraceStepPathProviderTest {
 
         val currentPath = cut2.t2..cut2.t1
         val nextPaths = pathProvider.nextPaths(currentPath).toList()
-        assertThat(nextPaths, containsInAnyOrder(cut2.t1..clamp2.t1, cut2.t1..clamp3.t1, cut2.t1..cut1.t2, cut2.t1..c8.t1))
+        assertThat(nextPaths, containsInAnyOrder(cut2.t1..<clamp2.t1, cut2.t1..<clamp3.t1, cut2.t1..<cut1.t2, cut2.t1..c8.t1))
     }
 
     @Suppress("DEPRECATION")
@@ -392,7 +392,7 @@ class NetworkTraceStepPathProviderTest {
         val currentPath = b0.t2..c1.t1
         val nextPaths = pathProvider.nextPaths(currentPath).toList()
 
-        assertThat(nextPaths, containsInAnyOrder(c1.t1..c1.t2, c1.t1..c1.t3))
+        assertThat(nextPaths, containsInAnyOrder(c1.t1..<c1.t2, c1.t1..<c1.t3))
     }
 
     private fun busbarNetwork(): NetworkService {
@@ -530,5 +530,21 @@ class NetworkTraceStepPathProviderTest {
     /**
      * Allows for shorthand notation to create a NetworkTraceStep.Path between 2 terminals. E.g. `j0.t2..c1.t1`
      */
-    private operator fun Terminal.rangeTo(other: Terminal): NetworkTraceStep.Path = NetworkTraceStep.Path(this, other)
+    private operator fun Terminal.rangeTo(other: Terminal): NetworkTraceStep.Path = NetworkTraceStep.Path(this, other, null)
+
+    /**
+     * Allows for shorthand notation to create a NetworkTraceStep.Path that traversed an AcLineSegment between 2 terminals . E.g. `c1.t1..<clamp1.t1`
+     */
+    private operator fun Terminal.rangeUntil(other: Terminal): NetworkTraceStep.Path =
+        NetworkTraceStep.Path(
+            this,
+            other,
+            when (val ce = this.conductingEquipment) {
+                is AcLineSegment -> ce
+                is Clamp -> ce.acLineSegment
+                is Cut -> ce.acLineSegment
+                else -> error("Did not traverse")
+            }
+        )
+
 }

--- a/src/test/kotlin/com/zepben/evolve/services/network/tracing/networktrace/NetworkTraceStepPathProviderTest.kt
+++ b/src/test/kotlin/com/zepben/evolve/services/network/tracing/networktrace/NetworkTraceStepPathProviderTest.kt
@@ -372,29 +372,6 @@ class NetworkTraceStepPathProviderTest {
         assertThat(nextPaths, containsInAnyOrder(cut2.t1..<clamp2.t1, cut2.t1..<clamp3.t1, cut2.t1..<cut1.t2, cut2.t1..c8.t1))
     }
 
-    @Suppress("DEPRECATION")
-    @Test
-    fun `supports legacy AcLineSegment with multiple terminals`() {
-        //
-        //              3
-        //  1 b0 21--c1-*-2
-        //
-        val network = TestNetworkBuilder()
-            .fromBreaker() // b0
-            .toAcls() // c1
-            .network
-
-        val b0: Breaker = network["b0"]!!
-        val c1: AcLineSegment = network["c1"]!!
-        c1.midSpanTerminalsEnabled = true
-        c1.addTerminal(Terminal())
-
-        val currentPath = b0.t2..c1.t1
-        val nextPaths = pathProvider.nextPaths(currentPath).toList()
-
-        assertThat(nextPaths, containsInAnyOrder(c1.t1..<c1.t2, c1.t1..<c1.t3))
-    }
-
     private fun busbarNetwork(): NetworkService {
         //         1
         //         b0

--- a/src/test/kotlin/com/zepben/evolve/testing/TestNetworkBuilderTest.kt
+++ b/src/test/kotlin/com/zepben/evolve/testing/TestNetworkBuilderTest.kt
@@ -168,6 +168,23 @@ internal class TestNetworkBuilderTest {
     }
 
     @Test
+    internal fun sampleNetworkStartingWithBusbarSections() {
+        //
+        // bbs0 11--c1--21 bbs2
+        //
+        TestNetworkBuilder()
+            .fromBusbarSection(PhaseCode.ABC) // bbs0
+            .toAcls(PhaseCode.ABC) // c1
+            .toBusbarSection(PhaseCode.ABC) // bbs2
+            .build()
+            .apply {
+                validateConnections("bbs0", listOf("c1-t1"))
+                validateConnections("c1", listOf("bbs0-t1"), listOf("bbs2-t1"))
+                validateConnections("bbs2", listOf("c1-t2"))
+            }
+    }
+
+    @Test
     internal fun `can override ids`() {
         TestNetworkBuilder()
             .fromSource(mRID = "my source 1")
@@ -205,6 +222,17 @@ internal class TestNetworkBuilderTest {
                         "my other 2"
                     )
                 )
+            }
+    }
+
+    @Test
+    internal fun `can override other prefix`() {
+        TestNetworkBuilder()
+            .fromOther(::Fuse, defaultMridPrefix = "abc")
+            .toOther(::Fuse, defaultMridPrefix = "def")
+            .build()
+            .apply {
+                assertThat(listOf<ConductingEquipment>().map { it.mRID }, containsInAnyOrder("abc0", "def1"))
             }
     }
 


### PR DESCRIPTION
# Description

Added support for `Cut` and `Clamp` on `AcLineSegment` in the tracing API.

# Associated tasks

None.

# Test Steps

Create a network model that includes cuts and clamps on an AcLineSegment. Run a trace over it and see cuts and clamps are included when stepping along the network.

The unit tests also hopefully give confidence that it works.

# Checklist

If any of these are not applicable, strikethrough the line `~like this~`. **Do not delete it!**. Let the reviewer decide if you should have done it.

### Code
- [x] I have performed a self review of my own code (including checking issues raised when creating the PR).
- [x] I have added/updated unit tests for these changes, and if not I have explained why they are not necessary.
- [x] I have commented my code in any hard-to-understand or hacky areas.
- [x] I have handled all new warnings generated by the compiler or IDE.
- [x] I have rebased onto the target branch (usually main).

### Documentation
- [x] I have updated the changelog.
~- [ ] I have updated any documentation required for these changes.~ 

# Breaking Changes
- [x] I have considered if this is a breaking change and will communicate it with other team members if so.

AcLineSegments can now only have 2 terminals. Segments with mid-span terminals need to be migrated to use clamps.

