### PR TITLE
Fixed bug that would cause a null pointer exception when processing metrics job sources with a null metadata timestamp

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -100,6 +100,7 @@
 * None.
 
 ### Fixes
+* Fixed bug that would cause a null pointer exception when processing metrics job sources with a null metadata timestamp
 * Marked some extensions properties and classes with [ZBEX] that were missing them (might still be more). In addition to the ones moved into the extensions
   package:
   * `PhaseCode.Y`

--- a/src/main/kotlin/com/zepben/ewb/database/postgres/metrics/MetricsEntryWriter.kt
+++ b/src/main/kotlin/com/zepben/ewb/database/postgres/metrics/MetricsEntryWriter.kt
@@ -59,7 +59,7 @@ internal class MetricsEntryWriter(
 
         insert.setObject(table.JOB_ID.queryIndex, jobId)
         insert.setString(table.DATA_SOURCE.queryIndex, sourceName)
-        insert.setTimestamp(table.SOURCE_TIME.queryIndex, Timestamp.from(sourceMetadata.timestamp))
+        insert.setTimestamp(table.SOURCE_TIME.queryIndex, sourceMetadata.timestamp?.let { Timestamp.from(it) })
         insert.setObject(table.FILE_SHA.queryIndex, sourceMetadata.fileHash)
 
         return insert.tryExecuteSingleUpdate("job source")


### PR DESCRIPTION
# Description

The Ops teams was having issues with the gis-network-extractor because it would fail with a null pointer exception when processing metrics job sources with null timestamps. 
The schema supports a null timestamp and we have customers with metrics data that have a null timestamp so it should support handling a null timestamp.

# Associated tasks
NONE

# Test Steps
Try to process a job source that has a null timestamp in its metadata. It will work now, it did not before this fix.

# Checklist

If any of these are not applicable, strikethrough the line `~like this~`. **Do not delete it!**. Let the reviewer decide if you should have done it.

### Code
- [X] I have performed a self review of my own code (including checking issues raised when creating the PR).
- [X] I have added/updated unit tests for these changes, and if not I have explained why they are not necessary.
~- [ ] I have commented my code in any hard-to-understand or hacky areas.~ nothing hacky about the fix
- [X] I have handled all new warnings generated by the compiler or IDE.
- [X] I have rebased onto the target branch (usually main).

### Security
When developing applications, use following guidelines for information security considerations:
* Access to applications should be protected with security keys/tokens or usernames and passwords;
* All sessions are encrypted if possible;
* All application input is sanitised before being acted on (ie SQL statements, etc);
* Log messages, and especially client-facing ones, must be handled securely and must not leak credentials information (internal URLs, passwords, tokens).

- [X] I have considered if this change impacts information security and made sure those impacts are handled.

### Documentation
- [X] I have updated the changelog.
~- [ ] I have updated any documentation required for these changes.~ not doco change required

# Breaking Changes
- [X] I have considered if this is a breaking change and will communicate it with other team members by posting it on the Slack **breaking-changes** channel.

Not a breaking change.