### PR TITLE
DEV-2506 Tracing fixes

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -9,7 +9,7 @@
   need to update your code.
 * `RemovePhases` now stops at open points like the `SetPhases` counterpart. If you were relying on the bug to remove phases through open points you will now
   need to start additional traces from the other side of the open points to maintain this behaviour.
-* `SetDirection` now correctly sets directions for networks with `BusbarSection`.
+* `SetDirection` now correctly sets directions for networks with `BusbarSection`, `Cut` and `Clamp`.
 * `RemoveDirection` has been removed. It did not work reliably with dual fed networks with loops. You now need to clear direction using the new
   `ClearDirection` and reapply directions where appropriate using `SetDirection`.
 * `FindWithUsagePoints` was deemed too use-case specific for the SDK and has been removed.

--- a/changelog.md
+++ b/changelog.md
@@ -54,6 +54,9 @@
 * `AcLineSegment` supports adding a maximum of 2 terminals. Mid-span terminals are no longer supported and models should migrate to using `Clamp`.
 * `Clamp` supports only adding a single terminal.
 * `Cut` supports adding a maximum of 2 terminals.
+* Direction aware helpers in `Condition` that didn't use the `FeederDirectionStateOperations` have been removed, with the remaining helpers now taking
+  `NetworkStateOperators` as a receiver.
+* `NetworkStateOperators` implements a new sub-interface `ConnectivityStateOperators`.
 
 ### New Features
 * Added `ClearDirection` that clears feeder directions.

--- a/src/main/kotlin/com/zepben/evolve/services/network/tracing/feeder/SetDirection.kt
+++ b/src/main/kotlin/com/zepben/evolve/services/network/tracing/feeder/SetDirection.kt
@@ -11,6 +11,7 @@ package com.zepben.evolve.services.network.tracing.feeder
 import com.zepben.evolve.cim.iec61970.base.core.Feeder
 import com.zepben.evolve.cim.iec61970.base.core.Terminal
 import com.zepben.evolve.cim.iec61970.base.wires.BusbarSection
+import com.zepben.evolve.cim.iec61970.base.wires.Cut
 import com.zepben.evolve.cim.iec61970.base.wires.PowerTransformer
 import com.zepben.evolve.services.network.NetworkService
 import com.zepben.evolve.services.network.tracing.networktrace.NetworkTrace
@@ -36,11 +37,12 @@ class SetDirection {
             return FeederDirection.CONNECTOR
         }
 
