### PR TITLE
[DEV-2350] `UpdateNetworkStateService.setCurrentStates` no longer blocks while waiting for `onSetCurrentStates` callbacks when handling the `onCompleted` request.

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -56,6 +56,8 @@
 * Added `connectionTestTimeoutMs` field to `GrpcBuildArgs` with a default value of `5000`. This timeout is only applied to requests made in the initial connection tests.
 * Updated to ewb-grpc 0.34.1:
   * Changed AddJumperEvent to not use reserved words.
+* `UpdateNetworkStateService.setCurrentStates` no longer blocks while waiting for `onSetCurrentStates` callbacks when handling the `onCompleted` request. This
+  only effects the gRPC threads.
 
 ### Fixes
 * `RemovePhases` now stops at open points like the `SetPhases` counterpart.


### PR DESCRIPTION
# Description

`UpdateNetworkStateService.setCurrentStates` no longer blocks while waiting for `onSetCurrentStates` callbacks when handling the `onCompleted` request.

# Test Steps

Send in a batch of state changes that will take a measurable amount of time and check the status of the gRPC thread while waiting for them to complete (good luck).

# Checklist

If any of these are not applicable, strikethrough the line `~like this~`. **Do not delete it!**. Let the reviewer decide if you should have done it.

### Code
- [x] I have performed a self review of my own code (including checking issues raised when creating the PR).
~- [ ] I have added/updated unit tests for these changes, and if not I have explained why they are not necessary.~ not worth the effort of trying to mock out the multithreaded requirements of testing this.
- [x] I have commented my code in any hard-to-understand or hacky areas.
- [x] I have handled all new warnings generated by the compiler or IDE.
- [x] I have rebased onto the target branch (usually main).

### Documentation
- [x] I have updated the changelog.
~- [ ] I have updated any documentation required for these changes.~Implementation change only

# Breaking Changes
- [x] I have considered if this is a breaking change and will communicate it with other team members if so.

Non-breaking unless you were relying on the gRPC thread blocking (why?)