### PR TITLE
DEV-3252 Update grpc version to support customer level load

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -97,7 +97,7 @@
 * Added `com.zepben.ewb.issues` package including `IssuesLog`, `IssueTracker` and `IssueTrackerGroup` for tracking issues.
 
 ### Enhancements
-* None.
+* Upgrade ewb-grpc to 1.0.0 to support customer level load results.
 
 ### Fixes
 * Fixed bug that would cause a null pointer exception when processing metrics job sources with a null metadata timestamp

--- a/pom.xml
+++ b/pom.xml
@@ -68,7 +68,7 @@
         <dependency>
             <groupId>com.zepben</groupId>
             <artifactId>protobuf</artifactId>
-            <version>1.0.0b1</version>
+            <version>1.0.0b2</version>
         </dependency>
         <dependency>
             <groupId>com.zepben</groupId>


### PR DESCRIPTION
# Description

Update evolve-grpc from 0.36.0 to 1.0.0 to support customer level load results in HCS.

There were no changes in 0.37.0.

# Associated tasks

 - https://github.com/zepben/ewb-grpc/pull/131

Next down the chain:
- https://github.com/zepben/network-verifier-lib/pull/72

# Test Steps

No relevance to this code.

# Checklist

If any of these are not applicable, strikethrough the line `~like this~`. **Do not delete it!**. Let the reviewer decide if you should have done it.

### Code
- [x] I have performed a self review of my own code (including checking issues raised when creating the PR).
- [ ] ~I have added/updated unit tests for these changes, and if not~ I have explained why they are not necessary. **Only a dependency update.**
- [x] I have commented my code in any hard-to-understand or hacky areas.
- [x] I have handled all new warnings generated by the compiler or IDE.
- [x] I have rebased onto the target branch (usually main).

### Documentation
- [x] I have updated the changelog.
- [ ] ~I have updated any documentation required for these changes.~

# Breaking Changes
- [x] I have considered if this is a breaking change and will communicate it with other team members by posting it on the Slack **breaking-changes** channel.

Only dependency updates. It is a GRPC change so everything should be using matching versions regardless.
 