### PR TITLE
DEV-2568 Tracing fixes and more unit tests

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -25,7 +25,7 @@
   need to update your code.
 * `RemovePhases` now stops at open points like the `SetPhases` counterpart. If you were relying on the bug to remove phases through open points you will now
   need to start additional traces from the other side of the open points to maintain this behaviour.
-* `SetDirection` now correctly sets directions for networks with `BusbarSection`.
+* `SetDirection` now correctly sets directions for networks with `BusbarSection`, `Cut` and `Clamp`.
 * `RemoveDirection` has been removed. It did not work reliably with dual fed networks with loops. You now need to clear direction using the new
   `ClearDirection` and reapply directions where appropriate using `SetDirection`.
 * `FindWithUsagePoints` was deemed too use-case specific for the SDK and has been removed.

--- a/src/main/kotlin/com/zepben/evolve/services/network/tracing/networktrace/conditions/Conditions.kt
+++ b/src/main/kotlin/com/zepben/evolve/services/network/tracing/networktrace/conditions/Conditions.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Zeppelin Bend Pty Ltd
+ * Copyright 2025 Zeppelin Bend Pty Ltd
  *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
@@ -22,9 +22,6 @@ import com.zepben.evolve.services.network.tracing.traversal.QueueCondition
 import com.zepben.evolve.services.network.tracing.traversal.StopCondition
 import kotlin.reflect.KClass
 
-private typealias NetworkTraceQueueCondition<T> = QueueCondition<NetworkTraceStep<T>>
-private typealias NetworkTraceStopCondition<T> = StopCondition<NetworkTraceStep<T>>
-
 /**
  * Provides a collection of predefined conditions for use in network traces.
  */
@@ -42,7 +39,7 @@ object Conditions {
      * @return A [NetworkTraceQueueCondition] that results in upstream tracing.
      */
     @JvmStatic
-    fun <T> NetworkStateOperators.upstream(): NetworkTraceQueueCondition<T> =
+    fun <T> NetworkStateOperators.upstream(): QueueCondition<NetworkTraceStep<T>> =
         withDirection(FeederDirection.UPSTREAM)
 
     /**
@@ -57,7 +54,7 @@ object Conditions {
      * @return A [NetworkTraceQueueCondition] that results in downstream tracing.
      */
     @JvmStatic
-    fun <T> NetworkStateOperators.downstream(): NetworkTraceQueueCondition<T> =
+    fun <T> NetworkStateOperators.downstream(): QueueCondition<NetworkTraceStep<T>> =
         withDirection(FeederDirection.DOWNSTREAM)
 
     /**
@@ -72,7 +69,7 @@ object Conditions {
      * @return A [NetworkTraceQueueCondition] that results in upstream tracing.
      */
     @JvmStatic
-    fun <T> NetworkStateOperators.withDirection(direction: FeederDirection): NetworkTraceQueueCondition<T> =
+    fun <T> NetworkStateOperators.withDirection(direction: FeederDirection): QueueCondition<NetworkTraceStep<T>> =
         DirectionCondition(direction, this)
 
     /**
@@ -83,7 +80,7 @@ object Conditions {
      * @return A [NetworkTraceQueueCondition] that results in not tracing through open equipment.
      */
     @JvmStatic
-    fun <T> stopAtOpen(openTest: (Switch, SinglePhaseKind?) -> Boolean, phase: SinglePhaseKind? = null): NetworkTraceQueueCondition<T> =
+    fun <T> stopAtOpen(openTest: (Switch, SinglePhaseKind?) -> Boolean, phase: SinglePhaseKind? = null): QueueCondition<NetworkTraceStep<T>> =
         OpenCondition(openTest, phase)
 
     /**
@@ -99,7 +96,7 @@ object Conditions {
      * @return A [NetworkTraceQueueCondition] that results in not queueing through open equipment.
      */
     @JvmStatic
-    fun <T> OpenStateOperators.stopAtOpen(phase: SinglePhaseKind? = null): NetworkTraceQueueCondition<T> =
+    fun <T> OpenStateOperators.stopAtOpen(phase: SinglePhaseKind? = null): QueueCondition<NetworkTraceStep<T>> =
         stopAtOpen(this::isOpen, phase)
 
     /**
@@ -109,7 +106,7 @@ object Conditions {
      * @return A [NetworkTraceStopCondition] that stops tracing the path once the step limit is reached.
      */
     @JvmStatic
-    fun <T> limitEquipmentSteps(limit: Int): NetworkTraceStopCondition<T> =
+    fun <T> limitEquipmentSteps(limit: Int): StopCondition<NetworkTraceStep<T>> =
         EquipmentStepLimitCondition(limit)
 
     /**
@@ -121,7 +118,7 @@ object Conditions {
      * @return A [NetworkTraceStopCondition] that stops the trace when the step limit is reached for the specified equipment type.
      */
     @JvmStatic
-    fun <T> limitEquipmentSteps(limit: Int, equipmentType: KClass<out ConductingEquipment>): NetworkTraceStopCondition<T> =
+    fun <T> limitEquipmentSteps(limit: Int, equipmentType: KClass<out ConductingEquipment>): StopCondition<NetworkTraceStep<T>> =
         EquipmentTypeStepLimitCondition(limit, equipmentType)
 
     /**
@@ -132,7 +129,7 @@ object Conditions {
      * @return A [NetworkTraceStopCondition] that stops the trace when the step limit is reached for the specified equipment type.
      */
     @JvmStatic
-    fun <T> limitEquipmentSteps(limit: Int, equipmentType: Class<out ConductingEquipment>): NetworkTraceStopCondition<T> =
+    fun <T> limitEquipmentSteps(limit: Int, equipmentType: Class<out ConductingEquipment>): StopCondition<NetworkTraceStep<T>> =
         limitEquipmentSteps(limit, equipmentType.kotlin)
 
 }

--- a/src/main/kotlin/com/zepben/evolve/services/network/tracing/networktrace/conditions/NetworkTraceQueueCondition.kt
+++ b/src/main/kotlin/com/zepben/evolve/services/network/tracing/networktrace/conditions/NetworkTraceQueueCondition.kt
@@ -6,8 +6,9 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
-package com.zepben.evolve.services.network.tracing.networktrace
+package com.zepben.evolve.services.network.tracing.networktrace.conditions
 
