### PR TITLE
Add Asset to PowerSystemResource relationship

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -24,7 +24,9 @@
 * None.
 
 ### New Features
-* None.
+* Added relationships between `Asset` and `PowerSystemResource` which enables linking `Equipment` to `Pole`:
+  * `Asset.powerSystemResources`
+  * `PowerSystemResource.assets`
 
 ### Enhancements
 * Added support to `TestNetworkBuilder` for:

--- a/changelog.md
+++ b/changelog.md
@@ -45,6 +45,7 @@
     * Next paths when starting on a `Clamp` terminal.
     * Traversing AcLineSegments with single cuts or clamps.
 * Added missing `@JvmOverloads` annotations to the `TestNetworkBuilder`.
+* `AssignToFeeders` and `AssignToLvFeeders` will now associate `PowerElectronicUnits` with their `powerElectronicsConnection` `Feeder`/`LvFeeder`.
 * Fixes from ewb-conn-jvm 0.12.1:
   * JWTAuthenticator will now handle JwkExceptions and return 403 Unauthenticated responses.
   * JWTAuthenticator will now pass through unhandled exceptions to the caller rather than wrapping them in 500 errors.

--- a/pom.xml
+++ b/pom.xml
@@ -74,7 +74,7 @@
         <dependency>
             <groupId>com.zepben.protobuf</groupId>
             <artifactId>evolve-grpc</artifactId>
-            <version>0.34.1</version>
+            <version>0.35.0-SNAPSHOT2</version>
         </dependency>
 
         <dependency>

--- a/src/main/kotlin/com/zepben/evolve/cim/iec61968/assets/Asset.kt
+++ b/src/main/kotlin/com/zepben/evolve/cim/iec61968/assets/Asset.kt
@@ -10,6 +10,7 @@ package com.zepben.evolve.cim.iec61968.assets
 
 import com.zepben.evolve.cim.iec61968.common.Location
 import com.zepben.evolve.cim.iec61970.base.core.IdentifiedObject
+import com.zepben.evolve.cim.iec61970.base.core.PowerSystemResource
 import com.zepben.evolve.services.common.extensions.asUnmodifiable
 import com.zepben.evolve.services.common.extensions.getByMRID
 import com.zepben.evolve.services.common.extensions.safeRemove
@@ -24,6 +25,7 @@ import com.zepben.evolve.services.common.extensions.validateReference
 abstract class Asset(mRID: String = "") : IdentifiedObject(mRID) {
 
     private var _organisationRoles: MutableList<AssetOrganisationRole>? = null
+    private var _powerSystemResources: MutableList<PowerSystemResource>? = null
 
     /**
      * Location of this asset.
@@ -34,6 +36,12 @@ abstract class Asset(mRID: String = "") : IdentifiedObject(mRID) {
      * All roles an organisation plays for this asset. The returned collection is read only.
      */
     val organisationRoles: Collection<AssetOrganisationRole> get() = _organisationRoles.asUnmodifiable()
+
+    /**
+     * All power system resources used to electrically model this asset. For example, transformer asset is electrically modelled with a transformer and its
+     * windings and tap changer.
+     */
+    val powerSystemResources: Collection<PowerSystemResource> get() = _powerSystemResources.asUnmodifiable()
 
     /**
      * Get the number of entries in the [AssetOrganisationRole] collection.
@@ -76,4 +84,53 @@ abstract class Asset(mRID: String = "") : IdentifiedObject(mRID) {
         _organisationRoles = null
         return this
     }
+
+    /**
+     * Get the number of entries in the [PowerSystemResource] collection.
+     */
+    fun numPowerSystemResources(): Int = _powerSystemResources?.size ?: 0
+
+    /**
+     * Get a [PowerSystemResource]s associated with this [Asset]
+     *
+     * @param mRID the mRID of the required [PowerSystemResource]
+     * @return The [PowerSystemResource] with the specified [mRID] if it exists, otherwise null
+     */
+    fun getPowerSystemResource(mRID: String): PowerSystemResource? = _powerSystemResources.getByMRID(mRID)
+
+    /**
+     * Add a [PowerSystemResource] to this [Asset]
+     *
+     * @param powerSystemResource the [PowerSystemResource] to associate with this [Asset].
+     * @return A reference to this [Asset] to allow fluent use.
+     */
+    fun addPowerSystemResource(powerSystemResource: PowerSystemResource): Asset {
+        if (validateReference(powerSystemResource, ::getPowerSystemResource, "A PowerSystemResource"))
+            return this
+
+        _powerSystemResources = _powerSystemResources ?: mutableListOf()
+        _powerSystemResources!!.add(powerSystemResource)
+
+        return this
+    }
+
+    /**
+     * @param powerSystemResource the [PowerSystemResource] to disassociate from this [Asset].
+     * @return true if the [PowerSystemResource] is disassociated.
+     */
+    fun removePowerSystemResource(powerSystemResource: PowerSystemResource): Boolean {
+        val ret = _powerSystemResources.safeRemove(powerSystemResource)
+        if (_powerSystemResources.isNullOrEmpty()) _powerSystemResources = null
+        return ret
+    }
+
+    /**
+     * Remove all [PowerSystemResource]s from this [Asset]
+     * @return A reference to this [Asset] to allow fluent use.
+     */
+    fun clearPowerSystemResources(): Asset {
+        _powerSystemResources = null
+        return this
+    }
+
 }

