### PR TITLE
[DEV-3981] Fixed a bug in the LV feeder assignment when processing sites in the current state.

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -10,7 +10,8 @@
 * None.
 
 ### Fixes
-* None.
+* Fixed a bug in the LV feeder assignment when processing sites in the current state of the network. This prevented LV feeders on switches (rather than the
+  transformer) from being assigned to the current state energising feeder.
 
 ### Notes
 * None.

--- a/src/main/kotlin/com/zepben/ewb/services/network/tracing/feeder/AssignToLvFeeders.kt
+++ b/src/main/kotlin/com/zepben/ewb/services/network/tracing/feeder/AssignToLvFeeders.kt
@@ -187,7 +187,11 @@ class AssignToLvFeeders(
         private fun ConductingEquipment.findLvFeeders(lvFeederStartPoints: Set<ConductingEquipment>): Iterable<LvFeeder> {
             // Check to see if the LV feeder head is part of a dist transformer site. If so, we want to find all LV feeders on any equipment
             // in the site, not just the LV feeder of the head we found.
-            val sites = getFilteredContainers<Site>(stateOperators)
+            //
+            // NOTE: Sites aren't added to the current state containers, so they will always need to be looked up from the normal containers,
+            //       regardless of the state operators being used.
+            //
+            val sites = containers.filterIsInstance<Site>()
             return if (sites.isNotEmpty())
                 sites.findLvFeeders(lvFeederStartPoints, stateOperators)
             else


### PR DESCRIPTION
# Description

Fixes a bug reported in the Jemena network where LV feeders weren't be assigned to the energising feeders in the current state of the network. This was found to be due to using the state operators to look for sites, but sites are only part of the normal state of the network.

# Associated tasks

- https://github.com/zepben/commons/pull/94
- https://github.com/zepben/ewb-sdk-python/pull/202

# Test Steps

Unit tests.

# Checklist

If any of these are not applicable, strikethrough the line `~like this~`. **Do not delete it!**. Let the reviewer decide if you should have done it.

### Code
- [x] I have performed a self review of my own code (including checking issues raised when creating the PR).
- [x] I have added/updated unit tests for these changes, and if not I have explained why they are not necessary.
- [x] I have commented my code in any hard-to-understand or hacky areas.
- [x] I have handled all new warnings generated by the compiler or IDE.
- [x] I have rebased onto the target branch (usually main).

### Security
When developing applications, use following guidelines for information security considerations:
* Access to applications should be protected with security keys/tokens or usernames and passwords;
* All sessions are encrypted if possible;
* All application input is sanitised before being acted on (ie SQL statements, etc);
* Log messages, and especially client-facing ones, must be handled securely and must not leak credentials information (internal URLs, passwords, tokens).

- [x] I have considered if this change impacts information security and made sure those impacts are handled.

### Documentation
- [x] I have updated the changelog.
~- [ ] I have updated any documentation required for these changes.~

# Breaking Changes
- [x] I have considered if this is a breaking change and will communicate it with other team members by posting it on the Slack **breaking-changes** channel.

Non-breaking