-        val directionApplied = step.data
-        val nextDirection = when (directionApplied) {
-            FeederDirection.UPSTREAM -> FeederDirection.DOWNSTREAM
-            FeederDirection.DOWNSTREAM, FeederDirection.CONNECTOR -> FeederDirection.UPSTREAM
-            else -> FeederDirection.NONE
+        val nextDirection = when {
+            step.data == FeederDirection.NONE -> FeederDirection.NONE
+            nextPath.tracedInternally -> FeederDirection.DOWNSTREAM
+            nextPath.toEquipment is Cut -> FeederDirection.UPSTREAM
+            nextPath.didTraverseAcLineSegment -> FeederDirection.DOWNSTREAM
+            else -> FeederDirection.UPSTREAM
         }
 
         //

--- a/src/main/kotlin/com/zepben/evolve/services/network/tracing/networktrace/NetworkTrace.kt
+++ b/src/main/kotlin/com/zepben/evolve/services/network/tracing/networktrace/NetworkTrace.kt
@@ -84,7 +84,7 @@ class NetworkTrace<T> private constructor(
         computeData: ComputeData<T>,
     ) : this(
         networkStateOperators,
-        BasicQueueType(NetworkTraceQueueNext.Basic(NetworkTraceStepPathProvider(networkStateOperators), computeData.withActionType(actionType)), queue),
+        BasicQueueType(NetworkTraceQueueNext.Basic(networkStateOperators, computeData.withActionType(actionType)), queue),
         null,
         actionType,
     )
@@ -98,7 +98,7 @@ class NetworkTrace<T> private constructor(
         computeNextT: ComputeDataWithPaths<T>,
     ) : this(
         networkStateOperators,
-        BasicQueueType(NetworkTraceQueueNext.Basic(NetworkTraceStepPathProvider(networkStateOperators), computeNextT.withActionType(actionType)), queue),
+        BasicQueueType(NetworkTraceQueueNext.Basic(networkStateOperators, computeNextT.withActionType(actionType)), queue),
         null,
         actionType,
     )
@@ -114,7 +114,7 @@ class NetworkTrace<T> private constructor(
     ) : this(
         networkStateOperators,
         BranchingQueueType(
-            NetworkTraceQueueNext.Branching(NetworkTraceStepPathProvider(networkStateOperators), computeData.withActionType(actionType)),
+            NetworkTraceQueueNext.Branching(networkStateOperators, computeData.withActionType(actionType)),
             queueFactory,
             branchQueueFactory
         ),
@@ -134,7 +134,7 @@ class NetworkTrace<T> private constructor(
     ) : this(
         networkStateOperators,
         BranchingQueueType(
-            NetworkTraceQueueNext.Branching(NetworkTraceStepPathProvider(networkStateOperators), computeNextT.withActionType(actionType)),
+            NetworkTraceQueueNext.Branching(networkStateOperators, computeNextT.withActionType(actionType)),
             queueFactory,
             branchQueueFactory
         ),

--- a/src/main/kotlin/com/zepben/evolve/services/network/tracing/networktrace/NetworkTraceExtensions.kt
+++ b/src/main/kotlin/com/zepben/evolve/services/network/tracing/networktrace/NetworkTraceExtensions.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Zeppelin Bend Pty Ltd
+ * Copyright 2025 Zeppelin Bend Pty Ltd
  *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
@@ -31,7 +31,7 @@ fun NetworkTrace<Unit>.addStartItem(start: Terminal, phases: PhaseCode? = null):
  * @param phases Phases to trace; `null` to ignore phases.
  */
 fun NetworkTrace<Unit>.addStartItem(start: ConductingEquipment, phases: PhaseCode? = null): NetworkTrace<Unit> {
-    start.terminals.forEach { addStartItem(it, Unit, phases) }
+    addStartItem(start, Unit, phases)
     return this
 }
 

--- a/src/main/kotlin/com/zepben/evolve/services/network/tracing/networktrace/conditions/Conditions.kt
+++ b/src/main/kotlin/com/zepben/evolve/services/network/tracing/networktrace/conditions/Conditions.kt
@@ -9,13 +9,14 @@
 package com.zepben.evolve.services.network.tracing.networktrace.conditions
 
 import com.zepben.evolve.cim.iec61970.base.core.ConductingEquipment
-import com.zepben.evolve.cim.iec61970.base.core.Terminal
 import com.zepben.evolve.cim.iec61970.base.wires.SinglePhaseKind
 import com.zepben.evolve.cim.iec61970.base.wires.Switch
 import com.zepben.evolve.services.network.tracing.feeder.FeederDirection
 import com.zepben.evolve.services.network.tracing.networktrace.NetworkTrace
 import com.zepben.evolve.services.network.tracing.networktrace.NetworkTraceStep
+import com.zepben.evolve.services.network.tracing.networktrace.conditions.Conditions.limitEquipmentSteps
 import com.zepben.evolve.services.network.tracing.networktrace.operators.FeederDirectionStateOperations
+import com.zepben.evolve.services.network.tracing.networktrace.operators.NetworkStateOperators
 import com.zepben.evolve.services.network.tracing.networktrace.operators.OpenStateOperators
 import com.zepben.evolve.services.network.tracing.traversal.QueueCondition
 import com.zepben.evolve.services.network.tracing.traversal.StopCondition
@@ -31,16 +32,6 @@ object Conditions {
 
     /**
      * Creates a [NetworkTrace] condition that will cause tracing a feeder upstream (towards the head terminal).
-     *
-     * @param getDirection A function that retrieves the [FeederDirection] of a given [Terminal].
-     * @return A [NetworkTraceQueueCondition] that results in upstream tracing.
-     */
-    @JvmStatic
-    fun <T> upstream(getDirection: (Terminal) -> FeederDirection): NetworkTraceQueueCondition<T> =
-        withDirection(FeederDirection.UPSTREAM, getDirection)
-
-    /**
-     * Creates a [NetworkTrace] condition that will cause tracing a feeder upstream (towards the head terminal).
      * This uses [FeederDirectionStateOperations.getDirection] receiver instance method within the condition.
      *
      * This variant is used to enable a DSL style syntax when setting up a [NetworkTrace].
@@ -51,43 +42,8 @@ object Conditions {
      * @return A [NetworkTraceQueueCondition] that results in upstream tracing.
      */
     @JvmStatic
-    fun <T> FeederDirectionStateOperations.upstream(): NetworkTraceQueueCondition<T> =
-        upstream(this::getDirection)
-
-    /**
-     * Creates a [NetworkTrace] condition that will cause tracing a feeder downstream (away from the head terminal).
-     *
-     * @param getDirection A function that retrieves the [FeederDirection] of a given [Terminal].
-     * @return A [NetworkTraceQueueCondition] that results in downstream tracing.
-     */
-    @JvmStatic
-    fun <T> downstream(getDirection: (Terminal) -> FeederDirection): NetworkTraceQueueCondition<T> =
-        withDirection(FeederDirection.DOWNSTREAM, getDirection)
-
-    /**
-     * Creates a [NetworkTrace] condition that will cause tracing only terminals with directions that match [direction].
-     *
-     * @param getDirection A function that retrieves the [FeederDirection] of a given [Terminal].
-     * @return A [NetworkTraceQueueCondition] that results in tracing terminals with the matching direction.
-     */
-    @JvmStatic
-    fun <T> withDirection(direction: FeederDirection, getDirection: (Terminal) -> FeederDirection): NetworkTraceQueueCondition<T> =
-        DirectionCondition(direction, getDirection)
-
-    /**
-     * Creates a [NetworkTrace] condition that will cause tracing only terminals with directions that match [direction].
-     * This uses [FeederDirectionStateOperations.getDirection] receiver instance method within the condition.
-     *
-     * This variant is used to enable a DSL style syntax when setting up a [NetworkTrace].
-     * ```
-     * trace.addCondition { withDirection(FeederDirection.BOTH) }
-     * ```
-     *
-     * @return A [NetworkTraceQueueCondition] that results in upstream tracing.
-     */
-    @JvmStatic
-    fun <T> FeederDirectionStateOperations.withDirection(direction: FeederDirection): NetworkTraceQueueCondition<T> =
-        withDirection(direction, this::getDirection)
+    fun <T> NetworkStateOperators.upstream(): NetworkTraceQueueCondition<T> =
+        withDirection(FeederDirection.UPSTREAM)
 
     /**
      * Creates a [NetworkTrace] condition that will cause tracing a feeder downstream (away from the head terminal).
@@ -101,8 +57,23 @@ object Conditions {
      * @return A [NetworkTraceQueueCondition] that results in downstream tracing.
      */
     @JvmStatic
-    fun <T> FeederDirectionStateOperations.downstream(): NetworkTraceQueueCondition<T> =
-        downstream(this::getDirection)
+    fun <T> NetworkStateOperators.downstream(): NetworkTraceQueueCondition<T> =
+        withDirection(FeederDirection.DOWNSTREAM)
+
+    /**
+     * Creates a [NetworkTrace] condition that will cause tracing only terminals with directions that match [direction].
+     * This uses [FeederDirectionStateOperations.getDirection] receiver instance method within the condition.
+     *
+     * This variant is used to enable a DSL style syntax when setting up a [NetworkTrace].
+     * ```
+     * trace.addCondition { withDirection(FeederDirection.BOTH) }
+     * ```
+     *
+     * @return A [NetworkTraceQueueCondition] that results in upstream tracing.
+     */
+    @JvmStatic
+    fun <T> NetworkStateOperators.withDirection(direction: FeederDirection): NetworkTraceQueueCondition<T> =
+        DirectionCondition(direction, this)
 
     /**
      * Creates a [NetworkTrace] condition that will cause a trace to not queue through open equipment.

--- a/src/main/kotlin/com/zepben/evolve/services/network/tracing/networktrace/conditions/Conditions.kt
+++ b/src/main/kotlin/com/zepben/evolve/services/network/tracing/networktrace/conditions/Conditions.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Zeppelin Bend Pty Ltd
+ * Copyright 2025 Zeppelin Bend Pty Ltd
  *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
@@ -22,9 +22,6 @@ import com.zepben.evolve.services.network.tracing.traversal.QueueCondition
 import com.zepben.evolve.services.network.tracing.traversal.StopCondition
 import kotlin.reflect.KClass
 
-private typealias NetworkTraceQueueCondition<T> = QueueCondition<NetworkTraceStep<T>>
-private typealias NetworkTraceStopCondition<T> = StopCondition<NetworkTraceStep<T>>
-
 /**
  * Provides a collection of predefined conditions for use in network traces.
  */
@@ -42,7 +39,7 @@ object Conditions {
      * @return A [NetworkTraceQueueCondition] that results in upstream tracing.
      */
     @JvmStatic
-    fun <T> NetworkStateOperators.upstream(): NetworkTraceQueueCondition<T> =
+    fun <T> NetworkStateOperators.upstream(): QueueCondition<NetworkTraceStep<T>> =
         withDirection(FeederDirection.UPSTREAM)
 
     /**
@@ -57,7 +54,7 @@ object Conditions {
      * @return A [NetworkTraceQueueCondition] that results in downstream tracing.
      */
     @JvmStatic
-    fun <T> NetworkStateOperators.downstream(): NetworkTraceQueueCondition<T> =
+    fun <T> NetworkStateOperators.downstream(): QueueCondition<NetworkTraceStep<T>> =
         withDirection(FeederDirection.DOWNSTREAM)
 
     /**
@@ -72,7 +69,7 @@ object Conditions {
      * @return A [NetworkTraceQueueCondition] that results in upstream tracing.
      */
     @JvmStatic
-    fun <T> NetworkStateOperators.withDirection(direction: FeederDirection): NetworkTraceQueueCondition<T> =
+    fun <T> NetworkStateOperators.withDirection(direction: FeederDirection): QueueCondition<NetworkTraceStep<T>> =
         DirectionCondition(direction, this)
 
     /**
@@ -83,7 +80,7 @@ object Conditions {
      * @return A [NetworkTraceQueueCondition] that results in not tracing through open equipment.
      */
     @JvmStatic
-    fun <T> stopAtOpen(openTest: (Switch, SinglePhaseKind?) -> Boolean, phase: SinglePhaseKind? = null): NetworkTraceQueueCondition<T> =
+    fun <T> stopAtOpen(openTest: (Switch, SinglePhaseKind?) -> Boolean, phase: SinglePhaseKind? = null): QueueCondition<NetworkTraceStep<T>> =
         OpenCondition(openTest, phase)
 
     /**
@@ -99,7 +96,7 @@ object Conditions {
      * @return A [NetworkTraceQueueCondition] that results in not queueing through open equipment.
      */
     @JvmStatic
-    fun <T> OpenStateOperators.stopAtOpen(phase: SinglePhaseKind? = null): NetworkTraceQueueCondition<T> =
+    fun <T> OpenStateOperators.stopAtOpen(phase: SinglePhaseKind? = null): QueueCondition<NetworkTraceStep<T>> =
         stopAtOpen(this::isOpen, phase)
 
     /**
@@ -109,7 +106,7 @@ object Conditions {
      * @return A [NetworkTraceStopCondition] that stops tracing the path once the step limit is reached.
      */
     @JvmStatic
-    fun <T> limitEquipmentSteps(limit: Int): NetworkTraceStopCondition<T> =
+    fun <T> limitEquipmentSteps(limit: Int): StopCondition<NetworkTraceStep<T>> =
         EquipmentStepLimitCondition(limit)
 
     /**
@@ -121,7 +118,7 @@ object Conditions {
      * @return A [NetworkTraceStopCondition] that stops the trace when the step limit is reached for the specified equipment type.
      */
     @JvmStatic
-    fun <T> limitEquipmentSteps(limit: Int, equipmentType: KClass<out ConductingEquipment>): NetworkTraceStopCondition<T> =
+    fun <T> limitEquipmentSteps(limit: Int, equipmentType: KClass<out ConductingEquipment>): StopCondition<NetworkTraceStep<T>> =
         EquipmentTypeStepLimitCondition(limit, equipmentType)
 
     /**
@@ -132,7 +129,7 @@ object Conditions {
      * @return A [NetworkTraceStopCondition] that stops the trace when the step limit is reached for the specified equipment type.
      */
     @JvmStatic
-    fun <T> limitEquipmentSteps(limit: Int, equipmentType: Class<out ConductingEquipment>): NetworkTraceStopCondition<T> =
+    fun <T> limitEquipmentSteps(limit: Int, equipmentType: Class<out ConductingEquipment>): StopCondition<NetworkTraceStep<T>> =
         limitEquipmentSteps(limit, equipmentType.kotlin)
 
 }

--- a/src/main/kotlin/com/zepben/evolve/services/network/tracing/networktrace/conditions/DirectionCondition.kt
+++ b/src/main/kotlin/com/zepben/evolve/services/network/tracing/networktrace/conditions/DirectionCondition.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Zeppelin Bend Pty Ltd
+ * Copyright 2025 Zeppelin Bend Pty Ltd
  *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
@@ -8,6 +8,7 @@
 
 package com.zepben.evolve.services.network.tracing.networktrace.conditions
 
+import com.zepben.evolve.cim.iec61970.base.wires.Clamp
 import com.zepben.evolve.cim.iec61970.base.wires.Cut
 import com.zepben.evolve.services.network.tracing.feeder.FeederDirection
 import com.zepben.evolve.services.network.tracing.feeder.FeederDirection.*
@@ -34,20 +35,26 @@ internal class DirectionCondition<T>(
         // Cuts do weird things with directions depending on if they are energised from an external connection, or through a "closed" cut. To prevent
         // dealing with this awful mess, it is much simpler to just ask if anything else past it needs queueing. This could be made to short-circuit
         // for traversing downstream, but the code is much more complex to only save one extra step.
-        return if (path.toEquipment is Cut) {
-            usableNextPaths(path).any { furtherPath -> shouldQueue(furtherPath) }
-        } else if (path.tracedInternally || path.didTraverseAcLineSegment) {
-            direction in getDirection(path.toTerminal)
-        } else {
-            direction.complementaryExternalDirection() in getDirection(path.toTerminal)
+        return when {
+            path.toEquipment is Cut -> path.shouldQueueNextPaths()
+            path.tracedInternally || path.didTraverseAcLineSegment -> direction in getDirection(path.toTerminal)
+            else -> direction.complementaryExternalDirection() in getDirection(path.toTerminal)
         }
     }
 
-    private fun usableNextPaths(path: NetworkTraceStep.Path) =
-        stateOperators.nextPaths(path).filterNot { nextPath -> nextPath.tracedInternally && stateOperators.isOpen(path.toEquipment) }
+    private fun NetworkTraceStep.Path.shouldQueueNextPaths() =
+        stateOperators.nextPaths(this)
+            .filterNot { nextPath -> nextPath.tracedInternally && stateOperators.isOpen(toEquipment) }
+            .any { furtherPath -> shouldQueue(furtherPath) }
 
     override fun shouldQueueStartItem(item: NetworkTraceStep<T>): Boolean =
-        direction in getDirection(item.path.toTerminal)
+        when {
+            direction in getDirection(item.path.toTerminal) -> true
+            // Because cuts and clamps behave a bit different with directions than other equipment terminals, we can also check if any further paths needs to be
+            // queued, and if they do we queue the start item.
+            item.path.toEquipment is Clamp || item.path.toEquipment is Cut -> item.path.shouldQueueNextPaths()
+            else -> false
+        }
 
     private fun FeederDirection.complementaryExternalDirection(): FeederDirection = when (this) {
         NONE -> NONE

--- a/src/main/kotlin/com/zepben/evolve/services/network/tracing/networktrace/conditions/DirectionCondition.kt
+++ b/src/main/kotlin/com/zepben/evolve/services/network/tracing/networktrace/conditions/DirectionCondition.kt
@@ -8,26 +8,43 @@
 
 package com.zepben.evolve.services.network.tracing.networktrace.conditions
 
-import com.zepben.evolve.cim.iec61970.base.core.Terminal
+import com.zepben.evolve.cim.iec61970.base.wires.Cut
 import com.zepben.evolve.services.network.tracing.feeder.FeederDirection
 import com.zepben.evolve.services.network.tracing.feeder.FeederDirection.*
 import com.zepben.evolve.services.network.tracing.networktrace.NetworkTraceStep
+import com.zepben.evolve.services.network.tracing.networktrace.operators.NetworkStateOperators
 import com.zepben.evolve.services.network.tracing.traversal.QueueCondition
 import com.zepben.evolve.services.network.tracing.traversal.StepContext
 
 internal class DirectionCondition<T>(
     val direction: FeederDirection,
-    val getDirection: (Terminal) -> FeederDirection
+    val stateOperators: NetworkStateOperators
 ) : QueueCondition<NetworkTraceStep<T>> {
 
-    override fun shouldQueue(nextItem: NetworkTraceStep<T>, nextContext: StepContext, currentItem: NetworkTraceStep<T>, currentContext: StepContext): Boolean {
-        val path = nextItem.path
-        return if (path.tracedInternally) {
+    private val getDirection = stateOperators::getDirection
+
+    init {
+        require(direction != CONNECTOR) { "A direction of CONNECTOR is not currently supported." }
+    }
+
+    override fun shouldQueue(nextItem: NetworkTraceStep<T>, nextContext: StepContext, currentItem: NetworkTraceStep<T>, currentContext: StepContext): Boolean =
+        shouldQueue(nextItem.path)
+
+    private fun shouldQueue(path: NetworkTraceStep.Path): Boolean {
+        // Cuts do weird things with directions depending on if they are energised from an external connection, or through a "closed" cut. To prevent
+        // dealing with this awful mess, it is much simpler to just ask if anything else past it needs queueing. This could be made to short-circuit
+        // for traversing downstream, but the code is much more complex to only save one extra step.
+        return if (path.toEquipment is Cut) {
+            usableNextPaths(path).any { furtherPath -> shouldQueue(furtherPath) }
+        } else if (path.tracedInternally || path.didTraverseAcLineSegment) {
             direction in getDirection(path.toTerminal)
         } else {
             direction.complementaryExternalDirection() in getDirection(path.toTerminal)
         }
     }
+
+    private fun usableNextPaths(path: NetworkTraceStep.Path) =
+        stateOperators.nextPaths(path).filterNot { nextPath -> nextPath.tracedInternally && stateOperators.isOpen(path.toEquipment) }
 
     override fun shouldQueueStartItem(item: NetworkTraceStep<T>): Boolean =
         direction in getDirection(item.path.toTerminal)

--- a/src/main/kotlin/com/zepben/evolve/services/network/tracing/networktrace/conditions/NetworkTraceQueueCondition.kt
+++ b/src/main/kotlin/com/zepben/evolve/services/network/tracing/networktrace/conditions/NetworkTraceQueueCondition.kt
@@ -6,8 +6,9 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
-package com.zepben.evolve.services.network.tracing.networktrace
+package com.zepben.evolve.services.network.tracing.networktrace.conditions
 
+import com.zepben.evolve.services.network.tracing.networktrace.NetworkTraceStep
 import com.zepben.evolve.services.network.tracing.traversal.QueueCondition
 import com.zepben.evolve.services.network.tracing.traversal.StepContext
 

--- a/src/main/kotlin/com/zepben/evolve/services/network/tracing/networktrace/conditions/NetworkTraceStopCondition.kt
+++ b/src/main/kotlin/com/zepben/evolve/services/network/tracing/networktrace/conditions/NetworkTraceStopCondition.kt
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2025 Zeppelin Bend Pty Ltd
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+package com.zepben.evolve.services.network.tracing.networktrace.conditions
+
+import com.zepben.evolve.services.network.tracing.networktrace.NetworkTraceStep
+import com.zepben.evolve.services.network.tracing.traversal.StepContext
+import com.zepben.evolve.services.network.tracing.traversal.StopCondition
+
+/**
+ * A special stop condition implementation that allows only checking `shouldStop` when a [NetworkTraceStep] matches a given
+ * [NetworkTraceStep.Type]. When [stepType] is:
+ * *[NetworkTraceStep.Type.ALL]: [shouldStop] will be checked for every step.
+ * *[NetworkTraceStep.Type.INTERNAL]: [shouldStop] will be checked only when [NetworkTraceStep.type] is [NetworkTraceStep.Type.INTERNAL].
+ * *[NetworkTraceStep.Type.EXTERNAL]: [shouldStop] will be checked only when [NetworkTraceStep.type] is [NetworkTraceStep.Type.EXTERNAL].
+ *
+ * If the step does not match the given step type, `false` will always be returned.
+ *
+ * @property stepType The step type to match to check `shouldStop`.
+ */
+abstract class NetworkTraceStopCondition<T>(val stepType: NetworkTraceStep.Type) : StopCondition<NetworkTraceStep<T>> {
+
+    private val shouldStopFunc = when (stepType) {
+        NetworkTraceStep.Type.ALL -> ::shouldStopMatchedStep
+        NetworkTraceStep.Type.INTERNAL -> ::shouldStopInternalStep
+        NetworkTraceStep.Type.EXTERNAL -> ::shouldStopExternalStep
+    }
+
+    override fun shouldStop(item: NetworkTraceStep<T>, context: StepContext): Boolean =
+        shouldStopFunc(item, context)
+
+    /**
+     * The logic you would normally put in [shouldStop]. However, this will only be called when a step matches the [stepType].
+     */
+    abstract fun shouldStopMatchedStep(
+        item: NetworkTraceStep<T>,
+        context: StepContext
+    ): Boolean
+
+    private fun shouldStopInternalStep(
+        item: NetworkTraceStep<T>,
+        context: StepContext
+    ): Boolean =
+        if (item.type == NetworkTraceStep.Type.INTERNAL) shouldStopMatchedStep(item, context) else false
+
+    private fun shouldStopExternalStep(
+        item: NetworkTraceStep<T>,
+        context: StepContext
+    ): Boolean =
+        if (item.type == NetworkTraceStep.Type.EXTERNAL) shouldStopMatchedStep(item, context) else false
+
+    companion object {
+        /**
+         * Creates A [NetworkTraceStopCondition] that delegates to the given [condition] when matching the given [stepType].
+         * The [condition] is already a [NetworkTraceStopCondition] this will override the [stepType] of that instance.
+         *
+         * @param stepType The step type to match to check the queue condition.
+         * @param condition The queue conditions to delegate to when matching the step type.
+         * @return A new queue condition that only checks the condition when matching the given step type.
+         */
+        @JvmStatic
+        fun <T> delegateTo(stepType: NetworkTraceStep.Type, condition: StopCondition<NetworkTraceStep<T>>): NetworkTraceStopCondition<T> =
+            DelegatedNetworkTraceStopCondition(stepType, condition)
+    }
+}
+
+private class DelegatedNetworkTraceStopCondition<T>(
+    stepType: NetworkTraceStep.Type,
+    val delegate: StopCondition<NetworkTraceStep<T>>
+) : NetworkTraceStopCondition<T>(stepType) {
+    override fun shouldStopMatchedStep(
+        item: NetworkTraceStep<T>,
+        context: StepContext
+    ): Boolean = delegate.shouldStop(item, context)
+}

--- a/src/main/kotlin/com/zepben/evolve/services/network/tracing/networktrace/conditions/OpenCondition.kt
+++ b/src/main/kotlin/com/zepben/evolve/services/network/tracing/networktrace/conditions/OpenCondition.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Zeppelin Bend Pty Ltd
+ * Copyright 2025 Zeppelin Bend Pty Ltd
  *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
@@ -10,12 +10,9 @@ package com.zepben.evolve.services.network.tracing.networktrace.conditions
 
 import com.zepben.evolve.cim.iec61970.base.wires.SinglePhaseKind
 import com.zepben.evolve.cim.iec61970.base.wires.Switch
-import com.zepben.evolve.services.network.tracing.networktrace.NetworkTraceQueueCondition
 import com.zepben.evolve.services.network.tracing.networktrace.NetworkTraceStep
 import com.zepben.evolve.services.network.tracing.traversal.StepContext
 
-// NOTE: This is a queue condition and not a stop condition because once cuts and jumpers are added to the network model we need the 'next' terminal
-//       to determine if the step goes through an open circuit.
 internal class OpenCondition<T>(
     val isOpen: (Switch, SinglePhaseKind?) -> Boolean,
     val phase: SinglePhaseKind? = null

--- a/src/main/kotlin/com/zepben/evolve/services/network/tracing/networktrace/operators/ConnectivityStateOperators.kt
+++ b/src/main/kotlin/com/zepben/evolve/services/network/tracing/networktrace/operators/ConnectivityStateOperators.kt
@@ -1,0 +1,17 @@
+/*
+ * Copyright 2025 Zeppelin Bend Pty Ltd
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+package com.zepben.evolve.services.network.tracing.networktrace.operators
+
+import com.zepben.evolve.services.network.tracing.networktrace.NetworkTraceStep
+
+interface ConnectivityStateOperators {
+
+    fun nextPaths(path: NetworkTraceStep.Path): Sequence<NetworkTraceStep.Path>
+
+}

--- a/src/main/kotlin/com/zepben/evolve/services/network/tracing/networktrace/operators/ConnectivityStateOperators.kt
+++ b/src/main/kotlin/com/zepben/evolve/services/network/tracing/networktrace/operators/ConnectivityStateOperators.kt
@@ -10,8 +10,17 @@ package com.zepben.evolve.services.network.tracing.networktrace.operators
 
 import com.zepben.evolve.services.network.tracing.networktrace.NetworkTraceStep
 
+/**
+ * State aware operations relating to network conducting equipment connectivity.
+ */
 interface ConnectivityStateOperators {
 
+    /**
+     * Provides the next "paths" (from terminal to terminal) from a current path. This provides 'connected' terminals in a fashion
+     * that is suitable for tracing and not just terminals that are connected via connectivity nodes. For example:
+     * - Finding connected terminals on an AcLineSegment when the current path is at a clamp.
+     * - Stepping to and from a BusbarSection terminal.
+     */
     fun nextPaths(path: NetworkTraceStep.Path): Sequence<NetworkTraceStep.Path>
 
 }

--- a/src/main/kotlin/com/zepben/evolve/services/network/tracing/networktrace/operators/NetworkStateOperators.kt
+++ b/src/main/kotlin/com/zepben/evolve/services/network/tracing/networktrace/operators/NetworkStateOperators.kt
@@ -9,6 +9,8 @@
 package com.zepben.evolve.services.network.tracing.networktrace.operators
 
 import com.zepben.evolve.services.network.tracing.networktrace.NetworkTrace
+import com.zepben.evolve.services.network.tracing.networktrace.NetworkTraceStep
+import com.zepben.evolve.services.network.tracing.networktrace.NetworkTraceStepPathProvider
 
 /**
  * Interface providing access to and operations on specific network state properties and functions for items within a network.
@@ -28,7 +30,8 @@ interface NetworkStateOperators :
     FeederDirectionStateOperations,
     EquipmentContainerStateOperators,
     InServiceStateOperators,
-    PhaseStateOperators {
+    PhaseStateOperators,
+    ConnectivityStateOperators {
 
     companion object {
         /**
@@ -50,11 +53,23 @@ private class NormalNetworkStateOperators : NetworkStateOperators,
     FeederDirectionStateOperations by FeederDirectionStateOperations.NORMAL,
     EquipmentContainerStateOperators by EquipmentContainerStateOperators.NORMAL,
     InServiceStateOperators by InServiceStateOperators.NORMAL,
-    PhaseStateOperators by PhaseStateOperators.NORMAL
+    PhaseStateOperators by PhaseStateOperators.NORMAL {
+
+    private val networkTraceStepPathProvider = NetworkTraceStepPathProvider(this)
+
+    override fun nextPaths(path: NetworkTraceStep.Path): Sequence<NetworkTraceStep.Path> =
+        networkTraceStepPathProvider.nextPaths(path)
+}
 
 private class CurrentNetworkStateOperators : NetworkStateOperators,
     OpenStateOperators by OpenStateOperators.CURRENT,
     FeederDirectionStateOperations by FeederDirectionStateOperations.CURRENT,
     EquipmentContainerStateOperators by EquipmentContainerStateOperators.CURRENT,
     InServiceStateOperators by InServiceStateOperators.CURRENT,
-    PhaseStateOperators by PhaseStateOperators.CURRENT {}
+    PhaseStateOperators by PhaseStateOperators.CURRENT {
+
+    private val networkTraceStepPathProvider = NetworkTraceStepPathProvider(this)
+
+    override fun nextPaths(path: NetworkTraceStep.Path): Sequence<NetworkTraceStep.Path> =
+        networkTraceStepPathProvider.nextPaths(path)
+}

--- a/src/main/kotlin/com/zepben/evolve/services/network/tracing/networktrace/operators/NetworkStateOperators.kt
+++ b/src/main/kotlin/com/zepben/evolve/services/network/tracing/networktrace/operators/NetworkStateOperators.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Zeppelin Bend Pty Ltd
+ * Copyright 2025 Zeppelin Bend Pty Ltd
  *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
@@ -57,6 +57,8 @@ private class NormalNetworkStateOperators : NetworkStateOperators,
 
     private val networkTraceStepPathProvider = NetworkTraceStepPathProvider(this)
 
+    // This is not implemented in the same NORMAL/CURRENT single instance pattern as all the other
+    // StateOperator interfaces because the implementation of next paths has a dependency on other state operators.
     override fun nextPaths(path: NetworkTraceStep.Path): Sequence<NetworkTraceStep.Path> =
         networkTraceStepPathProvider.nextPaths(path)
 }
@@ -70,6 +72,8 @@ private class CurrentNetworkStateOperators : NetworkStateOperators,
 
     private val networkTraceStepPathProvider = NetworkTraceStepPathProvider(this)
 
+    // This is not implemented in the same NORMAL/CURRENT single instance pattern as all the other
+    // StateOperator interfaces because the implementation of next paths has a dependency on other state operators.
     override fun nextPaths(path: NetworkTraceStep.Path): Sequence<NetworkTraceStep.Path> =
         networkTraceStepPathProvider.nextPaths(path)
 }

--- a/src/main/kotlin/com/zepben/evolve/services/network/tracing/traversal/Traversal.kt
+++ b/src/main/kotlin/com/zepben/evolve/services/network/tracing/traversal/Traversal.kt
@@ -408,25 +408,25 @@ abstract class Traversal<T, D : Traversal<T, D>> internal constructor(
             } else {
                 queue.add(startItem)
             }
+        }
 
-            var canStop = canStopOnStartItem
-            while (queue.hasNext()) {
-                queue.next()?.let { current ->
-                    val context = getStepContext(current)
-                    if (canVisitItem(current, context)) {
-                        context.isStopping = canStop && matchesAnyStopCondition(current, context)
+        var canStop = canStopOnStartItem
+        while (queue.hasNext()) {
+            queue.next()?.let { current ->
+                val context = getStepContext(current)
+                if (canVisitItem(current, context)) {
+                    context.isStopping = canStop && matchesAnyStopCondition(current, context)
 
-                        context.isActionableItem = canActionItem(current, context)
-                        if (context.isActionableItem) {
-                            applyStepActions(current, context)
-                        }
-
-                        if (!context.isStopping) {
-                            queueNext(current, context)
-                        }
-
-                        canStop = true
+                    context.isActionableItem = canActionItem(current, context)
+                    if (context.isActionableItem) {
+                        applyStepActions(current, context)
                     }
+
+                    if (!context.isStopping) {
+                        queueNext(current, context)
+                    }
+
+                    canStop = true
                 }
             }
         }

--- a/src/main/kotlin/com/zepben/evolve/services/network/tracing/traversal/Traversal.kt
+++ b/src/main/kotlin/com/zepben/evolve/services/network/tracing/traversal/Traversal.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Zeppelin Bend Pty Ltd
+ * Copyright 2025 Zeppelin Bend Pty Ltd
  *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
@@ -348,11 +348,14 @@ abstract class Traversal<T, D : Traversal<T, D>> internal constructor(
 
         if (parent == null && queueType is BranchingQueueType && startItems.size > 1) {
             branchStartItems()
+            // Because we don't traverse anything at the top level parent, we need to pass canStopAtStart item
+            // to the child branch only in this case because they are actually start items.
+            traverseBranches(canStopOnStartItem)
         } else {
             traverse(canStopOnStartItem)
+            // Child branches should never stop at start items because a branch start item is not a whole trace start item.
+            traverseBranches(true)
         }
-
-        traverseBranches(canStopOnStartItem)
 
         running = false
     }

--- a/src/main/kotlin/com/zepben/evolve/services/network/tracing/traversal/Traversal.kt
+++ b/src/main/kotlin/com/zepben/evolve/services/network/tracing/traversal/Traversal.kt
@@ -149,7 +149,7 @@ abstract class Traversal<T, D : Traversal<T, D>> internal constructor(
      * @param condition The stop condition to add.
      * @return this traversal instance.
      */
-    fun addStopCondition(condition: StopCondition<T>): D {
+    open fun addStopCondition(condition: StopCondition<T>): D {
         stopConditions.add(condition)
         if (condition is StopConditionWithContextValue<T, *>) {
             computeNextContextFuns[condition.key] = condition
@@ -414,10 +414,10 @@ abstract class Traversal<T, D : Traversal<T, D>> internal constructor(
                 queue.next()?.let { current ->
                     val context = getStepContext(current)
                     if (canVisitItem(current, context)) {
-                        context.isActionableItem = canActionItem(current, context)
+                        context.isStopping = canStop && matchesAnyStopCondition(current, context)
 
+                        context.isActionableItem = canActionItem(current, context)
                         if (context.isActionableItem) {
-                            context.isStopping = canStop && matchesAnyStopCondition(current, context)
                             applyStepActions(current, context)
                         }
 

--- a/src/test/kotlin/com/zepben/evolve/services/network/testdata/CutsAndClampsNetwork.kt
+++ b/src/test/kotlin/com/zepben/evolve/services/network/testdata/CutsAndClampsNetwork.kt
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2025 Zeppelin Bend Pty Ltd
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+package com.zepben.evolve.services.network.testdata
+
+import com.zepben.evolve.cim.iec61970.base.core.ConductingEquipment
+import com.zepben.evolve.cim.iec61970.base.core.Terminal
+import com.zepben.evolve.cim.iec61970.base.wires.AcLineSegment
+import com.zepben.evolve.cim.iec61970.base.wires.Clamp
+import com.zepben.evolve.cim.iec61970.base.wires.Cut
+import com.zepben.evolve.services.network.NetworkService
+import com.zepben.evolve.testing.TestNetworkBuilder
+
+object CutsAndClampsNetwork {
+
+    fun mulitiCutAndClampNetwork(): TestNetworkBuilder {
+        //
+        //          2                     2
+        //          c3          2         c7          2
+        //          1           c5        1           c9
+        //          1 clamp1    1         1 clamp3    1
+        //          |           |         |           |
+        // 1 b0 21--*--*1 cut1 2*--*--c1--*--*1 cut2 2*--*--21 b2 2
+        //             |           |         |           |
+        //             1           1 clamp2  1           1 clamp4
+        //             c4          1         c8          1
+        //             2           c6        2           c10
+        //                         2                     2
+        //
+        val builder = TestNetworkBuilder()
+            .fromBreaker() // b0
+            .toAcls() // c1
+            .toBreaker() // b2
+            .fromAcls() // c3
+            .fromAcls() // c4
+            .fromAcls() // c5
+            .fromAcls() // c6
+            .fromAcls() // c7
+            .fromAcls() // c8
+            .fromAcls() // c9
+            .fromAcls() // c10
+
+        val network = builder.network
+
+        val segment: AcLineSegment = network["c1"]!!
+
+        val clamp1 = segment.withClamp(network, 1.0)
+        val cut1 = segment.withCut(network, 2.0)
+        val clamp2 = segment.withClamp(network, 3.0)
+        val clamp3 = segment.withClamp(network, 4.0)
+        val cut2 = segment.withCut(network, 5.0)
+        val clamp4 = segment.withClamp(network, 6.0)
+
+        network.connect(clamp1.t1, network.get<ConductingEquipment>("c3")!!.t1)
+        network.connect(cut1.t1, network.get<ConductingEquipment>("c4")!!.t1)
+        network.connect(cut1.t2, network.get<ConductingEquipment>("c5")!!.t1)
+        network.connect(clamp2.t1, network.get<ConductingEquipment>("c6")!!.t1)
+        network.connect(clamp3.t1, network.get<ConductingEquipment>("c7")!!.t1)
+        network.connect(cut2.t1, network.get<ConductingEquipment>("c8")!!.t1)
+        network.connect(cut2.t2, network.get<ConductingEquipment>("c9")!!.t1)
+        network.connect(clamp4.t1, network.get<ConductingEquipment>("c10")!!.t1)
+
+        return builder
+    }
+
+    fun AcLineSegment.withClamp(network: NetworkService, lengthFromTerminal1: Double?): Clamp {
+        val clamp = Clamp("clamp${numClamps() + 1}").apply {
+            addTerminal(Terminal("$mRID-t1"))
+            this.lengthFromTerminal1 = lengthFromTerminal1
+        }
+
+        addClamp(clamp)
+        network.add(clamp)
+
+        return clamp
+    }
+
+    fun AcLineSegment.withCut(network: NetworkService, lengthFromTerminal1: Double?): Cut {
+        val cut = Cut("cut${numCuts() + 1}").apply {
+            addTerminal(Terminal("$mRID-t1"))
+            addTerminal(Terminal("$mRID-t2"))
+            this.lengthFromTerminal1 = lengthFromTerminal1
+        }
+
+        addCut(cut)
+        network.add(cut)
+        return cut
+    }
+
+}

--- a/src/test/kotlin/com/zepben/evolve/services/network/tracing/feeder/SetDirectionTest.kt
+++ b/src/test/kotlin/com/zepben/evolve/services/network/tracing/feeder/SetDirectionTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Zeppelin Bend Pty Ltd
+ * Copyright 2025 Zeppelin Bend Pty Ltd
  *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
@@ -16,8 +16,10 @@ import com.zepben.evolve.cim.iec61970.base.core.PhaseCode
 import com.zepben.evolve.cim.iec61970.base.core.Substation
 import com.zepben.evolve.cim.iec61970.base.core.Terminal
 import com.zepben.evolve.cim.iec61970.base.wires.BusbarSection
+import com.zepben.evolve.cim.iec61970.base.wires.Cut
 import com.zepben.evolve.services.network.NetworkService
 import com.zepben.evolve.services.network.getT
+import com.zepben.evolve.services.network.testdata.CutsAndClampsNetwork
 import com.zepben.evolve.services.network.testdata.PhaseSwapLoopNetwork
 import com.zepben.evolve.services.network.tracing.feeder.DirectionValidator.validateDirection
 import com.zepben.evolve.services.network.tracing.feeder.FeederDirection.*
@@ -520,6 +522,224 @@ internal class SetDirectionTest {
         n.getT("b4", 2).validateDirection(BOTH, NetworkStateOperators.NORMAL)
         n.getT("c5", 1).validateDirection(BOTH, NetworkStateOperators.NORMAL)
         n.getT("c5", 2).validateDirection(BOTH, NetworkStateOperators.NORMAL)
+    }
+
+    @Test
+    internal fun setsDirectionOnAclsWithCutsAndClampsFromAclsEndTerminal() {
+        val n = CutsAndClampsNetwork.mulitiCutAndClampNetwork()
+            .addFeeder("b0", 2)
+            .network
+
+        n.get<Cut>("cut1")?.setNormallyOpen(false)
+        n.get<Cut>("cut2")?.setNormallyOpen(true)
+
+        doSetDirectionTrace(n.getT("b0", 2))
+
+        n.getT("b0", 2).validateDirection(DOWNSTREAM, NetworkStateOperators.NORMAL)
+        n.getT("c1", 1).validateDirection(UPSTREAM, NetworkStateOperators.NORMAL)
+        n.getT("clamp1", 1).validateDirection(DOWNSTREAM, NetworkStateOperators.NORMAL)
+        n.getT("c3", 1).validateDirection(UPSTREAM, NetworkStateOperators.NORMAL)
+        n.getT("c3", 2).validateDirection(DOWNSTREAM, NetworkStateOperators.NORMAL)
+        n.getT("c4", 1).validateDirection(UPSTREAM, NetworkStateOperators.NORMAL)
+        n.getT("c4", 2).validateDirection(DOWNSTREAM, NetworkStateOperators.NORMAL)
+        n.getT("cut1", 1).validateDirection(UPSTREAM, NetworkStateOperators.NORMAL)
+        n.getT("cut1", 2).validateDirection(DOWNSTREAM, NetworkStateOperators.NORMAL)
+        n.getT("c5", 1).validateDirection(UPSTREAM, NetworkStateOperators.NORMAL)
+        n.getT("c5", 2).validateDirection(DOWNSTREAM, NetworkStateOperators.NORMAL)
+        n.getT("clamp2", 1).validateDirection(DOWNSTREAM, NetworkStateOperators.NORMAL)
+        n.getT("clamp3", 1).validateDirection(DOWNSTREAM, NetworkStateOperators.NORMAL)
+        n.getT("c8", 1).validateDirection(UPSTREAM, NetworkStateOperators.NORMAL)
+        n.getT("c8", 2).validateDirection(DOWNSTREAM, NetworkStateOperators.NORMAL)
+        n.getT("cut2", 1).validateDirection(UPSTREAM, NetworkStateOperators.NORMAL)
+        n.getT("cut2", 2).validateDirection(NONE, NetworkStateOperators.NORMAL)
+    }
+
+    @Test
+    internal fun setsDirectionOnAclsWithCutsAndClampsFedFromClamp() {
+        val n = CutsAndClampsNetwork.mulitiCutAndClampNetwork()
+            .addFeeder("c6", 1)
+            .network
+
+        n.get<Cut>("cut1")?.setNormallyOpen(false)
+        n.get<Cut>("cut2")?.setNormallyOpen(true)
+
+        doSetDirectionTrace(n.getT("c6", 1))
+
+        n.getT("c6", 1).validateDirection(DOWNSTREAM, NetworkStateOperators.NORMAL)
+        n.getT("c6", 2).validateDirection(NONE, NetworkStateOperators.NORMAL)
+        n.getT("clamp2", 1).validateDirection(UPSTREAM, NetworkStateOperators.NORMAL)
+        n.getT("clamp3", 1).validateDirection(DOWNSTREAM, NetworkStateOperators.NORMAL)
+        n.getT("c7", 1).validateDirection(UPSTREAM, NetworkStateOperators.NORMAL)
+        n.getT("c7", 2).validateDirection(DOWNSTREAM, NetworkStateOperators.NORMAL)
+        n.getT("c8", 1).validateDirection(UPSTREAM, NetworkStateOperators.NORMAL)
+        n.getT("c8", 2).validateDirection(DOWNSTREAM, NetworkStateOperators.NORMAL)
+        n.getT("cut2", 1).validateDirection(UPSTREAM, NetworkStateOperators.NORMAL)
+        n.getT("cut2", 2).validateDirection(NONE, NetworkStateOperators.NORMAL)
+        n.getT("c5", 1).validateDirection(UPSTREAM, NetworkStateOperators.NORMAL)
+        n.getT("c5", 2).validateDirection(DOWNSTREAM, NetworkStateOperators.NORMAL)
+        n.getT("cut1", 2).validateDirection(UPSTREAM, NetworkStateOperators.NORMAL)
+        n.getT("cut1", 1).validateDirection(DOWNSTREAM, NetworkStateOperators.NORMAL)
+        n.getT("c4", 1).validateDirection(UPSTREAM, NetworkStateOperators.NORMAL)
+        n.getT("c4", 2).validateDirection(DOWNSTREAM, NetworkStateOperators.NORMAL)
+        n.getT("clamp1", 1).validateDirection(DOWNSTREAM, NetworkStateOperators.NORMAL)
+        n.getT("c3", 1).validateDirection(UPSTREAM, NetworkStateOperators.NORMAL)
+        n.getT("c3", 2).validateDirection(DOWNSTREAM, NetworkStateOperators.NORMAL)
+        n.getT("c1", 1).validateDirection(DOWNSTREAM, NetworkStateOperators.NORMAL)
+        n.getT("b0", 2).validateDirection(UPSTREAM, NetworkStateOperators.NORMAL)
+        n.getT("b0", 1).validateDirection(DOWNSTREAM, NetworkStateOperators.NORMAL)
+    }
+
+    @Test
+    internal fun setsDirectionOnAclsWithCutsAndClampsFedFromCut() {
+        val n = CutsAndClampsNetwork.mulitiCutAndClampNetwork()
+            .addFeeder("c5", 1)
+            .network
+
+        n.get<Cut>("cut1")?.setNormallyOpen(false)
+        n.get<Cut>("cut2")?.setNormallyOpen(true)
+
+        doSetDirectionTrace(n.getT("c5", 1))
+
+        n.getT("c5", 1).validateDirection(DOWNSTREAM, NetworkStateOperators.NORMAL)
+        n.getT("c5", 2).validateDirection(NONE, NetworkStateOperators.NORMAL)
+        n.getT("cut1", 2).validateDirection(UPSTREAM, NetworkStateOperators.NORMAL)
+        n.getT("cut1", 1).validateDirection(DOWNSTREAM, NetworkStateOperators.NORMAL)
+        n.getT("c4", 1).validateDirection(UPSTREAM, NetworkStateOperators.NORMAL)
+        n.getT("c4", 2).validateDirection(DOWNSTREAM, NetworkStateOperators.NORMAL)
+        n.getT("clamp1", 1).validateDirection(DOWNSTREAM, NetworkStateOperators.NORMAL)
+        n.getT("c3", 1).validateDirection(UPSTREAM, NetworkStateOperators.NORMAL)
+        n.getT("c3", 2).validateDirection(DOWNSTREAM, NetworkStateOperators.NORMAL)
+        n.getT("c1", 1).validateDirection(DOWNSTREAM, NetworkStateOperators.NORMAL)
+        n.getT("b0", 2).validateDirection(UPSTREAM, NetworkStateOperators.NORMAL)
+        n.getT("b0", 1).validateDirection(DOWNSTREAM, NetworkStateOperators.NORMAL)
+        n.getT("clamp2", 1).validateDirection(DOWNSTREAM, NetworkStateOperators.NORMAL)
+        n.getT("c6", 1).validateDirection(UPSTREAM, NetworkStateOperators.NORMAL)
+        n.getT("c6", 2).validateDirection(DOWNSTREAM, NetworkStateOperators.NORMAL)
+        n.getT("clamp3", 1).validateDirection(DOWNSTREAM, NetworkStateOperators.NORMAL)
+        n.getT("c7", 1).validateDirection(UPSTREAM, NetworkStateOperators.NORMAL)
+        n.getT("c7", 2).validateDirection(DOWNSTREAM, NetworkStateOperators.NORMAL)
+        n.getT("c8", 1).validateDirection(UPSTREAM, NetworkStateOperators.NORMAL)
+        n.getT("c8", 2).validateDirection(DOWNSTREAM, NetworkStateOperators.NORMAL)
+        n.getT("cut2", 1).validateDirection(UPSTREAM, NetworkStateOperators.NORMAL)
+        n.getT("cut2", 2).validateDirection(NONE, NetworkStateOperators.NORMAL)
+    }
+
+    @Test
+    internal fun setsDirectionOnAclsWithCutsAndClampsFedFromBothAclsEnds() {
+        val n = CutsAndClampsNetwork.mulitiCutAndClampNetwork()
+            .addFeeder("b0", 2)
+            .addFeeder("b2", 1)
+            .network
+
+        n.get<Cut>("cut1")?.setNormallyOpen(false)
+        n.get<Cut>("cut2")?.setNormallyOpen(false)
+
+        doSetDirectionTrace(n.getT("b0", 2))
+        doSetDirectionTrace(n.getT("b2", 1))
+
+        n.getT("b0", 2).validateDirection(BOTH, NetworkStateOperators.NORMAL)
+        n.getT("b0", 1).validateDirection(NONE, NetworkStateOperators.NORMAL)
+        n.getT("c1", 1).validateDirection(BOTH, NetworkStateOperators.NORMAL)
+        n.getT("clamp1", 1).validateDirection(DOWNSTREAM, NetworkStateOperators.NORMAL)
+        n.getT("c3", 1).validateDirection(UPSTREAM, NetworkStateOperators.NORMAL)
+        n.getT("c3", 2).validateDirection(DOWNSTREAM, NetworkStateOperators.NORMAL)
+        n.getT("c4", 1).validateDirection(UPSTREAM, NetworkStateOperators.NORMAL)
+        n.getT("c4", 2).validateDirection(DOWNSTREAM, NetworkStateOperators.NORMAL)
+        n.getT("cut1", 2).validateDirection(BOTH, NetworkStateOperators.NORMAL)
+        n.getT("cut1", 1).validateDirection(BOTH, NetworkStateOperators.NORMAL)
+        n.getT("c5", 1).validateDirection(UPSTREAM, NetworkStateOperators.NORMAL)
+        n.getT("c5", 2).validateDirection(DOWNSTREAM, NetworkStateOperators.NORMAL)
+        n.getT("clamp2", 1).validateDirection(DOWNSTREAM, NetworkStateOperators.NORMAL)
+        n.getT("c6", 1).validateDirection(UPSTREAM, NetworkStateOperators.NORMAL)
+        n.getT("c6", 2).validateDirection(DOWNSTREAM, NetworkStateOperators.NORMAL)
+        n.getT("clamp3", 1).validateDirection(DOWNSTREAM, NetworkStateOperators.NORMAL)
+        n.getT("c7", 1).validateDirection(UPSTREAM, NetworkStateOperators.NORMAL)
+        n.getT("c7", 2).validateDirection(DOWNSTREAM, NetworkStateOperators.NORMAL)
+        n.getT("c8", 1).validateDirection(UPSTREAM, NetworkStateOperators.NORMAL)
+        n.getT("c8", 2).validateDirection(DOWNSTREAM, NetworkStateOperators.NORMAL)
+        n.getT("cut2", 1).validateDirection(BOTH, NetworkStateOperators.NORMAL)
+        n.getT("cut2", 2).validateDirection(BOTH, NetworkStateOperators.NORMAL)
+        n.getT("c9", 1).validateDirection(UPSTREAM, NetworkStateOperators.NORMAL)
+        n.getT("c9", 2).validateDirection(DOWNSTREAM, NetworkStateOperators.NORMAL)
+        n.getT("clamp4", 1).validateDirection(DOWNSTREAM, NetworkStateOperators.NORMAL)
+        n.getT("c10", 1).validateDirection(UPSTREAM, NetworkStateOperators.NORMAL)
+        n.getT("c10", 2).validateDirection(DOWNSTREAM, NetworkStateOperators.NORMAL)
+        n.getT("b2", 1).validateDirection(BOTH, NetworkStateOperators.NORMAL)
+        n.getT("b2", 2).validateDirection(NONE, NetworkStateOperators.NORMAL)
+    }
+
+    @Test
+    internal fun setsDirectionOnAclsWithCutsAndClampsFedFromAclsEndAndClamp() {
+        val n = CutsAndClampsNetwork.mulitiCutAndClampNetwork()
+            .addFeeder("b0", 2)
+            .addFeeder("c6", 1)
+            .network
+
+        n.get<Cut>("cut1")?.setNormallyOpen(false)
+        n.get<Cut>("cut2")?.setNormallyOpen(true)
+
+        doSetDirectionTrace(n.getT("b0", 2))
+        doSetDirectionTrace(n.getT("c6", 1))
+
+        n.getT("b0", 2).validateDirection(BOTH, NetworkStateOperators.NORMAL)
+        n.getT("b0", 1).validateDirection(NONE, NetworkStateOperators.NORMAL)
+        n.getT("c1", 1).validateDirection(BOTH, NetworkStateOperators.NORMAL)
+        n.getT("clamp1", 1).validateDirection(DOWNSTREAM, NetworkStateOperators.NORMAL)
+        n.getT("c3", 1).validateDirection(UPSTREAM, NetworkStateOperators.NORMAL)
+        n.getT("c3", 2).validateDirection(DOWNSTREAM, NetworkStateOperators.NORMAL)
+        n.getT("c4", 1).validateDirection(UPSTREAM, NetworkStateOperators.NORMAL)
+        n.getT("c4", 2).validateDirection(DOWNSTREAM, NetworkStateOperators.NORMAL)
+        n.getT("cut1", 2).validateDirection(BOTH, NetworkStateOperators.NORMAL)
+        n.getT("cut1", 1).validateDirection(BOTH, NetworkStateOperators.NORMAL)
+        n.getT("c5", 1).validateDirection(UPSTREAM, NetworkStateOperators.NORMAL)
+        n.getT("c5", 2).validateDirection(DOWNSTREAM, NetworkStateOperators.NORMAL)
+        n.getT("clamp2", 1).validateDirection(BOTH, NetworkStateOperators.NORMAL)
+        n.getT("c6", 1).validateDirection(BOTH, NetworkStateOperators.NORMAL)
+        n.getT("c6", 2).validateDirection(NONE, NetworkStateOperators.NORMAL)
+        n.getT("clamp3", 1).validateDirection(DOWNSTREAM, NetworkStateOperators.NORMAL)
+        n.getT("c7", 1).validateDirection(UPSTREAM, NetworkStateOperators.NORMAL)
+        n.getT("c7", 2).validateDirection(DOWNSTREAM, NetworkStateOperators.NORMAL)
+        n.getT("c8", 1).validateDirection(UPSTREAM, NetworkStateOperators.NORMAL)
+        n.getT("c8", 2).validateDirection(DOWNSTREAM, NetworkStateOperators.NORMAL)
+        n.getT("cut2", 1).validateDirection(UPSTREAM, NetworkStateOperators.NORMAL)
+        n.getT("cut2", 2).validateDirection(NONE, NetworkStateOperators.NORMAL)
+    }
+
+    @Test
+    internal fun setsDirectionOnAclsWithCutsAndClampsFedFromAclsClampAndCut() {
+        val n = CutsAndClampsNetwork.mulitiCutAndClampNetwork()
+            .addFeeder("c3", 1)
+            .addFeeder("c5", 1)
+            .network
+
+        n.get<Cut>("cut1")?.setNormallyOpen(false)
+        n.get<Cut>("cut2")?.setNormallyOpen(true)
+
+        doSetDirectionTrace(n.getT("c3", 1))
+        doSetDirectionTrace(n.getT("c5", 1))
+
+        n.getT("b0", 2).validateDirection(UPSTREAM, NetworkStateOperators.NORMAL)
+        n.getT("b0", 1).validateDirection(DOWNSTREAM, NetworkStateOperators.NORMAL)
+        n.getT("c1", 1).validateDirection(DOWNSTREAM, NetworkStateOperators.NORMAL)
+        n.getT("clamp1", 1).validateDirection(BOTH, NetworkStateOperators.NORMAL)
+        n.getT("c3", 1).validateDirection(BOTH, NetworkStateOperators.NORMAL)
+        n.getT("c3", 2).validateDirection(NONE, NetworkStateOperators.NORMAL)
+        n.getT("c4", 1).validateDirection(UPSTREAM, NetworkStateOperators.NORMAL)
+        n.getT("c4", 2).validateDirection(DOWNSTREAM, NetworkStateOperators.NORMAL)
+        n.getT("cut1", 2).validateDirection(BOTH, NetworkStateOperators.NORMAL)
+        n.getT("cut1", 1).validateDirection(BOTH, NetworkStateOperators.NORMAL)
+        n.getT("c5", 1).validateDirection(BOTH, NetworkStateOperators.NORMAL)
+        n.getT("c5", 2).validateDirection(NONE, NetworkStateOperators.NORMAL)
+        n.getT("clamp2", 1).validateDirection(DOWNSTREAM, NetworkStateOperators.NORMAL)
+        n.getT("c6", 1).validateDirection(UPSTREAM, NetworkStateOperators.NORMAL)
+        n.getT("c6", 2).validateDirection(DOWNSTREAM, NetworkStateOperators.NORMAL)
+        n.getT("clamp3", 1).validateDirection(DOWNSTREAM, NetworkStateOperators.NORMAL)
+        n.getT("c7", 1).validateDirection(UPSTREAM, NetworkStateOperators.NORMAL)
+        n.getT("c7", 2).validateDirection(DOWNSTREAM, NetworkStateOperators.NORMAL)
+        n.getT("c8", 1).validateDirection(UPSTREAM, NetworkStateOperators.NORMAL)
+        n.getT("c8", 2).validateDirection(DOWNSTREAM, NetworkStateOperators.NORMAL)
+        n.getT("cut2", 1).validateDirection(UPSTREAM, NetworkStateOperators.NORMAL)
+        n.getT("cut2", 2).validateDirection(NONE, NetworkStateOperators.NORMAL)
     }
 
     private fun doSetDirectionTrace(terminal: Terminal) {

--- a/src/test/kotlin/com/zepben/evolve/services/network/tracing/networktrace/NetworkTraceQueueNextTest.kt
+++ b/src/test/kotlin/com/zepben/evolve/services/network/tracing/networktrace/NetworkTraceQueueNextTest.kt
@@ -8,6 +8,7 @@
 
 package com.zepben.evolve.services.network.tracing.networktrace
 
+import com.zepben.evolve.services.network.tracing.networktrace.operators.NetworkStateOperators
 import com.zepben.evolve.services.network.tracing.traversal.StepContext
 import io.mockk.every
 import io.mockk.mockk
@@ -18,14 +19,14 @@ import org.junit.jupiter.api.Test
 
 class NetworkTraceQueueNextTest {
 
-    private val pathProvider = mockk<NetworkTraceStepPathProvider>()
+    private val stateOperators = mockk<NetworkStateOperators>()
     private val dataComputer = mockk<ComputeData<String>>()
     private val queuer = TestQueuer<String>()
     private val branchingQueuer = TestQueuer<String>()
 
     @Test
     fun `queues next basic`() {
-        val queueNext = NetworkTraceQueueNext.Basic(pathProvider, dataComputer)
+        val queueNext = NetworkTraceQueueNext.Basic(stateOperators, dataComputer)
 
         val seedPath = mockk<NetworkTraceStep.Path>()
         val seedStep = mockk<NetworkTraceStep<String>> {
@@ -37,7 +38,7 @@ class NetworkTraceQueueNextTest {
 
         val nextPath1 = mockk<NetworkTraceStep.Path> { every { tracedExternally } returns true }
         val nextPath2 = mockk<NetworkTraceStep.Path> { every { tracedExternally } returns false }
-        every { pathProvider.nextPaths(seedPath) } returns sequenceOf(nextPath1, nextPath2)
+        every { stateOperators.nextPaths(seedPath) } returns sequenceOf(nextPath1, nextPath2)
 
         every { dataComputer.computeNext(seedStep, seedContext, nextPath1) } returns "Foo"
         every { dataComputer.computeNext(seedStep, seedContext, nextPath2) } returns "Bar"
@@ -61,7 +62,7 @@ class NetworkTraceQueueNextTest {
 
     @Test
     fun `calls branching queuer when queuing more than 1 path on branching queue next`() {
-        val queueNext = NetworkTraceQueueNext.Branching(pathProvider, dataComputer)
+        val queueNext = NetworkTraceQueueNext.Branching(stateOperators, dataComputer)
 
         val seedPath = mockk<NetworkTraceStep.Path>()
         val seedStep = mockk<NetworkTraceStep<String>> {
@@ -73,7 +74,7 @@ class NetworkTraceQueueNextTest {
 
         val nextPath1 = mockk<NetworkTraceStep.Path> { every { tracedExternally } returns true }
         val nextPath2 = mockk<NetworkTraceStep.Path> { every { tracedExternally } returns false }
-        every { pathProvider.nextPaths(seedPath) } returns sequenceOf(nextPath1, nextPath2)
+        every { stateOperators.nextPaths(seedPath) } returns sequenceOf(nextPath1, nextPath2)
 
         every { dataComputer.computeNext(seedStep, seedContext, nextPath1) } returns "Foo"
         every { dataComputer.computeNext(seedStep, seedContext, nextPath2) } returns "Bar"
@@ -98,7 +99,7 @@ class NetworkTraceQueueNextTest {
 
     @Test
     fun `calls straight queuer when queuing a single path on branching queue next`() {
-        val queueNext = NetworkTraceQueueNext.Branching(pathProvider, dataComputer)
+        val queueNext = NetworkTraceQueueNext.Branching(stateOperators, dataComputer)
 
         val seedPath = mockk<NetworkTraceStep.Path>()
         val seedStep = mockk<NetworkTraceStep<String>> {
@@ -109,7 +110,7 @@ class NetworkTraceQueueNextTest {
         val seedContext = mockk<StepContext>()
 
         val nextPath1 = mockk<NetworkTraceStep.Path> { every { tracedExternally } returns true }
-        every { pathProvider.nextPaths(seedPath) } returns sequenceOf(nextPath1)
+        every { stateOperators.nextPaths(seedPath) } returns sequenceOf(nextPath1)
 
         every { dataComputer.computeNext(seedStep, seedContext, nextPath1) } returns "Foo"
 

--- a/src/test/kotlin/com/zepben/evolve/services/network/tracing/networktrace/NetworkTraceStepPathProviderTest.kt
+++ b/src/test/kotlin/com/zepben/evolve/services/network/tracing/networktrace/NetworkTraceStepPathProviderTest.kt
@@ -373,6 +373,30 @@ class NetworkTraceStepPathProviderTest {
     }
 
     @Test
+    fun `starting on clamp terminal flagged as traversed segment only steps externally`() {
+        val network = aclsWithClampsAndCutsNetwork()
+
+        val c3: AcLineSegment = network["c3"]!!
+        val clamp1: Clamp = network["clamp1"]!!
+
+        val nextPaths = pathProvider.nextPaths(clamp1.t1..<clamp1.t1).toList()
+        assertThat(nextPaths, containsInAnyOrder(clamp1.t1..c3.t1))
+    }
+
+    @Test
+    fun `starting on clamp terminal that flagged as not traversed segment steps externally and traverses`() {
+        val network = aclsWithClampsAndCutsNetwork()
+
+        val c3: AcLineSegment = network["c3"]!!
+        val clamp1: Clamp = network["clamp1"]!!
+        val cut1: Cut = network["cut1"]!!
+        val c1: AcLineSegment = network["c1"]!!
+
+        val nextPaths = pathProvider.nextPaths(clamp1.t1..clamp1.t1).toList()
+        assertThat(nextPaths, containsInAnyOrder(clamp1.t1..c3.t1, clamp1.t1..<c1.t1, clamp1.t1..<cut1.t1))
+    }
+
+    @Test
     fun `traverse with cut with unknown length from t1 does not return clamp with known length from t1`() {
         //
         //  (Cut with null length is treated as at 0.0)

--- a/src/test/kotlin/com/zepben/evolve/services/network/tracing/networktrace/NetworkTraceStepPathProviderTest.kt
+++ b/src/test/kotlin/com/zepben/evolve/services/network/tracing/networktrace/NetworkTraceStepPathProviderTest.kt
@@ -16,6 +16,9 @@ import com.zepben.evolve.cim.iec61970.base.wires.Breaker
 import com.zepben.evolve.cim.iec61970.base.wires.Clamp
 import com.zepben.evolve.cim.iec61970.base.wires.Cut
 import com.zepben.evolve.services.network.NetworkService
+import com.zepben.evolve.services.network.testdata.CutsAndClampsNetwork
+import com.zepben.evolve.services.network.testdata.CutsAndClampsNetwork.withClamp
+import com.zepben.evolve.services.network.testdata.CutsAndClampsNetwork.withCut
 import com.zepben.evolve.services.network.tracing.connectivity.NominalPhasePath
 import com.zepben.evolve.services.network.tracing.networktrace.operators.NetworkStateOperators
 import com.zepben.evolve.testing.TestNetworkBuilder
@@ -190,7 +193,7 @@ class NetworkTraceStepPathProviderTest {
 
     @Test
     fun `non traverse step to segment t1 traverses towards t2 stopping at cut`() {
-        val network = aclsWithClampsAndCutsNetwork()
+        val network = CutsAndClampsNetwork.mulitiCutAndClampNetwork().network
 
         val b0: Breaker = network["b0"]!!
         val segment: AcLineSegment = network["c1"]!!
@@ -204,7 +207,7 @@ class NetworkTraceStepPathProviderTest {
 
     @Test
     fun `non traverse step to segment t2 traverses towards t1 stopping at cut`() {
-        val network = aclsWithClampsAndCutsNetwork()
+        val network = CutsAndClampsNetwork.mulitiCutAndClampNetwork().network
 
         val b2: Breaker = network["b2"]!!
         val segment: AcLineSegment = network["c1"]!!
@@ -218,7 +221,7 @@ class NetworkTraceStepPathProviderTest {
 
     @Test
     fun `traverse step to cut t1 steps externally and across cut`() {
-        val network = aclsWithClampsAndCutsNetwork()
+        val network = CutsAndClampsNetwork.mulitiCutAndClampNetwork().network
 
         val segment: AcLineSegment = network["c1"]!!
         val cut1: Cut = network["cut1"]!!
@@ -231,7 +234,7 @@ class NetworkTraceStepPathProviderTest {
 
     @Test
     fun `traverse step to cut t2 steps externally and across cut`() {
-        val network = aclsWithClampsAndCutsNetwork()
+        val network = CutsAndClampsNetwork.mulitiCutAndClampNetwork().network
 
         val segment: AcLineSegment = network["c1"]!!
         val cut2: Cut = network["cut2"]!!
@@ -244,7 +247,7 @@ class NetworkTraceStepPathProviderTest {
 
     @Test
     fun `non traverse step to cut t1 traverses segment towards t1 and internally through cut to t2`() {
-        val network = aclsWithClampsAndCutsNetwork()
+        val network = CutsAndClampsNetwork.mulitiCutAndClampNetwork().network
 
         val segment: AcLineSegment = network["c1"]!!
         val clamp1: Clamp = network["clamp1"]!!
@@ -258,7 +261,7 @@ class NetworkTraceStepPathProviderTest {
 
     @Test
     fun `non traverse step to cut t2 traverses segment towards t2 and internally through cut to t1`() {
-        val network = aclsWithClampsAndCutsNetwork()
+        val network = CutsAndClampsNetwork.mulitiCutAndClampNetwork().network
 
         val segment: AcLineSegment = network["c1"]!!
         val clamp4: Clamp = network["clamp4"]!!
@@ -272,7 +275,7 @@ class NetworkTraceStepPathProviderTest {
 
     @Test
     fun `non traverse step to clamp traverses segment in both directions`() {
-        val network = aclsWithClampsAndCutsNetwork()
+        val network = CutsAndClampsNetwork.mulitiCutAndClampNetwork().network
 
         val segment: AcLineSegment = network["c1"]!!
         val clamp1: Clamp = network["clamp1"]!!
@@ -286,7 +289,7 @@ class NetworkTraceStepPathProviderTest {
 
     @Test
     fun `traverse step to clamp traces externally and does not traverse back along segment`() {
-        val network = aclsWithClampsAndCutsNetwork()
+        val network = CutsAndClampsNetwork.mulitiCutAndClampNetwork().network
 
         val segment: AcLineSegment = network["c1"]!!
         val clamp1: Clamp = network["clamp1"]!!
@@ -299,7 +302,7 @@ class NetworkTraceStepPathProviderTest {
 
     @Test
     fun `non traverse step to clamp between cuts traverses segment both ways stopping at cuts`() {
-        val network = aclsWithClampsAndCutsNetwork()
+        val network = CutsAndClampsNetwork.mulitiCutAndClampNetwork().network
 
         val c6: AcLineSegment = network["c6"]!!
         val clamp2: Clamp = network["clamp2"]!!
@@ -314,7 +317,7 @@ class NetworkTraceStepPathProviderTest {
 
     @Test
     fun `non traverse external step to cut t2 between cuts traverses segment towards t2 stopping at next cut and steps internally to cut t1`() {
-        val network = aclsWithClampsAndCutsNetwork()
+        val network = CutsAndClampsNetwork.mulitiCutAndClampNetwork().network
 
         val c5: AcLineSegment = network["c5"]!!
         val clamp2: Clamp = network["clamp2"]!!
@@ -329,7 +332,7 @@ class NetworkTraceStepPathProviderTest {
 
     @Test
     fun `non traverse external step to cut t1 between cuts traverses segment towards t1 stopping at next cut and steps internally to cut t2`() {
-        val network = aclsWithClampsAndCutsNetwork()
+        val network = CutsAndClampsNetwork.mulitiCutAndClampNetwork().network
 
         val c8: AcLineSegment = network["c8"]!!
         val clamp2: Clamp = network["clamp2"]!!
@@ -344,7 +347,7 @@ class NetworkTraceStepPathProviderTest {
 
     @Test
     fun `internal step to cut t2 between cuts steps externally and traverses segment towards t2 stopping at next cut`() {
-        val network = aclsWithClampsAndCutsNetwork()
+        val network = CutsAndClampsNetwork.mulitiCutAndClampNetwork().network
 
         val c5: AcLineSegment = network["c5"]!!
         val clamp2: Clamp = network["clamp2"]!!
@@ -359,7 +362,7 @@ class NetworkTraceStepPathProviderTest {
 
     @Test
     fun `internal step to cut t1 between cuts steps externally and traverses segment towards t1 stopping at next cut`() {
-        val network = aclsWithClampsAndCutsNetwork()
+        val network = CutsAndClampsNetwork.mulitiCutAndClampNetwork().network
 
         val c8: AcLineSegment = network["c8"]!!
         val clamp2: Clamp = network["clamp2"]!!
@@ -374,7 +377,7 @@ class NetworkTraceStepPathProviderTest {
 
     @Test
     fun `starting on clamp terminal flagged as traversed segment only steps externally`() {
-        val network = aclsWithClampsAndCutsNetwork()
+        val network = CutsAndClampsNetwork.mulitiCutAndClampNetwork().network
 
         val c3: AcLineSegment = network["c3"]!!
         val clamp1: Clamp = network["clamp1"]!!
@@ -385,7 +388,7 @@ class NetworkTraceStepPathProviderTest {
 
     @Test
     fun `starting on clamp terminal that flagged as not traversed segment steps externally and traverses`() {
-        val network = aclsWithClampsAndCutsNetwork()
+        val network = CutsAndClampsNetwork.mulitiCutAndClampNetwork().network
 
         val c3: AcLineSegment = network["c3"]!!
         val clamp1: Clamp = network["clamp1"]!!
@@ -766,55 +769,6 @@ class NetworkTraceStepPathProviderTest {
         return network
     }
 
-    private fun aclsWithClampsAndCutsNetwork(): NetworkService {
-        //
-        //          2                     2
-        //          c3          2         c7          2
-        //          1           c5        1           c9
-        //          1 clamp1    1         1 clamp3    1
-        //          |           |         |           |
-        // 1 b0 21--*--*1 cut1 2*--*--c1--*--*1 cut2 2*--*--21 b2 2
-        //             |           |         |           |
-        //             1           1 clamp2  1           1 clamp4
-        //             c4          1         c8          1
-        //             2           c6        2           c10
-        //                         2                     2
-        //
-        val network = TestNetworkBuilder()
-            .fromBreaker() // b0
-            .toAcls() // c1
-            .toBreaker() // b2
-            .fromAcls() // c3
-            .fromAcls() // c4
-            .fromAcls() // c5
-            .fromAcls() // c6
-            .fromAcls() // c7
-            .fromAcls() // c8
-            .fromAcls() // c9
-            .fromAcls() // c10
-            .network
-
-        val segment: AcLineSegment = network["c1"]!!
-
-        val clamp1 = segment.withClamp(network, 1.0)
-        val cut1 = segment.withCut(network, 2.0)
-        val clamp2 = segment.withClamp(network, 3.0)
-        val clamp3 = segment.withClamp(network, 4.0)
-        val cut2 = segment.withCut(network, 5.0)
-        val clamp4 = segment.withClamp(network, 6.0)
-
-        network.connect(clamp1.t1, network.get<ConductingEquipment>("c3")!!.t1)
-        network.connect(cut1.t1, network.get<ConductingEquipment>("c4")!!.t1)
-        network.connect(cut1.t2, network.get<ConductingEquipment>("c5")!!.t1)
-        network.connect(clamp2.t1, network.get<ConductingEquipment>("c6")!!.t1)
-        network.connect(clamp3.t1, network.get<ConductingEquipment>("c7")!!.t1)
-        network.connect(cut2.t1, network.get<ConductingEquipment>("c8")!!.t1)
-        network.connect(cut2.t2, network.get<ConductingEquipment>("c9")!!.t1)
-        network.connect(clamp4.t1, network.get<ConductingEquipment>("c10")!!.t1)
-
-        return network
-    }
-
     private fun aclsWithClampsAndCutsAtSamePositionNetwork(): NetworkService {
         // Drawing this is very messy, so it will be described in writing:
         // The network has 2 Breakers (b0, b2) with an AcLineSegment (c1) between them ( 1 b0 21--c1--21 b2 1 )
@@ -884,30 +838,6 @@ class NetworkTraceStepPathProviderTest {
         network.connect(cut6.t2, network.get<ConductingEquipment>("c-cut6t2")!!.t1)
 
         return network
-    }
-
-    private fun AcLineSegment.withClamp(network: NetworkService, lengthFromTerminal1: Double?): Clamp {
-        val clamp = Clamp("clamp${numClamps() + 1}").apply {
-            addTerminal(Terminal("$mRID-t1"))
-            this.lengthFromTerminal1 = lengthFromTerminal1
-        }
-
-        addClamp(clamp)
-        network.add(clamp)
-
-        return clamp
-    }
-
-    private fun AcLineSegment.withCut(network: NetworkService, lengthFromTerminal1: Double?): Cut {
-        val cut = Cut("cut${numCuts() + 1}").apply {
-            addTerminal(Terminal("$mRID-t1"))
-            addTerminal(Terminal("$mRID-t2"))
-            this.lengthFromTerminal1 = lengthFromTerminal1
-        }
-
-        addCut(cut)
-        network.add(cut)
-        return cut
     }
 
     /**

--- a/src/test/kotlin/com/zepben/evolve/services/network/tracing/networktrace/NetworkTraceTest.kt
+++ b/src/test/kotlin/com/zepben/evolve/services/network/tracing/networktrace/NetworkTraceTest.kt
@@ -13,7 +13,9 @@ import com.zepben.evolve.cim.iec61970.base.core.Terminal
 import com.zepben.evolve.cim.iec61970.base.wires.AcLineSegment
 import com.zepben.evolve.cim.iec61970.base.wires.Clamp
 import com.zepben.evolve.cim.iec61970.base.wires.Cut
+import com.zepben.evolve.cim.iec61970.base.wires.Junction
 import com.zepben.evolve.services.network.getT
+import com.zepben.evolve.services.network.tracing.traversal.TraversalQueue
 import com.zepben.evolve.testing.TestNetworkBuilder
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.containsInAnyOrder
@@ -115,6 +117,43 @@ class NetworkTraceTest {
             .run(ns.get<ConductingEquipment>("c0")!!)
 
         assertThat(steppedOn, containsInAnyOrder("c0", "c1", "j2", "c4"))
+    }
+
+    @Test
+    internal fun `breadth first queue supports multiple start items`() {
+        //
+        // 1--c1--21--c2--2
+        // 2              1
+        // j0             j3
+        // 1              2
+        // 2--c5--12--c4--1
+        //
+        val ns = TestNetworkBuilder()
+            .fromJunction() // j0
+            .toAcls() // c1
+            .toAcls() // c2
+            .toJunction() // j3
+            .toAcls() // c4
+            .toAcls() // c5
+            .connect("c5", "j0", 2, 1)
+            .network
+
+        val steps = mutableSetOf<NetworkTraceStep<Unit>>()
+        Tracing.networkTrace(queue = TraversalQueue.breadthFirst())
+            .addStepAction { step, _ -> steps.add(step) }
+            .run(ns.get<Junction>("j0")!!)
+
+        assertThat(
+            steps.map { it.numEquipmentSteps to it.path.toEquipment.mRID }.toSet(),
+            containsInAnyOrder(
+                0 to "j0",
+                1 to "c1",
+                1 to "c5",
+                2 to "c2",
+                2 to "c4",
+                3 to "j3"
+            )
+        )
     }
 
     @Test

--- a/src/test/kotlin/com/zepben/evolve/services/network/tracing/networktrace/conditions/ConditionsTest.kt
+++ b/src/test/kotlin/com/zepben/evolve/services/network/tracing/networktrace/conditions/ConditionsTest.kt
@@ -8,7 +8,6 @@
 
 package com.zepben.evolve.services.network.tracing.networktrace.conditions
 
-import com.zepben.evolve.cim.iec61970.base.core.Terminal
 import com.zepben.evolve.cim.iec61970.base.wires.PowerTransformer
 import com.zepben.evolve.cim.iec61970.base.wires.SinglePhaseKind
 import com.zepben.evolve.cim.iec61970.base.wires.Switch
@@ -17,7 +16,6 @@ import com.zepben.evolve.services.network.tracing.networktrace.conditions.Condit
 import com.zepben.evolve.services.network.tracing.networktrace.conditions.Conditions.stopAtOpen
 import com.zepben.evolve.services.network.tracing.networktrace.conditions.Conditions.upstream
 import com.zepben.evolve.services.network.tracing.networktrace.conditions.Conditions.withDirection
-import com.zepben.evolve.services.network.tracing.networktrace.operators.FeederDirectionStateOperations
 import com.zepben.evolve.services.network.tracing.networktrace.operators.NetworkStateOperators
 import com.zepben.evolve.services.network.tracing.networktrace.operators.OpenStateOperators
 import org.hamcrest.MatcherAssert.assertThat
@@ -28,62 +26,32 @@ import org.junit.jupiter.api.Test
 class ConditionsTest {
 
     @Test
-    fun withDirection() {
-        val getDirection = Terminal::normalFeederDirection
-        val condition = Conditions.withDirection<Unit>(FeederDirection.BOTH, getDirection)
+    fun stateOperatorsWithDirection() {
+        val stateOperators = NetworkStateOperators.NORMAL
+        val condition = stateOperators.withDirection<Unit>(FeederDirection.BOTH)
         assertThat(condition, instanceOf(DirectionCondition::class.java))
         condition as DirectionCondition
-        assertThat(condition.getDirection, equalTo(getDirection))
+        assertThat(condition.stateOperators, equalTo(stateOperators))
         assertThat(condition.direction, equalTo(FeederDirection.BOTH))
     }
 
     @Test
-    fun feederDirectionStateOperatorsWithDirection() {
-        val feederDirectionOperators: FeederDirectionStateOperations = NetworkStateOperators.NORMAL
-        val condition = feederDirectionOperators.withDirection<Unit>(FeederDirection.BOTH)
+    fun stateOperatorsUpstream() {
+        val stateOperators = NetworkStateOperators.NORMAL
+        val condition = stateOperators.upstream<Unit>()
         assertThat(condition, instanceOf(DirectionCondition::class.java))
         condition as DirectionCondition
-        assertThat(condition.getDirection, equalTo(feederDirectionOperators::getDirection))
-        assertThat(condition.direction, equalTo(FeederDirection.BOTH))
-    }
-
-    @Test
-    fun upstream() {
-        val getDirection = Terminal::normalFeederDirection
-        val condition = upstream<Unit>(getDirection)
-        assertThat(condition, instanceOf(DirectionCondition::class.java))
-        condition as DirectionCondition
-        assertThat(condition.getDirection, equalTo(getDirection))
+        assertThat(condition.stateOperators, equalTo(stateOperators))
         assertThat(condition.direction, equalTo(FeederDirection.UPSTREAM))
     }
 
     @Test
-    fun feederDirectionStateOperatorsUpstream() {
-        val feederDirectionOperators: FeederDirectionStateOperations = NetworkStateOperators.NORMAL
-        val condition = feederDirectionOperators.upstream<Unit>()
+    fun stateOperatorsDownstream() {
+        val stateOperators = NetworkStateOperators.NORMAL
+        val condition = stateOperators.downstream<Unit>()
         assertThat(condition, instanceOf(DirectionCondition::class.java))
         condition as DirectionCondition
-        assertThat(condition.getDirection, equalTo(feederDirectionOperators::getDirection))
-        assertThat(condition.direction, equalTo(FeederDirection.UPSTREAM))
-    }
-
-    @Test
-    fun downstream() {
-        val getDirection = Terminal::normalFeederDirection
-        val condition = downstream<Unit>(getDirection)
-        assertThat(condition, instanceOf(DirectionCondition::class.java))
-        condition as DirectionCondition
-        assertThat(condition.getDirection, equalTo(getDirection))
-        assertThat(condition.direction, equalTo(FeederDirection.DOWNSTREAM))
-    }
-
-    @Test
-    fun feederDirectionStateOperatorsDownstream() {
-        val feederDirectionOperators: FeederDirectionStateOperations = NetworkStateOperators.NORMAL
-        val condition = feederDirectionOperators.downstream<Unit>()
-        assertThat(condition, instanceOf(DirectionCondition::class.java))
-        condition as DirectionCondition
-        assertThat(condition.getDirection, equalTo(feederDirectionOperators::getDirection))
+        assertThat(condition.stateOperators, equalTo(stateOperators))
         assertThat(condition.direction, equalTo(FeederDirection.DOWNSTREAM))
     }
 

--- a/src/test/kotlin/com/zepben/evolve/services/network/tracing/networktrace/conditions/DirectionConditionTest.kt
+++ b/src/test/kotlin/com/zepben/evolve/services/network/tracing/networktrace/conditions/DirectionConditionTest.kt
@@ -9,9 +9,11 @@
 package com.zepben.evolve.services.network.tracing.networktrace.conditions
 
 import com.zepben.evolve.cim.iec61970.base.core.Terminal
+import com.zepben.evolve.cim.iec61970.base.wires.Junction
 import com.zepben.evolve.services.network.tracing.feeder.FeederDirection
 import com.zepben.evolve.services.network.tracing.feeder.FeederDirection.*
 import com.zepben.evolve.services.network.tracing.networktrace.NetworkTraceStep
+import com.zepben.evolve.services.network.tracing.networktrace.operators.NetworkStateOperators
 import io.mockk.every
 import io.mockk.mockk
 import org.hamcrest.MatcherAssert.assertThat
@@ -103,9 +105,12 @@ class DirectionConditionTest {
         val nextPath = mockk<NetworkTraceStep.Path>()
         every { nextPath.tracedInternally } returns tracedInternally
         every { nextPath.toTerminal } returns Terminal()
+        every { nextPath.toEquipment } returns Junction()
+        every { nextPath.didTraverseAcLineSegment } returns false
         val nextItem = NetworkTraceStep(nextPath, 0, 0, Unit)
 
-        val result = DirectionCondition<Unit>(direction) { toDirection }.shouldQueue(nextItem, mockk(), mockk(), mockk())
+        val stateOperators = mockk<NetworkStateOperators> { every { getDirection(nextPath.toTerminal) } returns toDirection }
+        val result = DirectionCondition<Unit>(direction, stateOperators).shouldQueue(nextItem, mockk(), mockk(), mockk())
 
         assertThat(result, equalTo(expected))
     }
@@ -114,9 +119,12 @@ class DirectionConditionTest {
         val (direction, toDirection) = this
         val nextPath = mockk<NetworkTraceStep.Path>()
         every { nextPath.toTerminal } returns Terminal()
+        every { nextPath.toEquipment } returns Junction()
+        every { nextPath.didTraverseAcLineSegment } returns false
         val nextItem = NetworkTraceStep(nextPath, 0, 0, Unit)
 
-        val result = DirectionCondition<Unit>(direction) { toDirection }.shouldQueueStartItem(nextItem)
+        val stateOperators = mockk<NetworkStateOperators> { every { getDirection(nextPath.toTerminal) } returns toDirection }
+        val result = DirectionCondition<Unit>(direction, stateOperators).shouldQueueStartItem(nextItem)
 
         assertThat(result, equalTo(expected))
     }

--- a/src/test/kotlin/com/zepben/evolve/services/network/tracing/traversal/TraversalTest.kt
+++ b/src/test/kotlin/com/zepben/evolve/services/network/tracing/traversal/TraversalTest.kt
@@ -265,7 +265,6 @@ class TraversalTest {
     fun `only actions items that can be actioned`() {
         val steps = mutableListOf<Int>()
         createTraversal(canActionItem = { item, _ -> item % 2 == 1 })
-            .addStopCondition { item, _ -> item == 2 } // stop conditions should not be called for items that are not actionable
             .addStopCondition { item, _ -> item == 3 }
             .addStepAction { item, _ -> steps.add(item) }
             .run(1)

--- a/src/test/kotlin/com/zepben/evolve/services/network/tracing/traversal/TraversalTest.kt
+++ b/src/test/kotlin/com/zepben/evolve/services/network/tracing/traversal/TraversalTest.kt
@@ -54,8 +54,6 @@ class TraversalTest {
 
     private fun createBranchingTraversal(): TestTraversal<Int> {
         val queueType = Traversal.BranchingQueueType<Int, TestTraversal<Int>>(
-            // Note: This is pretty simple and probably doesn't capture testing branching thoroughly. E.g it doesn't queue multiple branches at once...
-            //  Consider making a more thorough test.
             queueNext = { item, _, queueItem, queueBranch ->
                   if (item == 0) {
                       queueBranch(-10)


### PR DESCRIPTION
# Description

The follow fixes were added to Traversal and NetworkTrace:
* `canStopAtStartItem` now works for branching traversals.
* Traversal start items are added to the queue before traversal starts, so that the start items honour the queue type order.
* Stop conditions on the `NetworkTrace` now are checked based on a step type, like `QueueCondition` does, rather than by checking `canActionItem`.
* Cuts and Clamps are now supported in `SetDirection` and `DirectionCondition`.
* `NetworkTrace` now handles starting on `Cut `, `Clamp`, and `AcLineSegment` and their terminals in a explicit / sensible way.
* `NetworkTracePathProvider` now correctly handles next paths when starting on a `Clamp` terminal.

# Associated tasks

* https://app.clickup.com/t/6929263/DEV-2500

# Test Steps

Unit tests have been added.

# Checklist

If any of these are not applicable, strikethrough the line `~like this~`. **Do not delete it!**. Let the reviewer decide if you should have done it.

### Code
- [ ] I have performed a self review of my own code (including checking issues raised when creating the PR).
- [ ] I have added/updated unit tests for these changes, and if not I have explained why they are not necessary.
- [ ] I have commented my code in any hard-to-understand or hacky areas.
- [ ] I have handled all new warnings generated by the compiler or IDE.
- [ ] I have rebased onto the target branch (usually main).

### Documentation
- [ ] I have updated the changelog.
- ~[ ] I have updated any documentation required for these changes.~

# Breaking Changes
- [ ] I have considered if this is a breaking change and will communicate it with other team members if so.

This fixes bugs that will potentially cause things to break if you have built expecting the wrong behaviour. The current impact is just internal to Zepben.