+import com.zepben.evolve.services.network.tracing.networktrace.NetworkTraceStep
 import com.zepben.evolve.services.network.tracing.traversal.QueueCondition
 import com.zepben.evolve.services.network.tracing.traversal.StepContext
 

--- a/src/main/kotlin/com/zepben/evolve/services/network/tracing/networktrace/conditions/NetworkTraceStopCondition.kt
+++ b/src/main/kotlin/com/zepben/evolve/services/network/tracing/networktrace/conditions/NetworkTraceStopCondition.kt
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2025 Zeppelin Bend Pty Ltd
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+package com.zepben.evolve.services.network.tracing.networktrace.conditions
+
+import com.zepben.evolve.services.network.tracing.networktrace.NetworkTraceStep
+import com.zepben.evolve.services.network.tracing.traversal.StepContext
+import com.zepben.evolve.services.network.tracing.traversal.StopCondition
+
+/**
+ * A special stop condition implementation that allows only checking `shouldStop` when a [NetworkTraceStep] matches a given
+ * [NetworkTraceStep.Type]. When [stepType] is:
+ * *[NetworkTraceStep.Type.ALL]: [shouldStop] will be checked for every step.
+ * *[NetworkTraceStep.Type.INTERNAL]: [shouldStop] will be checked only when [NetworkTraceStep.type] is [NetworkTraceStep.Type.INTERNAL].
+ * *[NetworkTraceStep.Type.EXTERNAL]: [shouldStop] will be checked only when [NetworkTraceStep.type] is [NetworkTraceStep.Type.EXTERNAL].
+ *
+ * If the step does not match the given step type, `false` will always be returned.
+ *
+ * @property stepType The step type to match to check `shouldStop`.
+ */
+abstract class NetworkTraceStopCondition<T>(val stepType: NetworkTraceStep.Type) : StopCondition<NetworkTraceStep<T>> {
+
+    private val shouldStopFunc = when (stepType) {
+        NetworkTraceStep.Type.ALL -> ::shouldStopMatchedStep
+        NetworkTraceStep.Type.INTERNAL -> ::shouldStopInternalStep
+        NetworkTraceStep.Type.EXTERNAL -> ::shouldStopExternalStep
+    }
+
+    override fun shouldStop(item: NetworkTraceStep<T>, context: StepContext): Boolean =
+        shouldStopFunc(item, context)
+
+    /**
+     * The logic you would normally put in [shouldStop]. However, this will only be called when a step matches the [stepType].
+     */
+    abstract fun shouldStopMatchedStep(
+        item: NetworkTraceStep<T>,
+        context: StepContext
+    ): Boolean
+
+    private fun shouldStopInternalStep(
+        item: NetworkTraceStep<T>,
+        context: StepContext
+    ): Boolean =
+        if (item.type == NetworkTraceStep.Type.INTERNAL) shouldStopMatchedStep(item, context) else false
+
+    private fun shouldStopExternalStep(
+        item: NetworkTraceStep<T>,
+        context: StepContext
+    ): Boolean =
+        if (item.type == NetworkTraceStep.Type.EXTERNAL) shouldStopMatchedStep(item, context) else false
+
+    companion object {
+        /**
+         * Creates A [NetworkTraceStopCondition] that delegates to the given [condition] when matching the given [stepType].
+         * The [condition] is already a [NetworkTraceStopCondition] this will override the [stepType] of that instance.
+         *
+         * @param stepType The step type to match to check the queue condition.
+         * @param condition The queue conditions to delegate to when matching the step type.
+         * @return A new queue condition that only checks the condition when matching the given step type.
+         */
+        @JvmStatic
+        fun <T> delegateTo(stepType: NetworkTraceStep.Type, condition: StopCondition<NetworkTraceStep<T>>): NetworkTraceStopCondition<T> =
+            DelegatedNetworkTraceStopCondition(stepType, condition)
+    }
+}
+
+private class DelegatedNetworkTraceStopCondition<T>(
+    stepType: NetworkTraceStep.Type,
+    val delegate: StopCondition<NetworkTraceStep<T>>
+) : NetworkTraceStopCondition<T>(stepType) {
+    override fun shouldStopMatchedStep(
+        item: NetworkTraceStep<T>,
+        context: StepContext
+    ): Boolean = delegate.shouldStop(item, context)
+}

--- a/src/main/kotlin/com/zepben/evolve/services/network/tracing/networktrace/conditions/OpenCondition.kt
+++ b/src/main/kotlin/com/zepben/evolve/services/network/tracing/networktrace/conditions/OpenCondition.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Zeppelin Bend Pty Ltd
+ * Copyright 2025 Zeppelin Bend Pty Ltd
  *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
@@ -10,12 +10,9 @@ package com.zepben.evolve.services.network.tracing.networktrace.conditions
 
 import com.zepben.evolve.cim.iec61970.base.wires.SinglePhaseKind
 import com.zepben.evolve.cim.iec61970.base.wires.Switch
-import com.zepben.evolve.services.network.tracing.networktrace.NetworkTraceQueueCondition
 import com.zepben.evolve.services.network.tracing.networktrace.NetworkTraceStep
 import com.zepben.evolve.services.network.tracing.traversal.StepContext
 