--- a/src/main/kotlin/com/zepben/evolve/cim/iec61970/base/core/PowerSystemResource.kt
+++ b/src/main/kotlin/com/zepben/evolve/cim/iec61970/base/core/PowerSystemResource.kt
@@ -8,8 +8,13 @@
 
 package com.zepben.evolve.cim.iec61970.base.core
 
+import com.zepben.evolve.cim.iec61968.assets.Asset
 import com.zepben.evolve.cim.iec61968.assets.AssetInfo
 import com.zepben.evolve.cim.iec61968.common.Location
+import com.zepben.evolve.services.common.extensions.asUnmodifiable
+import com.zepben.evolve.services.common.extensions.getByMRID
+import com.zepben.evolve.services.common.extensions.safeRemove
+import com.zepben.evolve.services.common.extensions.validateReference
 
 /**
  *  Abstract class, should only be used through subclasses.
@@ -23,6 +28,7 @@ import com.zepben.evolve.cim.iec61968.common.Location
  */
 abstract class PowerSystemResource(mRID: String = "") : IdentifiedObject(mRID) {
 
+    private var _assets: MutableList<Asset>? = null
     open val assetInfo: AssetInfo? get() = null
     var location: Location? = null
     var numControls: Int = 0
@@ -31,5 +37,58 @@ abstract class PowerSystemResource(mRID: String = "") : IdentifiedObject(mRID) {
      * @return True if this [PowerSystemResource] has at least 1 Control associated with it, false otherwise.
      */
     fun hasControls(): Boolean = numControls > 0
+
+    /**
+     * All assets represented by this power system resource. For example, multiple conductor assets are electrically modelled as a single AC line segment.
+     */
+    val assets: Collection<Asset> get() = _assets.asUnmodifiable()
+
+    /**
+     * Get the number of entries in the [Asset]s collection.
+     */
+    fun numAssets(): Int = _assets?.size ?: 0
+
+    /**
+     * Get an [Asset] associated with this [PowerSystemResource]
+     *
+     * @param mRID the mRID of the required [Asset]
+     * @return The [Asset] with the specified [mRID] if it exists, otherwise null
+     */
+    fun getAsset(mRID: String): Asset? = _assets.getByMRID(mRID)
+
+    /**
+     * Add an [Asset] to this PowerSystemResource
+     *
+     * @param asset the [Asset] to associate with this [PowerSystemResource].
+     * @return A reference to this [PowerSystemResource] to allow fluent use.
+     */
+    fun addAsset(asset: Asset): PowerSystemResource {
+        if (validateReference(asset, ::getAsset, "An Asset"))
+            return this
+
+        _assets = _assets ?: mutableListOf()
+        _assets!!.add(asset)
+
+        return this
+    }
+
+    /**
+     * @param asset the [Asset] to disassociate from this [PowerSystemResource].
+     * @return true if the [Asset] is disassociated.
+     */
+    fun removeAsset(asset: Asset): Boolean {
+        val ret = _assets.safeRemove(asset)
+        if (_assets.isNullOrEmpty()) _assets = null
+        return ret
+    }
+
+    /**
+     * Remove all [Asset]s from this PowerSystemResource
+     * @return A reference to this [PowerSystemResource] to allow fluent use.
+     */
+    fun clearAssets(): PowerSystemResource {
+        _assets = null
+        return this
+    }
 
 }

--- a/src/main/kotlin/com/zepben/evolve/database/sqlite/cim/network/NetworkCimWriter.kt
+++ b/src/main/kotlin/com/zepben/evolve/database/sqlite/cim/network/NetworkCimWriter.kt
@@ -375,6 +375,7 @@ class NetworkCimWriter(
 
         insert.setNullableString(table.LOCATION_MRID.queryIndex, asset.location?.mRID)
         asset.organisationRoles.forEach { status = status and writeAssociation(it, asset) }
+        asset.powerSystemResources.forEach { status = status and writeAssociation(it, asset) }
 
         return status and writeIdentifiedObject(table, insert, asset, description)
     }
@@ -2477,6 +2478,17 @@ class NetworkCimWriter(
         insert.setString(table.ASSET_MRID.queryIndex, asset.mRID)
 
         return insert.tryExecuteSingleUpdate("asset organisation role to asset association")
+    }
+
+    @Throws(SQLException::class)
+    private fun writeAssociation(powerSystemResource: PowerSystemResource, asset: Asset): Boolean {
+        val table = databaseTables.getTable<TableAssetsPowerSystemResources>()
+        val insert = databaseTables.getInsert<TableAssetsPowerSystemResources>()
+
+        insert.setString(table.ASSET_MRID.queryIndex, asset.mRID)
+        insert.setString(table.POWER_SYSTEM_RESOURCE_MRID.queryIndex, powerSystemResource.mRID)
+
+        return insert.tryExecuteSingleUpdate("asset to power system resource association")
     }
 
     @Throws(SQLException::class)

--- a/src/main/kotlin/com/zepben/evolve/database/sqlite/cim/network/NetworkDatabaseTables.kt
+++ b/src/main/kotlin/com/zepben/evolve/database/sqlite/cim/network/NetworkDatabaseTables.kt
@@ -60,6 +60,7 @@ class NetworkDatabaseTables: CimDatabaseTables() {
             TableAccumulators(),
             TableAnalogs(),
             TableAssetOrganisationRolesAssets(),
+            TableAssetsPowerSystemResources(),
             TableAssetOwners(),
             TableBaseVoltages(),
             TableBatteryControls(),

--- a/src/main/kotlin/com/zepben/evolve/database/sqlite/cim/network/NetworkServiceReader.kt
+++ b/src/main/kotlin/com/zepben/evolve/database/sqlite/cim/network/NetworkServiceReader.kt
@@ -157,6 +157,7 @@ internal class NetworkServiceReader(
             readEach<TablePositionPoints>(service, reader::read) and
             readEach<TableLocationStreetAddresses>(service, reader::read) and
             readEach<TableAssetOrganisationRolesAssets>(service, reader::read) and
+            readEach<TableAssetsPowerSystemResources>(service, reader::read) and
             readEach<TableUsagePointsEndDevices>(service, reader::read) and
             readEach<TableEquipmentUsagePoints>(service, reader::read) and
             readEach<TableEquipmentOperationalRestrictions>(service, reader::read) and

--- a/src/main/kotlin/com/zepben/evolve/database/sqlite/cim/tables/TableCimVersion.kt
+++ b/src/main/kotlin/com/zepben/evolve/database/sqlite/cim/tables/TableCimVersion.kt
@@ -13,4 +13,4 @@ import com.zepben.evolve.database.sqlite.common.SqliteTableVersion
 /**
  * The `version` table in the CIM databases. Increment this when doing a schema update.
  */
-val tableCimVersion: SqliteTableVersion = SqliteTableVersion(58)
+val tableCimVersion: SqliteTableVersion = SqliteTableVersion(59)

--- a/src/main/kotlin/com/zepben/evolve/database/sqlite/cim/tables/associations/TableAssetsPowerSystemResources.kt
+++ b/src/main/kotlin/com/zepben/evolve/database/sqlite/cim/tables/associations/TableAssetsPowerSystemResources.kt
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2024 Zeppelin Bend Pty Ltd
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+package com.zepben.evolve.database.sqlite.cim.tables.associations
+
+import com.zepben.evolve.database.sql.Column
+import com.zepben.evolve.database.sql.Column.Nullable.NOT_NULL
+import com.zepben.evolve.database.sqlite.common.SqliteTable
+
+/**
+ * A class representing the association between Assets and PowerSystemResources.
+ *
+ * @property ASSET_MRID A column storing the mRID of Assets.
+ * @property POWER_SYSTEM_RESOURCE_MRID A column storing the mRID of PowerSystemResources.
+ */
+@Suppress("PropertyName")
+class TableAssetsPowerSystemResources : SqliteTable() {
+
+    val ASSET_MRID: Column = Column(++columnIndex, "asset_mrid", "TEXT", NOT_NULL)
+    val POWER_SYSTEM_RESOURCE_MRID: Column = Column(++columnIndex, "power_system_resource_mrid", "TEXT", NOT_NULL)
+
+    override val name: String = "assets_power_system_resources"
+
+    override val uniqueIndexColumns: MutableList<List<Column>> =
+        super.uniqueIndexColumns.apply {
+            add(listOf(ASSET_MRID, POWER_SYSTEM_RESOURCE_MRID))
+        }
+
+    override val nonUniqueIndexColumns: MutableList<List<Column>> =
+        super.nonUniqueIndexColumns.apply {
+            add(listOf(ASSET_MRID))
+            add(listOf(POWER_SYSTEM_RESOURCE_MRID))
+        }
+
+}

--- a/src/main/kotlin/com/zepben/evolve/database/sqlite/cim/upgrade/UpgradeRunner.kt
+++ b/src/main/kotlin/com/zepben/evolve/database/sqlite/cim/upgrade/UpgradeRunner.kt
@@ -43,7 +43,8 @@ class UpgradeRunner @JvmOverloads constructor(
         changeSet55(),
         changeSet56(),
         changeSet57(),
-        changeSet58()
+        changeSet58(),
+        changeSet59(),
     ),
     private val tableVersion: SqliteTableVersion = tableCimVersion
 ) {

--- a/src/main/kotlin/com/zepben/evolve/database/sqlite/cim/upgrade/changesets/ChangeSet59.kt
+++ b/src/main/kotlin/com/zepben/evolve/database/sqlite/cim/upgrade/changesets/ChangeSet59.kt
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2024 Zeppelin Bend Pty Ltd
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+package com.zepben.evolve.database.sqlite.cim.upgrade.changesets
+
+import com.zepben.evolve.database.paths.DatabaseType
+import com.zepben.evolve.database.sqlite.cim.upgrade.Change
+import com.zepben.evolve.database.sqlite.cim.upgrade.ChangeSet
+
+internal fun changeSet59() = ChangeSet(
+    59,
+    listOf(
+        // Network Change
+        `Create asset to power system resource association table`
+    )
+)
+
+// ###################
+// # Network Changes #
+// ###################
+
+@Suppress("ObjectPropertyName")
+private val `Create asset to power system resource association table` = Change(
+    listOf(
+        """CREATE TABLE assets_power_system_resources (
+            asset_mrid TEXT NOT_NULL,
+            power_system_resource_mrid TEXT NOT_NULL
+        );""".trimIndent(),
+        "CREATE UNIQUE INDEX asset_mrid_power_system_resource_mrid ON assets_power_system_resources (asset_mrid, power_system_resource_mrid);",
+        "CREATE INDEX assets_power_system_resources_asset_mrid ON assets_power_system_resources (asset_mrid);",
+        "CREATE INDEX assets_power_system_resources_power_system_resource_mrid ON assets_power_system_resources (power_system_resource_mrid);"
+    ),
+    targetDatabases = setOf(DatabaseType.NETWORK_MODEL)
+)

--- a/src/main/kotlin/com/zepben/evolve/services/common/ReferenceResolvers.kt
+++ b/src/main/kotlin/com/zepben/evolve/services/common/ReferenceResolvers.kt
@@ -503,6 +503,14 @@ internal object EndDeviceToEndDeviceFunctionResolver : ReferenceResolver<EndDevi
     EndDevice::class, EndDeviceFunction::class, EndDevice::addFunction
 )
 
+internal object AssetToPowerSystemResourceResolver: ReferenceResolver<Asset, PowerSystemResource> by KReferenceResolver(
+    Asset::class, PowerSystemResource::class, Asset::addPowerSystemResource
+)
+
+internal object PowerSystemResourceToAssetResolver: ReferenceResolver<PowerSystemResource, Asset> by KReferenceResolver(
+    PowerSystemResource::class, Asset::class, PowerSystemResource::addAsset
+)
+
 //-------------------------------------------//
 
 class KReferenceResolver<T : IdentifiedObject, R : IdentifiedObject>(

--- a/src/main/kotlin/com/zepben/evolve/services/common/Resolvers.kt
+++ b/src/main/kotlin/com/zepben/evolve/services/common/Resolvers.kt
@@ -546,4 +546,12 @@ object Resolvers {
     fun endDeviceFunctions(endDevice: EndDevice): BoundReferenceResolver<EndDevice, EndDeviceFunction> =
         BoundReferenceResolver(endDevice, EndDeviceToEndDeviceFunctionResolver, null)
 
+    @JvmStatic
+    fun powerSystemResources(asset: Asset): BoundReferenceResolver<Asset, PowerSystemResource> =
+        BoundReferenceResolver(asset, AssetToPowerSystemResourceResolver, PowerSystemResourceToAssetResolver)
+
+    @JvmStatic
+    fun assets(powerSystemResource: PowerSystemResource): BoundReferenceResolver<PowerSystemResource, Asset> =
+        BoundReferenceResolver(powerSystemResource, PowerSystemResourceToAssetResolver, AssetToPowerSystemResourceResolver)
+
 }

--- a/src/main/kotlin/com/zepben/evolve/services/network/NetworkServiceComparator.kt
+++ b/src/main/kotlin/com/zepben/evolve/services/network/NetworkServiceComparator.kt
@@ -217,6 +217,7 @@ class NetworkServiceComparator @JvmOverloads constructor(
 
             compareIdReferences(Asset::location)
             compareIdReferenceCollections(Asset::organisationRoles)
+            compareIdReferenceCollections(Asset::powerSystemResources)
         }
 
     private fun ObjectDifference<out AssetContainer>.compareAssetContainer(): ObjectDifference<out AssetContainer> =
@@ -491,6 +492,8 @@ class NetworkServiceComparator @JvmOverloads constructor(
             compareIdentifiedObject()
 
             compareIdReferences(PowerSystemResource::assetInfo, PowerSystemResource::location)
+            compareIdReferenceCollections(PowerSystemResource::assets)
+
             compareValues(PowerSystemResource::numControls)
         }
 

--- a/src/main/kotlin/com/zepben/evolve/services/network/tracing/feeder/AssignToFeeders.kt
+++ b/src/main/kotlin/com/zepben/evolve/services/network/tracing/feeder/AssignToFeeders.kt
@@ -10,6 +10,7 @@ package com.zepben.evolve.services.network.tracing.feeder
 
 import com.zepben.evolve.cim.iec61970.base.auxiliaryequipment.AuxiliaryEquipment
 import com.zepben.evolve.cim.iec61970.base.core.*
+import com.zepben.evolve.cim.iec61970.base.wires.PowerElectronicsConnection
 import com.zepben.evolve.cim.iec61970.base.wires.PowerTransformer
 import com.zepben.evolve.cim.iec61970.base.wires.ProtectedSwitch
 import com.zepben.evolve.cim.iec61970.base.wires.Switch
@@ -135,6 +136,7 @@ class AssignToFeeders {
             when (stepPath.toEquipment) {
                 is PowerTransformer -> feedersToAssign.tryEnergizeLvFeeders(stepPath.toEquipment, lvFeederStartPoints)
                 is ProtectedSwitch -> feedersToAssign.associateRelaySystems(stepPath.toEquipment)
+                is PowerElectronicsConnection -> feedersToAssign.associatePowerElectronicUnits(stepPath.toEquipment)
             }
         }
 
@@ -151,6 +153,10 @@ class AssignToFeeders {
 
         private fun Iterable<EquipmentContainer>.associateRelaySystems(toEquipment: ProtectedSwitch) {
             associateEquipment(toEquipment.relayFunctions.flatMap { it.schemes }.mapNotNull { it.system })
+        }
+
+        private fun Iterable<EquipmentContainer>.associatePowerElectronicUnits(toEquipment: PowerElectronicsConnection) {
+            associateEquipment(toEquipment.units)
         }
 
         private fun Iterable<Feeder>.tryEnergizeLvFeeders(toEquipment: PowerTransformer, lvFeederStartPoints: Set<ConductingEquipment>) {

--- a/src/main/kotlin/com/zepben/evolve/services/network/tracing/feeder/AssignToLvFeeders.kt
+++ b/src/main/kotlin/com/zepben/evolve/services/network/tracing/feeder/AssignToLvFeeders.kt
@@ -10,6 +10,7 @@ package com.zepben.evolve.services.network.tracing.feeder
 
 import com.zepben.evolve.cim.iec61970.base.auxiliaryequipment.AuxiliaryEquipment
 import com.zepben.evolve.cim.iec61970.base.core.*
+import com.zepben.evolve.cim.iec61970.base.wires.PowerElectronicsConnection
 import com.zepben.evolve.cim.iec61970.base.wires.ProtectedSwitch
 import com.zepben.evolve.cim.iec61970.base.wires.Switch
 import com.zepben.evolve.cim.iec61970.infiec61970.feeder.LvFeeder
@@ -167,6 +168,7 @@ class AssignToLvFeeders {
 
             when (stepPath.toEquipment) {
                 is ProtectedSwitch -> lvFeedersToAssign.associateRelaySystems(stepPath.toEquipment)
+                is PowerElectronicsConnection -> lvFeedersToAssign.associatePowerElectronicUnits(stepPath.toEquipment)
             }
         }
 
@@ -194,6 +196,10 @@ class AssignToLvFeeders {
 
         private fun Iterable<EquipmentContainer>.associateRelaySystems(toEquipment: ProtectedSwitch) {
             associateEquipment(toEquipment.relayFunctions.flatMap { it.schemes }.mapNotNull { it.system })
+        }
+
+        private fun Iterable<EquipmentContainer>.associatePowerElectronicUnits(toEquipment: PowerElectronicsConnection) {
+            associateEquipment(toEquipment.units)
         }
 
         private fun Iterable<LvFeeder>.energizedBy(feeders: Iterable<Feeder>) = forEach { lvFeeder ->

--- a/src/main/kotlin/com/zepben/evolve/services/network/translator/NetworkCimToProto.kt
+++ b/src/main/kotlin/com/zepben/evolve/services/network/translator/NetworkCimToProto.kt
@@ -656,6 +656,7 @@ fun toPb(cim: Asset, pb: PBAsset.Builder): PBAsset.Builder =
         cim.location?.let { locationMRID = it.mRID } ?: clearLocationMRID()
         clearOrganisationRoleMRIDs()
         cim.organisationRoles.forEach { addOrganisationRoleMRIDs(it.mRID) }
+        cim.powerSystemResources.forEach { addPowerSystemResourceMRIDs(it.mRID) }
         toPb(cim, ioBuilder)
     }
 
@@ -1294,6 +1295,8 @@ fun toPb(cim: PowerSystemResource, pb: PBPowerSystemResource.Builder): PBPowerSy
     pb.apply {
         cim.location?.let { locationMRID = it.mRID } ?: clearLocationMRID()
         cim.assetInfo?.let { assetInfoMRID = it.mRID } ?: clearAssetInfoMRID()
+        cim.assets.forEach { addAssetMRIDs(it.mRID) }
+
         numControls = cim.numControls
         toPb(cim, ioBuilder)
     }

--- a/src/main/kotlin/com/zepben/evolve/services/network/translator/NetworkProtoToCim.kt
+++ b/src/main/kotlin/com/zepben/evolve/services/network/translator/NetworkProtoToCim.kt
@@ -503,6 +503,10 @@ fun toCim(pb: PBAsset, cim: Asset, networkService: NetworkService): Asset =
         pb.organisationRoleMRIDsList.forEach {
             networkService.resolveOrDeferReference(Resolvers.organisationRoles(this), it)
         }
+        pb.powerSystemResourceMRIDsList.forEach {
+            networkService.resolveOrDeferReference(Resolvers.powerSystemResources(this), it)
+        }
+
         toCim(pb.io, this, networkService)
     }
 
@@ -1179,6 +1183,9 @@ fun toCim(pb: PBPowerSystemResource, cim: PowerSystemResource, networkService: N
         // NOTE: assetInfoMRID will be handled by classes that use it with specific types.
 
         networkService.resolveOrDeferReference(Resolvers.location(this), pb.locationMRID)
+        pb.assetMRIDsList.forEach { assetMRID ->
+            networkService.resolveOrDeferReference(Resolvers.assets(this), assetMRID)
+        }
         numControls = pb.numControls
         toCim(pb.io, this, networkService)
     }

--- a/src/test/kotlin/com/zepben/evolve/cim/iec61968/assets/AssetTest.kt
+++ b/src/test/kotlin/com/zepben/evolve/cim/iec61968/assets/AssetTest.kt
@@ -9,6 +9,7 @@
 package com.zepben.evolve.cim.iec61968.assets
 
 import com.zepben.evolve.cim.iec61968.common.Location
+import com.zepben.evolve.cim.iec61970.base.core.PowerSystemResource
 import com.zepben.evolve.utils.PrivateCollectionValidator
 import com.zepben.testutils.junit.SystemLogExtension
 import org.hamcrest.MatcherAssert.assertThat
@@ -51,6 +52,20 @@ internal class AssetTest {
             Asset::addOrganisationRole,
             Asset::removeOrganisationRole,
             Asset::clearOrganisationRoles
+        )
+    }
+
+    @Test
+    internal fun powerSystemResources() {
+        PrivateCollectionValidator.validateUnordered(
+            { object : Asset() {} },
+            { id -> object : PowerSystemResource(id) {} },
+            Asset::powerSystemResources,
+            Asset::numPowerSystemResources,
+            Asset::getPowerSystemResource,
+            Asset::addPowerSystemResource,
+            Asset::removePowerSystemResource,
+            Asset::clearPowerSystemResources
         )
     }
 }

--- a/src/test/kotlin/com/zepben/evolve/cim/iec61970/base/core/PowerSystemResourceTest.kt
+++ b/src/test/kotlin/com/zepben/evolve/cim/iec61970/base/core/PowerSystemResourceTest.kt
@@ -8,7 +8,9 @@
 
 package com.zepben.evolve.cim.iec61970.base.core
 
+import com.zepben.evolve.cim.iec61968.assets.Asset
 import com.zepben.evolve.cim.iec61968.common.Location
+import com.zepben.evolve.utils.PrivateCollectionValidator
 import com.zepben.testutils.junit.SystemLogExtension
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.*
@@ -45,5 +47,19 @@ internal class PowerSystemResourceTest {
         assertThat(powerSystemResource.location, equalTo(location))
         assertThat(powerSystemResource.numControls, equalTo(4))
         assertThat(powerSystemResource.hasControls(), equalTo(true))
+    }
+
+    @Test
+    internal fun assets() {
+        PrivateCollectionValidator.validateUnordered(
+            { object : PowerSystemResource() {} },
+            { id -> object : Asset(id) {} },
+            PowerSystemResource::assets,
+            PowerSystemResource::numAssets,
+            PowerSystemResource::getAsset,
+            PowerSystemResource::addAsset,
+            PowerSystemResource::removeAsset,
+            PowerSystemResource::clearAssets
+        )
     }
 }

--- a/src/test/kotlin/com/zepben/evolve/database/sqlite/cim/upgrade/ChangeSetTest.kt
+++ b/src/test/kotlin/com/zepben/evolve/database/sqlite/cim/upgrade/ChangeSetTest.kt
@@ -9,6 +9,7 @@
 package com.zepben.evolve.database.sqlite.cim.upgrade
 
 import com.zepben.evolve.database.paths.DatabaseType
+import com.zepben.evolve.database.sql.BaseDatabaseTables
 import com.zepben.evolve.database.sqlite.cim.customer.CustomerDatabaseTables
 import com.zepben.evolve.database.sqlite.cim.diagram.DiagramDatabaseTables
 import com.zepben.evolve.database.sqlite.cim.network.NetworkDatabaseTables
@@ -21,7 +22,6 @@ import com.zepben.evolve.database.sqlite.cim.upgrade.changesets.customer.ChangeS
 import com.zepben.evolve.database.sqlite.cim.upgrade.changesets.diagram.ChangeSet50DiagramValidator
 import com.zepben.evolve.database.sqlite.cim.upgrade.changesets.diagram.ChangeSet52DiagramValidator
 import com.zepben.evolve.database.sqlite.cim.upgrade.changesets.network.*
-import com.zepben.evolve.database.sql.BaseDatabaseTables
 import com.zepben.testutils.junit.SystemLogExtension
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.RegisterExtension
@@ -58,7 +58,8 @@ internal class ChangeSetTest {
         NoChanges(DatabaseType.CUSTOMER, 55),
         NoChanges(DatabaseType.CUSTOMER, 56),
         NoChanges(DatabaseType.CUSTOMER, 57),
-        NoChanges(DatabaseType.CUSTOMER, 58)
+        NoChanges(DatabaseType.CUSTOMER, 58),
+        NoChanges(DatabaseType.CUSTOMER, 59)
     ).associateBy { it.version }
 
     private val diagramChangeSetValidators = listOf(
@@ -70,7 +71,8 @@ internal class ChangeSetTest {
         NoChanges(DatabaseType.DIAGRAM, 55),
         NoChanges(DatabaseType.DIAGRAM, 56),
         NoChanges(DatabaseType.DIAGRAM, 57),
-        NoChanges(DatabaseType.DIAGRAM, 58)
+        NoChanges(DatabaseType.DIAGRAM, 58),
+        NoChanges(DatabaseType.DIAGRAM, 59),
     ).associateBy { it.version }
 
     private val networkChangeSetValidators = listOf(
@@ -82,7 +84,8 @@ internal class ChangeSetTest {
         ChangeSet55NetworkValidator,
         ChangeSet56NetworkValidator,
         ChangeSet57NetworkValidator,
-        ChangeSet58NetworkValidator
+        ChangeSet58NetworkValidator,
+        ChangeSet59NetworkValidator
     ).associateBy { it.version }
 
     @Test

--- a/src/test/kotlin/com/zepben/evolve/database/sqlite/cim/upgrade/changesets/network/ChangeSet59NetworkValidator.kt
+++ b/src/test/kotlin/com/zepben/evolve/database/sqlite/cim/upgrade/changesets/network/ChangeSet59NetworkValidator.kt
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2024 Zeppelin Bend Pty Ltd
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+package com.zepben.evolve.database.sqlite.cim.upgrade.changesets.network
+
+import com.zepben.evolve.database.paths.DatabaseType
+import com.zepben.evolve.database.sqlite.cim.upgrade.changesets.ChangeSetValidator
+import org.hamcrest.MatcherAssert.assertThat
+import org.hamcrest.Matchers.equalTo
+import java.sql.Statement
+
+object ChangeSet59NetworkValidator : ChangeSetValidator(DatabaseType.NETWORK_MODEL, 59) {
+
+    //
+    // NOTE: In the validators we are only checking the columns that were actually changed.
+    //
+
+    override fun setUpStatements(): List<String> = listOf(
+    )
+
+    override fun populateStatements(): List<String> = listOf(
+        "INSERT INTO assets_power_system_resources (asset_mrid, power_system_resource_mrid) VALUES ('asset_mrid', 'power_system_resource_mrid');",
+        )
+
+    override fun validateChanges(statement: Statement) {
+        ensureAddedAssetsPowerSystemResources(statement)
+        validateRows(statement, "SELECT * FROM assets_power_system_resources",
+            { rs ->
+                assertThat(rs.getString("asset_mrid"), equalTo("asset_mrid"))
+                assertThat(rs.getString("power_system_resource_mrid"), equalTo("power_system_resource_mrid"))
+            }
+        )
+    }
+
+    override fun tearDownStatements(): List<String> =
+        listOf(
+            "DELETE FROM assets_power_system_resources;",
+        )
+
+
+    private fun ensureAddedAssetsPowerSystemResources(statement: Statement) {
+        ensureTables(statement, "assets_power_system_resources")
+        ensureIndexes(
+            statement,
+            "assets_power_system_resources_asset_mrid",
+            "assets_power_system_resources_asset_mrid",
+            "assets_power_system_resources_power_system_resource_mrid"
+        )
+    }
+
+}

--- a/src/test/kotlin/com/zepben/evolve/services/network/testdata/FillFields.kt
+++ b/src/test/kotlin/com/zepben/evolve/services/network/testdata/FillFields.kt
@@ -241,6 +241,12 @@ fun Asset.fillFields(service: NetworkService, includeRuntime: Boolean = true): A
     (this as IdentifiedObject).fillFieldsCommon(service, includeRuntime)
 
     addOrganisationRole(AssetOwner().also { service.add(it) })
+    for (i in 0..1)
+        addPowerSystemResource(Junction().also {
+            it.addAsset(this)
+            service.add(it)
+        })
+
     location = Location().also { service.add(it) }
 
     return this
@@ -654,6 +660,12 @@ fun PowerSystemResource.fillFields(service: NetworkService, includeRuntime: Bool
 
     location = Location().apply { addPoint(PositionPoint(3.3, 4.4)) }.also { service.add(it) }
     numControls = 5
+
+    for (i in 0..1)
+        addAsset(Pole().also {
+            it.addPowerSystemResource(this)
+            service.add(it)
+        })
 
     return this
 }

--- a/src/test/kotlin/com/zepben/evolve/services/network/tracing/feeder/AssignToFeedersTest.kt
+++ b/src/test/kotlin/com/zepben/evolve/services/network/tracing/feeder/AssignToFeedersTest.kt
@@ -18,6 +18,8 @@ import com.zepben.evolve.cim.iec61970.base.protection.ProtectionRelayScheme
 import com.zepben.evolve.cim.iec61970.base.protection.ProtectionRelaySystem
 import com.zepben.evolve.cim.iec61970.base.wires.Junction
 import com.zepben.evolve.cim.iec61970.base.wires.ProtectedSwitch
+import com.zepben.evolve.cim.iec61970.base.wires.generation.production.PhotoVoltaicUnit
+import com.zepben.evolve.cim.iec61970.base.wires.generation.production.PowerElectronicsUnit
 import com.zepben.evolve.services.network.getT
 import com.zepben.evolve.services.network.testdata.*
 import com.zepben.evolve.services.network.tracing.networktrace.operators.NetworkStateOperators
@@ -203,6 +205,25 @@ internal class AssignToFeedersTest {
         assignToFeeders.run(network, NetworkStateOperators.NORMAL)
 
         validateEquipment(feeder.equipment, "b0", "prsys3")
+    }
+
+    @Test
+    internal fun `assigns PowerElectronicUnits to Feeder`() {
+        val peu1 = PhotoVoltaicUnit("peu1")
+
+        val network = TestNetworkBuilder()
+            .fromBreaker() // b0
+            .toPowerElectronicsConnection { addUnit(peu1); peu1.powerElectronicsConnection = this }  // pec1
+            .addFeeder("b0")
+            .network
+
+        network.add(peu1)
+
+        val feeder: Feeder = network["fdr2"]!!
+
+        assignToFeeders.run(network, NetworkStateOperators.NORMAL)
+
+        validateEquipment(feeder.equipment, "b0", "pec1", "peu1")
     }
 
     @Test

--- a/src/test/kotlin/com/zepben/evolve/services/network/tracing/feeder/AssignToLvFeedersTest.kt
+++ b/src/test/kotlin/com/zepben/evolve/services/network/tracing/feeder/AssignToLvFeedersTest.kt
@@ -18,6 +18,7 @@ import com.zepben.evolve.cim.iec61970.base.protection.ProtectionRelayScheme
 import com.zepben.evolve.cim.iec61970.base.protection.ProtectionRelaySystem
 import com.zepben.evolve.cim.iec61970.base.wires.Breaker
 import com.zepben.evolve.cim.iec61970.base.wires.ProtectedSwitch
+import com.zepben.evolve.cim.iec61970.base.wires.generation.production.PhotoVoltaicUnit
 import com.zepben.evolve.cim.iec61970.infiec61970.feeder.LvFeeder
 import com.zepben.evolve.services.network.getT
 import com.zepben.evolve.services.network.lvFeederStartPoints
@@ -259,6 +260,25 @@ internal class AssignToLvFeedersTest {
         assignToLvFeeders.run(network, NetworkStateOperators.NORMAL)
 
         validateEquipment(lvFeeder.equipment, "b0", "prsys3")
+    }
+
+    @Test
+    internal fun `assigns PowerElectronicUnits to Feeder`() {
+        val peu1 = PhotoVoltaicUnit("peu1")
+
+        val network = TestNetworkBuilder()
+            .fromBreaker() // b0
+            .toPowerElectronicsConnection { addUnit(peu1); peu1.powerElectronicsConnection = this }  // pec1
+            .addLvFeeder("b0")
+            .network
+
+        network.add(peu1)
+
+        val feeder: LvFeeder = network["lvf2"]!!
+
+        assignToLvFeeders.run(network, NetworkStateOperators.NORMAL)
+
+        validateEquipment(feeder.equipment, "b0", "pec1", "peu1")
     }
 
     @Test

--- a/src/test/kotlin/com/zepben/evolve/services/network/translator/NetworkTranslatorTest.kt
+++ b/src/test/kotlin/com/zepben/evolve/services/network/translator/NetworkTranslatorTest.kt
@@ -11,10 +11,7 @@ package com.zepben.evolve.services.network.translator
 import com.zepben.evolve.cim.extensions.iec61968.metering.PanDemandResponseFunction
 import com.zepben.evolve.cim.extensions.iec61970.base.wires.BatteryControl
 import com.zepben.evolve.cim.iec61968.assetinfo.*
-import com.zepben.evolve.cim.iec61968.assets.AssetOrganisationRole
-import com.zepben.evolve.cim.iec61968.assets.AssetOwner
-import com.zepben.evolve.cim.iec61968.assets.Pole
-import com.zepben.evolve.cim.iec61968.assets.Streetlight
+import com.zepben.evolve.cim.iec61968.assets.*
 import com.zepben.evolve.cim.iec61968.common.Location
 import com.zepben.evolve.cim.iec61968.common.Organisation
 import com.zepben.evolve.cim.iec61968.infiec61968.infassetinfo.CurrentTransformerInfo
@@ -195,6 +192,7 @@ internal class NetworkTranslatorTest : TranslatorTestBase<NetworkService>(
 
     override val abstractCreators = mapOf<Class<*>, (String) -> IdentifiedObject>(
         AssetOrganisationRole::class.java to { AssetOwner(it) },
+        Asset::class.java to { Pole(it) },
         ConductingEquipment::class.java to { Junction(it) },
         Curve::class.java to { ReactiveCapabilityCurve(it) },
         EarthFaultCompensator::class.java to { GroundingImpedance(it) },
@@ -204,6 +202,7 @@ internal class NetworkTranslatorTest : TranslatorTestBase<NetworkService>(
         EquipmentContainer::class.java to { Site(it) },
         Measurement::class.java to { Discrete(it) },
         PerLengthImpedance::class.java to { PerLengthSequenceImpedance(it) },
+        PowerSystemResource::class.java to { Junction(it) },
         ProtectionRelayFunction::class.java to { CurrentRelay(it) },
         ProtectedSwitch::class.java to { Breaker(it) },
         RegulatingControl::class.java to { TapChangerControl(it) },
@@ -218,6 +217,7 @@ internal class NetworkTranslatorTest : TranslatorTestBase<NetworkService>(
         super.excludedTables + setOf(
             // Excluded associations
             TableAssetOrganisationRolesAssets::class,
+            TableAssetsPowerSystemResources::class,
             TableBatteryUnitsBatteryControls::class,
             TableCircuitsSubstations::class,
             TableCircuitsTerminals::class,


### PR DESCRIPTION
# Description

As per title - pretty straightforward, however have also included an update to evolve-conn which fixes some server side auth issues.
And have included a fix to AssignTo[Lv]Feeders to assign PowerElectronicUnits to the feeder as well.

# Associated tasks
Depends on:

- https://github.com/zepben/ewb-grpc/pull/128


# Test Steps

Once EWB PR is done you can try link a Pole to a conductor in an ingestor, build a model, and see if you can retrieve that relationship through the NetworkConsumerClient.

Or you can just run the tests and pray.

# Checklist

If any of these are not applicable, strikethrough the line `~like this~`. **Do not delete it!**. Let the reviewer decide if you should have done it.

### Code
- [x] I have performed a self review of my own code (including checking issues raised when creating the PR).
- [x] I have added/updated unit tests for these changes, and if not I have explained why they are not necessary.
- [x] I have commented my code in any hard-to-understand or hacky areas.
- [x] I have handled all new warnings generated by the compiler or IDE.
- [x] I have rebased onto the target branch (usually main).

### Documentation
- [x] I have updated the changelog.
- [x] I have updated any documentation required for these changes.

# Breaking Changes
- [x] I have considered if this is a breaking change and will communicate it with other team members by posting it on the Slack **breaking-changes** channel.

Not breaking - I think should maintain compatibility with older versions of EWB
