### PR TITLE
Fix  QueryNetworkStateService.reportBatchStatus oncomplete

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -10,7 +10,7 @@
 * None.
 
 ### Fixes
-* None.
+* `QueryNetworkStateService.reportBatchStatus` now correctly sends the `Empty` response.
 
 ### Notes
 * None.

--- a/src/main/kotlin/com/zepben/evolve/streaming/get/QueryNetworkStateService.kt
+++ b/src/main/kotlin/com/zepben/evolve/streaming/get/QueryNetworkStateService.kt
@@ -14,6 +14,7 @@ import com.zepben.evolve.services.common.translator.toLocalDateTime
 import com.zepben.evolve.streaming.data.CurrentStateEvent
 import com.zepben.evolve.streaming.data.CurrentStateEventBatch
 import com.zepben.evolve.streaming.data.SetCurrentStatesStatus
+import com.zepben.evolve.streaming.get.QueryNetworkStateService.ProcessingErrorHandler
 import com.zepben.protobuf.connection.CheckConnectionRequest
 import com.zepben.protobuf.ns.GetCurrentStatesRequest
 import com.zepben.protobuf.ns.GetCurrentStatesResponse
@@ -166,7 +167,10 @@ class QueryNetworkStateService(
 
             override fun onError(e: Throwable) = throw e
 
-            override fun onCompleted() = responseObserver.onCompleted()
+            override fun onCompleted() {
+                responseObserver.onNext(Empty.getDefaultInstance())
+                responseObserver.onCompleted()
+            }
 
         }
 

--- a/src/test/kotlin/com/zepben/evolve/streaming/get/QueryNetworkStateServiceTest.kt
+++ b/src/test/kotlin/com/zepben/evolve/streaming/get/QueryNetworkStateServiceTest.kt
@@ -97,7 +97,10 @@ internal class QueryNetworkStateServiceTest {
 
     @Test
     internal fun `can receive status responses`() {
-        val responseObserver = mockk<StreamObserver<Empty>> { justRun { onCompleted() } }
+        val responseObserver = mockk<StreamObserver<Empty>> {
+            justRun { onCompleted() }
+            justRun { onNext(any()) }
+        }
         val requestObserver = service.reportBatchStatus(responseObserver)
 
         requestObserver.onNext(BatchNotProcessed(1L).toPb())
@@ -111,6 +114,7 @@ internal class QueryNetworkStateServiceTest {
         verifySequence {
             onCurrentStatesStatus(capture(statuses))
             onCurrentStatesStatus(capture(statuses))
+            responseObserver.onNext(any())
             responseObserver.onCompleted()
         }
 
@@ -120,7 +124,10 @@ internal class QueryNetworkStateServiceTest {
 
     @Test
     internal fun `calls process error handler with unknown status responses`() {
-        val responseObserver = mockk<StreamObserver<Empty>> { justRun { onCompleted() } }
+        val responseObserver = mockk<StreamObserver<Empty>> {
+            justRun { onCompleted() }
+            justRun { onNext(any()) }
+        }
         val requestObserver = service.reportBatchStatus(responseObserver)
 
         // Not sure if/how we can set this to something not supported like you would get from a future version, so just leave it blank.
@@ -130,6 +137,7 @@ internal class QueryNetworkStateServiceTest {
         val error = slot<GrpcException>()
         verifySequence {
             onProcessingError(capture(error))
+            responseObserver.onNext(any())
             responseObserver.onCompleted()
         }
 


### PR DESCRIPTION
# Description

`QueryNetworkStateService.reportBatchStatus` now correctly sends the `Empty` response.

# Associated tasks

List any other tasks / PRs that are required to be merged alongside this one (e.g. front end task for back end change or vice versa). If a PR exists, add a link. If not, just add an appropriate note here so reviewers know there is a dependency and will hold off merging until all things are ready.

# Test Steps

Explain in detail how your reviewer can test the changes proposed in this PR. If it cannot be tested, leave an explanation on why.

# Checklist

If any of these are not applicable, strikethrough the line `~like this~`. **Do not delete it!**. Let the reviewer decide if you should have done it.

### Code
- [x] I have performed a self review of my own code (including checking issues raised when creating the PR).
- [x] I have added/updated unit tests for these changes, and if not I have explained why they are not necessary.
- [x] I have commented my code in any hard-to-understand or hacky areas.
- [x] I have handled all new warnings generated by the compiler or IDE.
- [x] I have rebased onto the target branch (usually main).

### Documentation
- [x] I have updated the changelog.
~- [ ] I have updated any documentation required for these changes.~

# Breaking Changes
- [x] I have considered if this is a breaking change and will communicate it with other team members by posting it on the Slack **breaking-changes** channel.
Not a breaking change