-// NOTE: This is a queue condition and not a stop condition because once cuts and jumpers are added to the network model we need the 'next' terminal
-//       to determine if the step goes through an open circuit.
 internal class OpenCondition<T>(
     val isOpen: (Switch, SinglePhaseKind?) -> Boolean,
     val phase: SinglePhaseKind? = null

--- a/src/test/kotlin/com/zepben/evolve/services/network/testdata/CutsAndClampsNetwork.kt
+++ b/src/test/kotlin/com/zepben/evolve/services/network/testdata/CutsAndClampsNetwork.kt
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2025 Zeppelin Bend Pty Ltd
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+package com.zepben.evolve.services.network.testdata
+
+import com.zepben.evolve.cim.iec61970.base.core.ConductingEquipment
+import com.zepben.evolve.cim.iec61970.base.core.Terminal
+import com.zepben.evolve.cim.iec61970.base.wires.AcLineSegment
+import com.zepben.evolve.cim.iec61970.base.wires.Clamp
+import com.zepben.evolve.cim.iec61970.base.wires.Cut
+import com.zepben.evolve.services.network.NetworkService
+import com.zepben.evolve.testing.TestNetworkBuilder
+
+object CutsAndClampsNetwork {
+
+    fun mulitiCutAndClampNetwork(): TestNetworkBuilder {
+        //
+        //          2                     2
+        //          c3          2         c7          2
+        //          1           c5        1           c9
+        //          1 clamp1    1         1 clamp3    1
+        //          |           |         |           |
+        // 1 b0 21--*--*1 cut1 2*--*--c1--*--*1 cut2 2*--*--21 b2 2
+        //             |           |         |           |
+        //             1           1 clamp2  1           1 clamp4
+        //             c4          1         c8          1
+        //             2           c6        2           c10
+        //                         2                     2
+        //
+        val builder = TestNetworkBuilder()
+            .fromBreaker() // b0
+            .toAcls() // c1
+            .toBreaker() // b2
+            .fromAcls() // c3
+            .fromAcls() // c4
+            .fromAcls() // c5
+            .fromAcls() // c6
+            .fromAcls() // c7
+            .fromAcls() // c8
+            .fromAcls() // c9
+            .fromAcls() // c10
+
+        val network = builder.network
+
+        val segment: AcLineSegment = network["c1"]!!
+
+        val clamp1 = segment.withClamp(network, 1.0)
+        val cut1 = segment.withCut(network, 2.0)
+        val clamp2 = segment.withClamp(network, 3.0)
+        val clamp3 = segment.withClamp(network, 4.0)
+        val cut2 = segment.withCut(network, 5.0)
+        val clamp4 = segment.withClamp(network, 6.0)
+
+        network.connect(clamp1.t1, network.get<ConductingEquipment>("c3")!!.t1)
+        network.connect(cut1.t1, network.get<ConductingEquipment>("c4")!!.t1)
+        network.connect(cut1.t2, network.get<ConductingEquipment>("c5")!!.t1)
+        network.connect(clamp2.t1, network.get<ConductingEquipment>("c6")!!.t1)
+        network.connect(clamp3.t1, network.get<ConductingEquipment>("c7")!!.t1)
+        network.connect(cut2.t1, network.get<ConductingEquipment>("c8")!!.t1)
+        network.connect(cut2.t2, network.get<ConductingEquipment>("c9")!!.t1)
+        network.connect(clamp4.t1, network.get<ConductingEquipment>("c10")!!.t1)
+
+        return builder
+    }
+
+    fun AcLineSegment.withClamp(network: NetworkService, lengthFromTerminal1: Double?): Clamp {
+        val clamp = Clamp("clamp${numClamps() + 1}").apply {
+            addTerminal(Terminal("$mRID-t1"))
+            this.lengthFromTerminal1 = lengthFromTerminal1
+        }
+
+        addClamp(clamp)
+        network.add(clamp)
+
+        return clamp
+    }
+
+    fun AcLineSegment.withCut(network: NetworkService, lengthFromTerminal1: Double?): Cut {
+        val cut = Cut("cut${numCuts() + 1}").apply {
+            addTerminal(Terminal("$mRID-t1"))
+            addTerminal(Terminal("$mRID-t2"))
+            this.lengthFromTerminal1 = lengthFromTerminal1
+        }
+
+        addCut(cut)
+        network.add(cut)
+        return cut
+    }
+
+}

--- a/src/test/kotlin/com/zepben/evolve/services/network/tracing/feeder/SetDirectionTest.kt
+++ b/src/test/kotlin/com/zepben/evolve/services/network/tracing/feeder/SetDirectionTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Zeppelin Bend Pty Ltd
+ * Copyright 2025 Zeppelin Bend Pty Ltd
  *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
@@ -16,8 +16,10 @@ import com.zepben.evolve.cim.iec61970.base.core.PhaseCode
 import com.zepben.evolve.cim.iec61970.base.core.Substation
 import com.zepben.evolve.cim.iec61970.base.core.Terminal
 import com.zepben.evolve.cim.iec61970.base.wires.BusbarSection
+import com.zepben.evolve.cim.iec61970.base.wires.Cut
 import com.zepben.evolve.services.network.NetworkService
 import com.zepben.evolve.services.network.getT
+import com.zepben.evolve.services.network.testdata.CutsAndClampsNetwork
 import com.zepben.evolve.services.network.testdata.PhaseSwapLoopNetwork
 import com.zepben.evolve.services.network.tracing.feeder.DirectionValidator.validateDirection
 import com.zepben.evolve.services.network.tracing.feeder.FeederDirection.*
@@ -520,6 +522,224 @@ internal class SetDirectionTest {
         n.getT("b4", 2).validateDirection(BOTH, NetworkStateOperators.NORMAL)
         n.getT("c5", 1).validateDirection(BOTH, NetworkStateOperators.NORMAL)
         n.getT("c5", 2).validateDirection(BOTH, NetworkStateOperators.NORMAL)
+    }
+
+    @Test
+    internal fun setsDirectionOnAclsWithCutsAndClampsFromAclsEndTerminal() {
+        val n = CutsAndClampsNetwork.mulitiCutAndClampNetwork()
+            .addFeeder("b0", 2)
+            .network
+
+        n.get<Cut>("cut1")?.setNormallyOpen(false)
+        n.get<Cut>("cut2")?.setNormallyOpen(true)
+
+        doSetDirectionTrace(n.getT("b0", 2))
+
+        n.getT("b0", 2).validateDirection(DOWNSTREAM, NetworkStateOperators.NORMAL)
+        n.getT("c1", 1).validateDirection(UPSTREAM, NetworkStateOperators.NORMAL)
+        n.getT("clamp1", 1).validateDirection(DOWNSTREAM, NetworkStateOperators.NORMAL)
+        n.getT("c3", 1).validateDirection(UPSTREAM, NetworkStateOperators.NORMAL)
+        n.getT("c3", 2).validateDirection(DOWNSTREAM, NetworkStateOperators.NORMAL)
+        n.getT("c4", 1).validateDirection(UPSTREAM, NetworkStateOperators.NORMAL)
+        n.getT("c4", 2).validateDirection(DOWNSTREAM, NetworkStateOperators.NORMAL)
+        n.getT("cut1", 1).validateDirection(UPSTREAM, NetworkStateOperators.NORMAL)
+        n.getT("cut1", 2).validateDirection(DOWNSTREAM, NetworkStateOperators.NORMAL)
+        n.getT("c5", 1).validateDirection(UPSTREAM, NetworkStateOperators.NORMAL)
+        n.getT("c5", 2).validateDirection(DOWNSTREAM, NetworkStateOperators.NORMAL)
+        n.getT("clamp2", 1).validateDirection(DOWNSTREAM, NetworkStateOperators.NORMAL)
+        n.getT("clamp3", 1).validateDirection(DOWNSTREAM, NetworkStateOperators.NORMAL)
+        n.getT("c8", 1).validateDirection(UPSTREAM, NetworkStateOperators.NORMAL)
+        n.getT("c8", 2).validateDirection(DOWNSTREAM, NetworkStateOperators.NORMAL)
+        n.getT("cut2", 1).validateDirection(UPSTREAM, NetworkStateOperators.NORMAL)
+        n.getT("cut2", 2).validateDirection(NONE, NetworkStateOperators.NORMAL)
+    }
+
+    @Test
+    internal fun setsDirectionOnAclsWithCutsAndClampsFedFromClamp() {
+        val n = CutsAndClampsNetwork.mulitiCutAndClampNetwork()
+            .addFeeder("c6", 1)
+            .network
+
+        n.get<Cut>("cut1")?.setNormallyOpen(false)
+        n.get<Cut>("cut2")?.setNormallyOpen(true)
+
+        doSetDirectionTrace(n.getT("c6", 1))
+
+        n.getT("c6", 1).validateDirection(DOWNSTREAM, NetworkStateOperators.NORMAL)
+        n.getT("c6", 2).validateDirection(NONE, NetworkStateOperators.NORMAL)
+        n.getT("clamp2", 1).validateDirection(UPSTREAM, NetworkStateOperators.NORMAL)
+        n.getT("clamp3", 1).validateDirection(DOWNSTREAM, NetworkStateOperators.NORMAL)
+        n.getT("c7", 1).validateDirection(UPSTREAM, NetworkStateOperators.NORMAL)
+        n.getT("c7", 2).validateDirection(DOWNSTREAM, NetworkStateOperators.NORMAL)
+        n.getT("c8", 1).validateDirection(UPSTREAM, NetworkStateOperators.NORMAL)
+        n.getT("c8", 2).validateDirection(DOWNSTREAM, NetworkStateOperators.NORMAL)
+        n.getT("cut2", 1).validateDirection(UPSTREAM, NetworkStateOperators.NORMAL)
+        n.getT("cut2", 2).validateDirection(NONE, NetworkStateOperators.NORMAL)
+        n.getT("c5", 1).validateDirection(UPSTREAM, NetworkStateOperators.NORMAL)
+        n.getT("c5", 2).validateDirection(DOWNSTREAM, NetworkStateOperators.NORMAL)
+        n.getT("cut1", 2).validateDirection(UPSTREAM, NetworkStateOperators.NORMAL)
+        n.getT("cut1", 1).validateDirection(DOWNSTREAM, NetworkStateOperators.NORMAL)
+        n.getT("c4", 1).validateDirection(UPSTREAM, NetworkStateOperators.NORMAL)
+        n.getT("c4", 2).validateDirection(DOWNSTREAM, NetworkStateOperators.NORMAL)
+        n.getT("clamp1", 1).validateDirection(DOWNSTREAM, NetworkStateOperators.NORMAL)
+        n.getT("c3", 1).validateDirection(UPSTREAM, NetworkStateOperators.NORMAL)
+        n.getT("c3", 2).validateDirection(DOWNSTREAM, NetworkStateOperators.NORMAL)
+        n.getT("c1", 1).validateDirection(DOWNSTREAM, NetworkStateOperators.NORMAL)
+        n.getT("b0", 2).validateDirection(UPSTREAM, NetworkStateOperators.NORMAL)
+        n.getT("b0", 1).validateDirection(DOWNSTREAM, NetworkStateOperators.NORMAL)
+    }
+
+    @Test
+    internal fun setsDirectionOnAclsWithCutsAndClampsFedFromCut() {
+        val n = CutsAndClampsNetwork.mulitiCutAndClampNetwork()
+            .addFeeder("c5", 1)
+            .network
+
+        n.get<Cut>("cut1")?.setNormallyOpen(false)
+        n.get<Cut>("cut2")?.setNormallyOpen(true)
+
+        doSetDirectionTrace(n.getT("c5", 1))
+
+        n.getT("c5", 1).validateDirection(DOWNSTREAM, NetworkStateOperators.NORMAL)
+        n.getT("c5", 2).validateDirection(NONE, NetworkStateOperators.NORMAL)
+        n.getT("cut1", 2).validateDirection(UPSTREAM, NetworkStateOperators.NORMAL)
+        n.getT("cut1", 1).validateDirection(DOWNSTREAM, NetworkStateOperators.NORMAL)
+        n.getT("c4", 1).validateDirection(UPSTREAM, NetworkStateOperators.NORMAL)
+        n.getT("c4", 2).validateDirection(DOWNSTREAM, NetworkStateOperators.NORMAL)
+        n.getT("clamp1", 1).validateDirection(DOWNSTREAM, NetworkStateOperators.NORMAL)
+        n.getT("c3", 1).validateDirection(UPSTREAM, NetworkStateOperators.NORMAL)
+        n.getT("c3", 2).validateDirection(DOWNSTREAM, NetworkStateOperators.NORMAL)
+        n.getT("c1", 1).validateDirection(DOWNSTREAM, NetworkStateOperators.NORMAL)
+        n.getT("b0", 2).validateDirection(UPSTREAM, NetworkStateOperators.NORMAL)
+        n.getT("b0", 1).validateDirection(DOWNSTREAM, NetworkStateOperators.NORMAL)
+        n.getT("clamp2", 1).validateDirection(DOWNSTREAM, NetworkStateOperators.NORMAL)
+        n.getT("c6", 1).validateDirection(UPSTREAM, NetworkStateOperators.NORMAL)
+        n.getT("c6", 2).validateDirection(DOWNSTREAM, NetworkStateOperators.NORMAL)
+        n.getT("clamp3", 1).validateDirection(DOWNSTREAM, NetworkStateOperators.NORMAL)
+        n.getT("c7", 1).validateDirection(UPSTREAM, NetworkStateOperators.NORMAL)
+        n.getT("c7", 2).validateDirection(DOWNSTREAM, NetworkStateOperators.NORMAL)
+        n.getT("c8", 1).validateDirection(UPSTREAM, NetworkStateOperators.NORMAL)
+        n.getT("c8", 2).validateDirection(DOWNSTREAM, NetworkStateOperators.NORMAL)
+        n.getT("cut2", 1).validateDirection(UPSTREAM, NetworkStateOperators.NORMAL)
+        n.getT("cut2", 2).validateDirection(NONE, NetworkStateOperators.NORMAL)
+    }
+
+    @Test
+    internal fun setsDirectionOnAclsWithCutsAndClampsFedFromBothAclsEnds() {
+        val n = CutsAndClampsNetwork.mulitiCutAndClampNetwork()
+            .addFeeder("b0", 2)
+            .addFeeder("b2", 1)
+            .network
+
+        n.get<Cut>("cut1")?.setNormallyOpen(false)
+        n.get<Cut>("cut2")?.setNormallyOpen(false)
+
+        doSetDirectionTrace(n.getT("b0", 2))
+        doSetDirectionTrace(n.getT("b2", 1))
+
+        n.getT("b0", 2).validateDirection(BOTH, NetworkStateOperators.NORMAL)
+        n.getT("b0", 1).validateDirection(NONE, NetworkStateOperators.NORMAL)
+        n.getT("c1", 1).validateDirection(BOTH, NetworkStateOperators.NORMAL)
+        n.getT("clamp1", 1).validateDirection(DOWNSTREAM, NetworkStateOperators.NORMAL)
+        n.getT("c3", 1).validateDirection(UPSTREAM, NetworkStateOperators.NORMAL)
+        n.getT("c3", 2).validateDirection(DOWNSTREAM, NetworkStateOperators.NORMAL)
+        n.getT("c4", 1).validateDirection(UPSTREAM, NetworkStateOperators.NORMAL)
+        n.getT("c4", 2).validateDirection(DOWNSTREAM, NetworkStateOperators.NORMAL)
+        n.getT("cut1", 2).validateDirection(BOTH, NetworkStateOperators.NORMAL)
+        n.getT("cut1", 1).validateDirection(BOTH, NetworkStateOperators.NORMAL)
+        n.getT("c5", 1).validateDirection(UPSTREAM, NetworkStateOperators.NORMAL)
+        n.getT("c5", 2).validateDirection(DOWNSTREAM, NetworkStateOperators.NORMAL)
+        n.getT("clamp2", 1).validateDirection(DOWNSTREAM, NetworkStateOperators.NORMAL)
+        n.getT("c6", 1).validateDirection(UPSTREAM, NetworkStateOperators.NORMAL)
+        n.getT("c6", 2).validateDirection(DOWNSTREAM, NetworkStateOperators.NORMAL)
+        n.getT("clamp3", 1).validateDirection(DOWNSTREAM, NetworkStateOperators.NORMAL)
+        n.getT("c7", 1).validateDirection(UPSTREAM, NetworkStateOperators.NORMAL)
+        n.getT("c7", 2).validateDirection(DOWNSTREAM, NetworkStateOperators.NORMAL)
+        n.getT("c8", 1).validateDirection(UPSTREAM, NetworkStateOperators.NORMAL)
+        n.getT("c8", 2).validateDirection(DOWNSTREAM, NetworkStateOperators.NORMAL)
+        n.getT("cut2", 1).validateDirection(BOTH, NetworkStateOperators.NORMAL)
+        n.getT("cut2", 2).validateDirection(BOTH, NetworkStateOperators.NORMAL)
+        n.getT("c9", 1).validateDirection(UPSTREAM, NetworkStateOperators.NORMAL)
+        n.getT("c9", 2).validateDirection(DOWNSTREAM, NetworkStateOperators.NORMAL)
+        n.getT("clamp4", 1).validateDirection(DOWNSTREAM, NetworkStateOperators.NORMAL)
+        n.getT("c10", 1).validateDirection(UPSTREAM, NetworkStateOperators.NORMAL)
+        n.getT("c10", 2).validateDirection(DOWNSTREAM, NetworkStateOperators.NORMAL)
+        n.getT("b2", 1).validateDirection(BOTH, NetworkStateOperators.NORMAL)
+        n.getT("b2", 2).validateDirection(NONE, NetworkStateOperators.NORMAL)
+    }
+
+    @Test
+    internal fun setsDirectionOnAclsWithCutsAndClampsFedFromAclsEndAndClamp() {
+        val n = CutsAndClampsNetwork.mulitiCutAndClampNetwork()
+            .addFeeder("b0", 2)
+            .addFeeder("c6", 1)
+            .network
+
+        n.get<Cut>("cut1")?.setNormallyOpen(false)
+        n.get<Cut>("cut2")?.setNormallyOpen(true)
+
+        doSetDirectionTrace(n.getT("b0", 2))
+        doSetDirectionTrace(n.getT("c6", 1))
+
+        n.getT("b0", 2).validateDirection(BOTH, NetworkStateOperators.NORMAL)
+        n.getT("b0", 1).validateDirection(NONE, NetworkStateOperators.NORMAL)
+        n.getT("c1", 1).validateDirection(BOTH, NetworkStateOperators.NORMAL)
+        n.getT("clamp1", 1).validateDirection(DOWNSTREAM, NetworkStateOperators.NORMAL)
+        n.getT("c3", 1).validateDirection(UPSTREAM, NetworkStateOperators.NORMAL)
+        n.getT("c3", 2).validateDirection(DOWNSTREAM, NetworkStateOperators.NORMAL)
+        n.getT("c4", 1).validateDirection(UPSTREAM, NetworkStateOperators.NORMAL)
+        n.getT("c4", 2).validateDirection(DOWNSTREAM, NetworkStateOperators.NORMAL)
+        n.getT("cut1", 2).validateDirection(BOTH, NetworkStateOperators.NORMAL)
+        n.getT("cut1", 1).validateDirection(BOTH, NetworkStateOperators.NORMAL)
+        n.getT("c5", 1).validateDirection(UPSTREAM, NetworkStateOperators.NORMAL)
+        n.getT("c5", 2).validateDirection(DOWNSTREAM, NetworkStateOperators.NORMAL)
+        n.getT("clamp2", 1).validateDirection(BOTH, NetworkStateOperators.NORMAL)
+        n.getT("c6", 1).validateDirection(BOTH, NetworkStateOperators.NORMAL)
+        n.getT("c6", 2).validateDirection(NONE, NetworkStateOperators.NORMAL)
+        n.getT("clamp3", 1).validateDirection(DOWNSTREAM, NetworkStateOperators.NORMAL)
+        n.getT("c7", 1).validateDirection(UPSTREAM, NetworkStateOperators.NORMAL)
+        n.getT("c7", 2).validateDirection(DOWNSTREAM, NetworkStateOperators.NORMAL)
+        n.getT("c8", 1).validateDirection(UPSTREAM, NetworkStateOperators.NORMAL)
+        n.getT("c8", 2).validateDirection(DOWNSTREAM, NetworkStateOperators.NORMAL)
+        n.getT("cut2", 1).validateDirection(UPSTREAM, NetworkStateOperators.NORMAL)
+        n.getT("cut2", 2).validateDirection(NONE, NetworkStateOperators.NORMAL)
+    }
+
+    @Test
+    internal fun setsDirectionOnAclsWithCutsAndClampsFedFromAclsClampAndCut() {
+        val n = CutsAndClampsNetwork.mulitiCutAndClampNetwork()
+            .addFeeder("c3", 1)
+            .addFeeder("c5", 1)
+            .network
+
+        n.get<Cut>("cut1")?.setNormallyOpen(false)
+        n.get<Cut>("cut2")?.setNormallyOpen(true)
+
+        doSetDirectionTrace(n.getT("c3", 1))
+        doSetDirectionTrace(n.getT("c5", 1))
+
+        n.getT("b0", 2).validateDirection(UPSTREAM, NetworkStateOperators.NORMAL)
+        n.getT("b0", 1).validateDirection(DOWNSTREAM, NetworkStateOperators.NORMAL)
+        n.getT("c1", 1).validateDirection(DOWNSTREAM, NetworkStateOperators.NORMAL)
+        n.getT("clamp1", 1).validateDirection(BOTH, NetworkStateOperators.NORMAL)
+        n.getT("c3", 1).validateDirection(BOTH, NetworkStateOperators.NORMAL)
+        n.getT("c3", 2).validateDirection(NONE, NetworkStateOperators.NORMAL)
+        n.getT("c4", 1).validateDirection(UPSTREAM, NetworkStateOperators.NORMAL)
+        n.getT("c4", 2).validateDirection(DOWNSTREAM, NetworkStateOperators.NORMAL)
+        n.getT("cut1", 2).validateDirection(BOTH, NetworkStateOperators.NORMAL)
+        n.getT("cut1", 1).validateDirection(BOTH, NetworkStateOperators.NORMAL)
+        n.getT("c5", 1).validateDirection(BOTH, NetworkStateOperators.NORMAL)
+        n.getT("c5", 2).validateDirection(NONE, NetworkStateOperators.NORMAL)
+        n.getT("clamp2", 1).validateDirection(DOWNSTREAM, NetworkStateOperators.NORMAL)
+        n.getT("c6", 1).validateDirection(UPSTREAM, NetworkStateOperators.NORMAL)
+        n.getT("c6", 2).validateDirection(DOWNSTREAM, NetworkStateOperators.NORMAL)
+        n.getT("clamp3", 1).validateDirection(DOWNSTREAM, NetworkStateOperators.NORMAL)
+        n.getT("c7", 1).validateDirection(UPSTREAM, NetworkStateOperators.NORMAL)
+        n.getT("c7", 2).validateDirection(DOWNSTREAM, NetworkStateOperators.NORMAL)
+        n.getT("c8", 1).validateDirection(UPSTREAM, NetworkStateOperators.NORMAL)
+        n.getT("c8", 2).validateDirection(DOWNSTREAM, NetworkStateOperators.NORMAL)
+        n.getT("cut2", 1).validateDirection(UPSTREAM, NetworkStateOperators.NORMAL)
+        n.getT("cut2", 2).validateDirection(NONE, NetworkStateOperators.NORMAL)
     }
 
     private fun doSetDirectionTrace(terminal: Terminal) {

--- a/src/test/kotlin/com/zepben/evolve/services/network/tracing/networktrace/NetworkTraceStepPathProviderTest.kt
+++ b/src/test/kotlin/com/zepben/evolve/services/network/tracing/networktrace/NetworkTraceStepPathProviderTest.kt
@@ -16,6 +16,9 @@ import com.zepben.evolve.cim.iec61970.base.wires.Breaker
 import com.zepben.evolve.cim.iec61970.base.wires.Clamp
 import com.zepben.evolve.cim.iec61970.base.wires.Cut
 import com.zepben.evolve.services.network.NetworkService
+import com.zepben.evolve.services.network.testdata.CutsAndClampsNetwork
+import com.zepben.evolve.services.network.testdata.CutsAndClampsNetwork.withClamp
+import com.zepben.evolve.services.network.testdata.CutsAndClampsNetwork.withCut
 import com.zepben.evolve.services.network.tracing.connectivity.NominalPhasePath
 import com.zepben.evolve.services.network.tracing.networktrace.operators.NetworkStateOperators
 import com.zepben.evolve.testing.TestNetworkBuilder
@@ -190,7 +193,7 @@ class NetworkTraceStepPathProviderTest {
 
     @Test
     fun `non traverse step to segment t1 traverses towards t2 stopping at cut`() {
-        val network = aclsWithClampsAndCutsNetwork()
+        val network = CutsAndClampsNetwork.mulitiCutAndClampNetwork().network
 
         val b0: Breaker = network["b0"]!!
         val segment: AcLineSegment = network["c1"]!!
@@ -204,7 +207,7 @@ class NetworkTraceStepPathProviderTest {
 
     @Test
     fun `non traverse step to segment t2 traverses towards t1 stopping at cut`() {
-        val network = aclsWithClampsAndCutsNetwork()
+        val network = CutsAndClampsNetwork.mulitiCutAndClampNetwork().network
 
         val b2: Breaker = network["b2"]!!
         val segment: AcLineSegment = network["c1"]!!
@@ -218,7 +221,7 @@ class NetworkTraceStepPathProviderTest {
 
     @Test
     fun `traverse step to cut t1 steps externally and across cut`() {
-        val network = aclsWithClampsAndCutsNetwork()
+        val network = CutsAndClampsNetwork.mulitiCutAndClampNetwork().network
 
         val segment: AcLineSegment = network["c1"]!!
         val cut1: Cut = network["cut1"]!!
@@ -231,7 +234,7 @@ class NetworkTraceStepPathProviderTest {
 
     @Test
     fun `traverse step to cut t2 steps externally and across cut`() {
-        val network = aclsWithClampsAndCutsNetwork()
+        val network = CutsAndClampsNetwork.mulitiCutAndClampNetwork().network
 
         val segment: AcLineSegment = network["c1"]!!
         val cut2: Cut = network["cut2"]!!
@@ -244,7 +247,7 @@ class NetworkTraceStepPathProviderTest {
 
     @Test
     fun `non traverse step to cut t1 traverses segment towards t1 and internally through cut to t2`() {
-        val network = aclsWithClampsAndCutsNetwork()
+        val network = CutsAndClampsNetwork.mulitiCutAndClampNetwork().network
 
         val segment: AcLineSegment = network["c1"]!!
         val clamp1: Clamp = network["clamp1"]!!
@@ -258,7 +261,7 @@ class NetworkTraceStepPathProviderTest {
 
     @Test
     fun `non traverse step to cut t2 traverses segment towards t2 and internally through cut to t1`() {
-        val network = aclsWithClampsAndCutsNetwork()
+        val network = CutsAndClampsNetwork.mulitiCutAndClampNetwork().network
 
         val segment: AcLineSegment = network["c1"]!!
         val clamp4: Clamp = network["clamp4"]!!
@@ -272,7 +275,7 @@ class NetworkTraceStepPathProviderTest {
 
     @Test
     fun `non traverse step to clamp traverses segment in both directions`() {
-        val network = aclsWithClampsAndCutsNetwork()
+        val network = CutsAndClampsNetwork.mulitiCutAndClampNetwork().network
 
         val segment: AcLineSegment = network["c1"]!!
         val clamp1: Clamp = network["clamp1"]!!
@@ -286,7 +289,7 @@ class NetworkTraceStepPathProviderTest {
 
     @Test
     fun `traverse step to clamp traces externally and does not traverse back along segment`() {
-        val network = aclsWithClampsAndCutsNetwork()
+        val network = CutsAndClampsNetwork.mulitiCutAndClampNetwork().network
 
         val segment: AcLineSegment = network["c1"]!!
         val clamp1: Clamp = network["clamp1"]!!
@@ -299,7 +302,7 @@ class NetworkTraceStepPathProviderTest {
 
     @Test
     fun `non traverse step to clamp between cuts traverses segment both ways stopping at cuts`() {
-        val network = aclsWithClampsAndCutsNetwork()
+        val network = CutsAndClampsNetwork.mulitiCutAndClampNetwork().network
 
         val c6: AcLineSegment = network["c6"]!!
         val clamp2: Clamp = network["clamp2"]!!
@@ -314,7 +317,7 @@ class NetworkTraceStepPathProviderTest {
 
     @Test
     fun `non traverse external step to cut t2 between cuts traverses segment towards t2 stopping at next cut and steps internally to cut t1`() {
-        val network = aclsWithClampsAndCutsNetwork()
+        val network = CutsAndClampsNetwork.mulitiCutAndClampNetwork().network
 
         val c5: AcLineSegment = network["c5"]!!
         val clamp2: Clamp = network["clamp2"]!!
@@ -329,7 +332,7 @@ class NetworkTraceStepPathProviderTest {
 
     @Test
     fun `non traverse external step to cut t1 between cuts traverses segment towards t1 stopping at next cut and steps internally to cut t2`() {
-        val network = aclsWithClampsAndCutsNetwork()
+        val network = CutsAndClampsNetwork.mulitiCutAndClampNetwork().network
 
         val c8: AcLineSegment = network["c8"]!!
         val clamp2: Clamp = network["clamp2"]!!
@@ -344,7 +347,7 @@ class NetworkTraceStepPathProviderTest {
 
     @Test
     fun `internal step to cut t2 between cuts steps externally and traverses segment towards t2 stopping at next cut`() {
-        val network = aclsWithClampsAndCutsNetwork()
+        val network = CutsAndClampsNetwork.mulitiCutAndClampNetwork().network
 
         val c5: AcLineSegment = network["c5"]!!
         val clamp2: Clamp = network["clamp2"]!!
@@ -359,7 +362,7 @@ class NetworkTraceStepPathProviderTest {
 
     @Test
     fun `internal step to cut t1 between cuts steps externally and traverses segment towards t1 stopping at next cut`() {
-        val network = aclsWithClampsAndCutsNetwork()
+        val network = CutsAndClampsNetwork.mulitiCutAndClampNetwork().network
 
         val c8: AcLineSegment = network["c8"]!!
         val clamp2: Clamp = network["clamp2"]!!
@@ -374,7 +377,7 @@ class NetworkTraceStepPathProviderTest {
 
     @Test
     fun `starting on clamp terminal flagged as traversed segment only steps externally`() {
-        val network = aclsWithClampsAndCutsNetwork()
+        val network = CutsAndClampsNetwork.mulitiCutAndClampNetwork().network
 
         val c3: AcLineSegment = network["c3"]!!
         val clamp1: Clamp = network["clamp1"]!!
@@ -385,7 +388,7 @@ class NetworkTraceStepPathProviderTest {
 
     @Test
     fun `starting on clamp terminal that flagged as not traversed segment steps externally and traverses`() {
-        val network = aclsWithClampsAndCutsNetwork()
+        val network = CutsAndClampsNetwork.mulitiCutAndClampNetwork().network
 
         val c3: AcLineSegment = network["c3"]!!
         val clamp1: Clamp = network["clamp1"]!!
@@ -766,55 +769,6 @@ class NetworkTraceStepPathProviderTest {
         return network
     }
 
-    private fun aclsWithClampsAndCutsNetwork(): NetworkService {
-        //
-        //          2                     2
-        //          c3          2         c7          2
-        //          1           c5        1           c9
-        //          1 clamp1    1         1 clamp3    1
-        //          |           |         |           |
-        // 1 b0 21--*--*1 cut1 2*--*--c1--*--*1 cut2 2*--*--21 b2 2
-        //             |           |         |           |
-        //             1           1 clamp2  1           1 clamp4
-        //             c4          1         c8          1
-        //             2           c6        2           c10
-        //                         2                     2
-        //
-        val network = TestNetworkBuilder()
-            .fromBreaker() // b0
-            .toAcls() // c1
-            .toBreaker() // b2
-            .fromAcls() // c3
-            .fromAcls() // c4
-            .fromAcls() // c5
-            .fromAcls() // c6
-            .fromAcls() // c7
-            .fromAcls() // c8
-            .fromAcls() // c9
-            .fromAcls() // c10
-            .network
-
-        val segment: AcLineSegment = network["c1"]!!
-
-        val clamp1 = segment.withClamp(network, 1.0)
-        val cut1 = segment.withCut(network, 2.0)
-        val clamp2 = segment.withClamp(network, 3.0)
-        val clamp3 = segment.withClamp(network, 4.0)
-        val cut2 = segment.withCut(network, 5.0)
-        val clamp4 = segment.withClamp(network, 6.0)
-
-        network.connect(clamp1.t1, network.get<ConductingEquipment>("c3")!!.t1)
-        network.connect(cut1.t1, network.get<ConductingEquipment>("c4")!!.t1)
-        network.connect(cut1.t2, network.get<ConductingEquipment>("c5")!!.t1)
-        network.connect(clamp2.t1, network.get<ConductingEquipment>("c6")!!.t1)
-        network.connect(clamp3.t1, network.get<ConductingEquipment>("c7")!!.t1)
-        network.connect(cut2.t1, network.get<ConductingEquipment>("c8")!!.t1)
-        network.connect(cut2.t2, network.get<ConductingEquipment>("c9")!!.t1)
-        network.connect(clamp4.t1, network.get<ConductingEquipment>("c10")!!.t1)
-
-        return network
-    }
-
     private fun aclsWithClampsAndCutsAtSamePositionNetwork(): NetworkService {
         // Drawing this is very messy, so it will be described in writing:
         // The network has 2 Breakers (b0, b2) with an AcLineSegment (c1) between them ( 1 b0 21--c1--21 b2 1 )
@@ -884,30 +838,6 @@ class NetworkTraceStepPathProviderTest {
         network.connect(cut6.t2, network.get<ConductingEquipment>("c-cut6t2")!!.t1)
 
         return network
-    }
-
-    private fun AcLineSegment.withClamp(network: NetworkService, lengthFromTerminal1: Double?): Clamp {
-        val clamp = Clamp("clamp${numClamps() + 1}").apply {
-            addTerminal(Terminal("$mRID-t1"))
-            this.lengthFromTerminal1 = lengthFromTerminal1
-        }
-
-        addClamp(clamp)
-        network.add(clamp)
-
-        return clamp
-    }
-
-    private fun AcLineSegment.withCut(network: NetworkService, lengthFromTerminal1: Double?): Cut {
-        val cut = Cut("cut${numCuts() + 1}").apply {
-            addTerminal(Terminal("$mRID-t1"))
-            addTerminal(Terminal("$mRID-t2"))
-            this.lengthFromTerminal1 = lengthFromTerminal1
-        }
-
-        addCut(cut)
-        network.add(cut)
-        return cut
     }
 
     /**


### PR DESCRIPTION
# Description

The follow fixes were added to Traversal and NetworkTrace:
* `canStopAtStartItem` now works for branching traversals.
* Traversal start items are added to the queue before traversal starts, so that the start items honour the queue type order.
* Stop conditions on the `NetworkTrace` now are checked based on a step type, like `QueueCondition` does, rather than by checking `canActionItem`.
* Cuts and Clamps are now supported in `SetDirection` and `DirectionCondition`.
* `NetworkTrace` now handles starting on `Cut `, `Clamp`, and `AcLineSegment` and their terminals in a explicit / sensible way.
* `NetworkTracePathProvider` now correctly handles next paths when starting on a `Clamp` terminal.

# Associated tasks

* https://app.clickup.com/t/6929263/DEV-2500

# Test Steps

Unit tests have been added.

# Checklist

If any of these are not applicable, strikethrough the line `~like this~`. **Do not delete it!**. Let the reviewer decide if you should have done it.

### Code
- [ ] I have performed a self review of my own code (including checking issues raised when creating the PR).
- [ ] I have added/updated unit tests for these changes, and if not I have explained why they are not necessary.
- [ ] I have commented my code in any hard-to-understand or hacky areas.
- [ ] I have handled all new warnings generated by the compiler or IDE.
- [ ] I have rebased onto the target branch (usually main).

### Documentation
- [ ] I have updated the changelog.
- ~[ ] I have updated any documentation required for these changes.~

# Breaking Changes
- [ ] I have considered if this is a breaking change and will communicate it with other team members if so.

This fixes bugs that will potentially cause things to break if you have built expecting the wrong behaviour. The current impact is just internal to Zepben.

