### PR TITLE
Allow passing GrpcBuildArgs to connect functions

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -88,6 +88,7 @@
 * `RemovePhases` now stops at open points like the `SetPhases` counterpart.
 * `AssignToFeeder` and `AssignToLvFeeder` will no longer trace from start terminals that belong to open switches.
 * When finding `LvFeeders` in the `Site` we will now exclude `LvFeeders` that start with an open `Switch`
+* You can now pass GrpcBuildArgs to the `connect*` helper functions when connecting to EWB. See `GrpcBuildArgs` for options.
 
 ## [0.24.1] - 2025-01-23
 ### Breaking Changes

--- a/docs/docs/consumer.mdx
+++ b/docs/docs/consumer.mdx
@@ -235,6 +235,67 @@ GrpcChannelBuilder().forAddress("example.zepben.com", 443).makeSecure("ca.cert",
 </TabItem>
 </Tabs>
 
+### Specifying gRPC build args
+
+The `connect` functions listed above also allow passing `GrpcBuildArgs`, which provides some options for managing the underlying connection:
+
+1. `skipConnectionTest`: Will skip the initial connection test on the channel. Instead the connection will be lazily established upon the first query.1
+2. `debugConnectionTest`: If set to true will provide all errors found during the connection test. A lot of this may be noise, as it's only expected that at least one test succeeds.
+3. `connectionTestTimeoutMs`: The time in milliseconds to wait for the connection test to complete. Conservatively defaults to 10 seconds.
+4. `maxInboundMessageSize`: The maximum size of a protobuf message that can be received via gRPC calls. Conservatively defaults to 20 megabytes.
+
+You can specify these settings like so:
+
+<Tabs
+    groupId="code-example"
+    defaultValue="java"
+    values={[
+        { label: "Java", value: "java", },
+        { label: "Kotlin", value: "kotlin", },
+    ]
+}>
+<TabItem value="java">
+
+```java
+// With a personal access token and SSL
+try (GrpcChannel channel = Connect.connectWithAccessToken(
+    "example.zepben.com", // rpc hostname
+    443,                  // rpc port
+    "eyJhbGciOiJub25lIiwidHlwIjoiSldUIn0.eyJhdWQiOiJzZGtfZXhhbXBsZV9hdWRpZW5jZSJ9.",  // personal access token generated from EAS
+    "path/to/ca.cert",     // set to null to use system CAs for server cert verification
+    new GrpcBuildArgs(true, false, 0, 1024 * 1024 * 40)   // Specify to skip connection tests, change connection test timeout to 0, and increase max message size to 40mb.
+    )
+) {
+    NetworkConsumerClient client = new NetworkConsumerClient(channel);
+    GrpcResult result = client.getEquipmentContainer("container_mrid").throwOnError();
+    NetworkService ns = client.getService();
+}
+
+
+```
+
+</TabItem>
+<TabItem  value="kotlin">
+
+```kotlin
+Connect.connectWithAccessToken(
+    "example.zepben.com", // rpc hostname
+    443,                  // rpc port
+    "eyJhbGciOiJub25lIiwidHlwIjoiSldUIn0.eyJhdWQiOiJzZGtfZXhhbXBsZV9hdWRpZW5jZSJ9.",  // personal access token generated from EAS
+    "path/to/ca.cert",     // Do not pass if you intend to use system CAs for server cert verification
+    GrpcBuildArgs(skipConnectionTest=true, debugConnectionTest=false, connectionTestTimeoutMs=5000, maxInboundMessageSize=1024 * 1024 * 40)  // Specify to skip connection tests, change connection test timeout to 0, and increase max message size to 40mb.
+).use { channel ->
+     val client = NetworkConsumerClient(channel)
+     val result = client.getEquipmentContainer("container_mrid").throwOnError()
+     val ns = client.service
+}
+
+```
+
+</TabItem>
+</Tabs>
+
+
 ## Network Hierarchy
 
 The network can be built with a hierarchy as discussed earlier [here](datamodel.mdx#network-hierarchy). This allows you

--- a/src/main/kotlin/com/zepben/evolve/streaming/grpc/GrpcChannelBuilder.kt
+++ b/src/main/kotlin/com/zepben/evolve/streaming/grpc/GrpcChannelBuilder.kt
@@ -27,11 +27,17 @@ import java.util.concurrent.TimeUnit
 
 private const val TWENTY_MEGABYTES = 1024 * 1024 * 20
 
+/**
+ * @param skipConnectionTest Whether to skip the connection test when establishing the channel.
+ * @param debugConnectionTest Set to true to save and log all errors from the connection test. Note this will be verbose and is for advanced use only.
+ * @param connectionTestTimeoutMs The amount of time to wait for the connection test to complete.
+ * @param maxInboundMessageSize The amount of data that can be received in a single message over the gRPC connection.
+ */
 data class GrpcBuildArgs(
-    val skipConnectionTest: Boolean,
-    val debugConnectionTest: Boolean,
-    val connectionTestTimeoutMs: Long,
-    val maxInboundMessageSize: Int
+    val skipConnectionTest: Boolean = false,
+    val debugConnectionTest: Boolean = false,
+    val connectionTestTimeoutMs: Long = 10000,
+    val maxInboundMessageSize: Int = TWENTY_MEGABYTES
 )
 
 val DEFAULT_BUILD_ARGS = GrpcBuildArgs(skipConnectionTest = false, debugConnectionTest = true, connectionTestTimeoutMs = 5000, maxInboundMessageSize = TWENTY_MEGABYTES)

--- a/src/test/kotlin/com/zepben/evolve/streaming/grpc/ConnectTest.kt
+++ b/src/test/kotlin/com/zepben/evolve/streaming/grpc/ConnectTest.kt
@@ -51,11 +51,11 @@ internal class ConnectTest {
         every { gcbWithAddress.makeInsecure() } returns gcbWithOutTls
         every { gcbWithOutTls.withAccessToken("accessToken") } returns gcbWithToken
 
-        every { gcbWithAddress.build() } returns grpcChannel
-        every { gcbWithTls.build() } returns grpcChannelWithTls
-        every { gcbWithTlsWithToken.build() } returns grpcChannelWithTlsWithToken
-        every { gcbWithToken.build() } returns grpcChannelWithToken
-        every { gcbWithAuth.build() } returns grpcChannelWithAuth
+        every { gcbWithAddress.build(any()) } returns grpcChannel
+        every { gcbWithTls.build(any()) } returns grpcChannelWithTls
+        every { gcbWithTlsWithToken.build(any()) } returns grpcChannelWithTlsWithToken
+        every { gcbWithToken.build(any()) } returns grpcChannelWithToken
+        every { gcbWithAuth.build(any()) } returns grpcChannelWithAuth
 
         every { tokenFetcher.tokenRequestData } returns tokenRequestData
 


### PR DESCRIPTION
# Description

Just adds buildArgs to all the connect functions so that we don't have to use the GrpcChannelBuilder to do so.

Connection tests are still broken - this just makes it easier to pass the thing to skip them.

# Test Steps

Try any connect function and pass buildArgs=GrpcBuildArgs(skipConnectionTest=true)

# Checklist

If any of these are not applicable, strikethrough the line `~like this~`. **Do not delete it!**. Let the reviewer decide if you should have done it.

### Code
- [ ] I have performed a self review of my own code (including checking issues raised when creating the PR).
- [ ] I have added/updated unit tests for these changes, and if not I have explained why they are not necessary.
- [ ] I have commented my code in any hard-to-understand or hacky areas.
- [ ] I have handled all new warnings generated by the compiler or IDE.
- [ ] I have rebased onto the target branch (usually main).

### Documentation
- [ ] I have updated the changelog.
- [ ] I have updated any documentation required for these changes.

# Breaking Changes
- [ ] I have considered if this is a breaking change and will communicate it with other team members if so.

Not breaking
