### PR TITLE
Re-enabled tests and fixed test errors since moving to Kotlin 2.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -168,7 +168,7 @@
         <dependency>
             <groupId>com.zepben</groupId>
             <artifactId>test-utils</artifactId>
-            <version>3.2.0</version>
+            <version>3.3.1</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/src/main/kotlin/com/zepben/ewb/services/network/tracing/feeder/AssignToFeeders.kt
+++ b/src/main/kotlin/com/zepben/ewb/services/network/tracing/feeder/AssignToFeeders.kt
@@ -185,6 +185,8 @@ class AssignToFeeders(
             val sites = toEquipment.containers.filterIsInstance<Site>()
             val substations = toEquipment.containers.filterIsInstance<LvSubstation>()
             if (substations.isNotEmpty()) {
+                //todo no need to search. substations.findLvFeeders should be replaced with substations.normalEnergizedLvFeeders.
+                //todo update ewb-network-routes. Search for "`LvSubstation.normalEnergizedLvFeeders`"
                 energizes(substations.findLvFeeders(lvFeederStartPoints, stateOperators))
                 // Also energise any LvSubstations found on the transformer. LvSubstations should gradually replace Sites.
                 energizesLvSubstations(substations)

--- a/src/test/java/com/zepben/ewb/services/common/BaseServiceJavaTest.java
+++ b/src/test/java/com/zepben/ewb/services/common/BaseServiceJavaTest.java
@@ -31,8 +31,7 @@ import static org.hamcrest.Matchers.*;
 
 class BaseServiceJavaTest {
 
-    @RegisterExtension
-    static SystemLogExtension systemErr = SystemLogExtension.SYSTEM_ERR.captureLog().muteOnSuccess();
+    @RegisterExtension final static SystemLogExtension systemErr = SystemLogExtension.SYSTEM_ERR.captureLog().muteOnSuccess();
 
     private final BaseService service = new BaseServiceTest.TestBaseService();
     private final Breaker breaker1 = create(service, Breaker::new);

--- a/src/test/kotlin/com/zepben/ewb/TestsTest.kt
+++ b/src/test/kotlin/com/zepben/ewb/TestsTest.kt
@@ -1,20 +1,19 @@
 /*
- * Copyright 2025 Zeppelin Bend Pty Ltd
+ * Copyright 2026 Zeppelin Bend Pty Ltd
  *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
-package com.zepben.ewb.cim.extensions.iec61970.base.protection
+package com.zepben.ewb
 
 import com.zepben.testutils.junit.SystemLogExtension
-import org.hamcrest.MatcherAssert.assertThat
-import org.hamcrest.Matchers.equalTo
+import com.zepben.testutils.junit.TestClassValidator
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.RegisterExtension
 
-internal class VoltageRelayTest {
+class TestsTest {
 
     companion object {
         @JvmField
@@ -23,8 +22,8 @@ internal class VoltageRelayTest {
     }
 
     @Test
-    internal fun constructorCoverage() {
-        assertThat(VoltageRelay("id").mRID, equalTo("id"))
+    internal fun `validate test classes`() {
+        TestClassValidator.validate()
     }
 
 }

--- a/src/test/kotlin/com/zepben/ewb/auth/client/AuthProviderConfigTest.kt
+++ b/src/test/kotlin/com/zepben/ewb/auth/client/AuthProviderConfigTest.kt
@@ -9,10 +9,12 @@
 package com.zepben.ewb.auth.client
 
 import com.zepben.ewb.auth.common.StatusCode
+import com.zepben.testutils.junit.SystemLogExtension
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.RegisterExtension
 import java.net.URI
 import java.net.http.HttpClient
 import java.net.http.HttpRequest
@@ -20,6 +22,12 @@ import java.net.http.HttpResponse
 import java.net.http.HttpResponse.BodyHandler
 
 class AuthProviderConfigTest {
+
+    companion object {
+        @JvmField
+        @RegisterExtension
+        val systemErr: SystemLogExtension = SystemLogExtension.SYSTEM_ERR.captureLog().muteOnSuccess()
+    }
 
     val handler: BodyHandler<String> = mockk<BodyHandler<String>>()
     val response: HttpResponse<String> = mockk<HttpResponse<String>> {

--- a/src/test/kotlin/com/zepben/ewb/auth/client/ZepbenTokenFetcherTest.kt
+++ b/src/test/kotlin/com/zepben/ewb/auth/client/ZepbenTokenFetcherTest.kt
@@ -13,6 +13,7 @@ import com.zepben.ewb.auth.common.AuthMethod
 import com.zepben.ewb.auth.common.StatusCode
 import com.zepben.testutils.auth.TOKEN
 import com.zepben.testutils.exception.ExpectException.Companion.expect
+import com.zepben.testutils.junit.SystemLogExtension
 import com.zepben.vertxutils.testing.TestHttpServer
 import io.mockk.every
 import io.mockk.mockkObject
@@ -24,6 +25,7 @@ import org.hamcrest.core.IsEqual.equalTo
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.RegisterExtension
 import org.mockito.Mockito.*
 import org.mockito.kotlin.mock
 import java.net.http.HttpClient
@@ -32,6 +34,12 @@ import java.net.http.HttpResponse
 import javax.net.ssl.SSLContext
 
 internal class ZepbenTokenFetcherTest {
+
+    companion object {
+        @JvmField
+        @RegisterExtension
+        val systemErr: SystemLogExtension = SystemLogExtension.SYSTEM_ERR.captureLog().muteOnSuccess()
+    }
 
     private lateinit var server: TestHttpServer
     private var port = 8080

--- a/src/test/kotlin/com/zepben/ewb/auth/server/AuthProviderConfigRouteTest.kt
+++ b/src/test/kotlin/com/zepben/ewb/auth/server/AuthProviderConfigRouteTest.kt
@@ -10,6 +10,7 @@
 package com.zepben.ewb.auth.server
 
 import com.zepben.ewb.auth.common.AuthMethod
+import com.zepben.testutils.junit.SystemLogExtension
 import com.zepben.vertxutils.routing.RouteVersionUtils
 import com.zepben.vertxutils.testing.TestHttpServer
 import io.netty.handler.codec.http.HttpResponseStatus
@@ -19,8 +20,15 @@ import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.equalTo
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.RegisterExtension
 
 class AuthProviderConfigRouteTest {
+
+    companion object {
+        @JvmField
+        @RegisterExtension
+        val systemErr: SystemLogExtension = SystemLogExtension.SYSTEM_ERR.captureLog().muteOnSuccess()
+    }
 
     private var server: TestHttpServer? = null
     private var port = 8080

--- a/src/test/kotlin/com/zepben/ewb/auth/server/ConfigurableJwkProviderTest.kt
+++ b/src/test/kotlin/com/zepben/ewb/auth/server/ConfigurableJwkProviderTest.kt
@@ -9,16 +9,25 @@
 package com.zepben.ewb.auth.server
 
 import com.zepben.ewb.auth.common.StatusCode
+import com.zepben.testutils.junit.SystemLogExtension
 import io.mockk.every
 import io.mockk.mockk
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.equalTo
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.RegisterExtension
 import java.net.URL
 import java.net.http.HttpClient
 import java.net.http.HttpResponse
 
 class ConfigurableJwkProviderTest {
+
+    companion object {
+        @JvmField
+        @RegisterExtension
+        val systemErr: SystemLogExtension = SystemLogExtension.SYSTEM_ERR.captureLog().muteOnSuccess()
+    }
+
     val clientCreator: () -> HttpClient = { client }
     val url: URL = URL("https://fake-url.com")
 

--- a/src/test/kotlin/com/zepben/ewb/auth/server/JWKHolderTest.kt
+++ b/src/test/kotlin/com/zepben/ewb/auth/server/JWKHolderTest.kt
@@ -13,6 +13,7 @@ import com.auth0.jwk.JwkException
 import com.auth0.jwk.SigningKeyNotFoundException
 import com.zepben.ewb.auth.client.ProviderDetails
 import com.zepben.testutils.exception.ExpectException
+import com.zepben.testutils.junit.SystemLogExtension
 import io.mockk.every
 import io.mockk.excludeRecords
 import io.mockk.mockk
@@ -20,10 +21,17 @@ import io.mockk.verifySequence
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.equalTo
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.RegisterExtension
 import java.net.URI
 import java.net.URL
 
 class JWKHolderTest {
+
+    companion object {
+        @JvmField
+        @RegisterExtension
+        val systemErr: SystemLogExtension = SystemLogExtension.SYSTEM_ERR.captureLog().muteOnSuccess()
+    }
 
     private val jwk33 = mockk<Jwk>()
     private val jwk5006 = mockk<Jwk>()

--- a/src/test/kotlin/com/zepben/ewb/auth/server/JWTAuthenticatorTest.kt
+++ b/src/test/kotlin/com/zepben/ewb/auth/server/JWTAuthenticatorTest.kt
@@ -19,6 +19,7 @@ import com.zepben.ewb.auth.common.StatusCode
 import com.zepben.ewb.auth.server.JWTAuthoriser.authorise
 import com.zepben.testutils.auth.*
 import com.zepben.testutils.exception.ExpectException.Companion.expect
+import com.zepben.testutils.junit.SystemLogExtension
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.mockkStatic
@@ -26,6 +27,7 @@ import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.equalTo
 import org.hamcrest.Matchers.instanceOf
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.RegisterExtension
 
 fun createAuthenticator(aud: String, issuer: String): JWTAuthenticator {
     return JWTAuthenticator(
@@ -39,6 +41,12 @@ fun createAuthenticator(aud: String, issuer: String): JWTAuthenticator {
 }
 
 class JWTAuthenticatorTest {
+
+    companion object {
+        @JvmField
+        @RegisterExtension
+        val systemErr: SystemLogExtension = SystemLogExtension.SYSTEM_ERR.captureLog().muteOnSuccess()
+    }
 
     @Test
     fun testAuth() {

--- a/src/test/kotlin/com/zepben/ewb/auth/server/JWTAuthoriserTest.kt
+++ b/src/test/kotlin/com/zepben/ewb/auth/server/JWTAuthoriserTest.kt
@@ -11,11 +11,20 @@ package com.zepben.ewb.auth.server
 import com.auth0.jwt.JWT
 import com.auth0.jwt.algorithms.Algorithm
 import com.zepben.ewb.auth.common.StatusCode
+import com.zepben.testutils.junit.SystemLogExtension
 import org.hamcrest.MatcherAssert
 import org.hamcrest.Matchers
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.RegisterExtension
 
 class JWTAuthoriserTest {
+
+    companion object {
+        @JvmField
+        @RegisterExtension
+        val systemErr: SystemLogExtension = SystemLogExtension.SYSTEM_ERR.captureLog().muteOnSuccess()
+    }
+
     @Test
     fun permissionsFieldTest() {
         checkPermissionsField("permissions", StatusCode.OK)

--- a/src/test/kotlin/com/zepben/ewb/auth/server/JWTMultiIssuerVerifierBuilderTest.kt
+++ b/src/test/kotlin/com/zepben/ewb/auth/server/JWTMultiIssuerVerifierBuilderTest.kt
@@ -15,13 +15,21 @@ import com.auth0.jwt.exceptions.InvalidClaimException
 import com.auth0.jwt.interfaces.DecodedJWT
 import com.auth0.jwt.interfaces.Verification
 import com.zepben.testutils.exception.ExpectException.Companion.expect
+import com.zepben.testutils.junit.SystemLogExtension
 import io.mockk.*
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.equalTo
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.RegisterExtension
 import java.security.interfaces.RSAPublicKey
 
 class JWTMultiIssuerVerifierBuilderTest {
+
+    companion object {
+        @JvmField
+        @RegisterExtension
+        val systemErr: SystemLogExtension = SystemLogExtension.SYSTEM_ERR.captureLog().muteOnSuccess()
+    }
 
     private val trustedIssuerOne = mockk<TrustedIssuer> {
         every { issuerDomain } returns "one"

--- a/src/test/kotlin/com/zepben/ewb/auth/server/TrustedIssuerTest.kt
+++ b/src/test/kotlin/com/zepben/ewb/auth/server/TrustedIssuerTest.kt
@@ -9,11 +9,19 @@
 package com.zepben.ewb.auth.server
 
 import com.zepben.ewb.auth.client.ProviderDetails
+import com.zepben.testutils.junit.SystemLogExtension
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.equalTo
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.RegisterExtension
 
 class TrustedIssuerTest {
+
+    companion object {
+        @JvmField
+        @RegisterExtension
+        val systemErr: SystemLogExtension = SystemLogExtension.SYSTEM_ERR.captureLog().muteOnSuccess()
+    }
 
     @Test
     fun lazyFetchWorksAsExpected() {

--- a/src/test/kotlin/com/zepben/ewb/auth/server/grpc/AuthInterceptorTest.kt
+++ b/src/test/kotlin/com/zepben/ewb/auth/server/grpc/AuthInterceptorTest.kt
@@ -13,6 +13,7 @@ import com.zepben.ewb.auth.server.createAuthenticator
 import com.zepben.testutils.auth.MockServerCall
 import com.zepben.testutils.auth.MockServerCallHandler
 import com.zepben.testutils.auth.TOKEN
+import com.zepben.testutils.junit.SystemLogExtension
 import io.grpc.Metadata
 import io.grpc.Status
 import io.mockk.every
@@ -20,10 +21,17 @@ import io.mockk.mockk
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.equalTo
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.RegisterExtension
 
 const val write_network_scope: String = "write:network"
 
 class AuthInterceptorTest {
+
+    companion object {
+        @JvmField
+        @RegisterExtension
+        val systemErr: SystemLogExtension = SystemLogExtension.SYSTEM_ERR.captureLog().muteOnSuccess()
+    }
 
     @Test
     fun testIntercept() {

--- a/src/test/kotlin/com/zepben/ewb/cim/extensions/iec61968/assetinfo/RelayInfoTest.kt
+++ b/src/test/kotlin/com/zepben/ewb/cim/extensions/iec61968/assetinfo/RelayInfoTest.kt
@@ -12,11 +12,19 @@ import com.zepben.ewb.services.common.testdata.generateId
 import com.zepben.ewb.services.network.NetworkService
 import com.zepben.ewb.services.network.testdata.fillFields
 import com.zepben.ewb.utils.PrivateCollectionValidator
+import com.zepben.testutils.junit.SystemLogExtension
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.*
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.RegisterExtension
 
 internal class RelayInfoTest {
+
+    companion object {
+        @JvmField
+        @RegisterExtension
+        val systemErr: SystemLogExtension = SystemLogExtension.SYSTEM_ERR.captureLog().muteOnSuccess()
+    }
 
     @Test
     internal fun constructorCoverage() {

--- a/src/test/kotlin/com/zepben/ewb/cim/extensions/iec61970/base/feeder/LvSubstationTest.kt
+++ b/src/test/kotlin/com/zepben/ewb/cim/extensions/iec61970/base/feeder/LvSubstationTest.kt
@@ -14,12 +14,21 @@ import com.zepben.ewb.cim.iec61970.base.wires.Fuse
 import com.zepben.ewb.cim.iec61970.base.wires.PowerTransformer
 import com.zepben.ewb.services.common.testdata.generateId
 import com.zepben.ewb.utils.PrivateCollectionValidator
+import com.zepben.testutils.junit.SystemLogExtension
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.contains
 import org.hamcrest.Matchers.equalTo
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.RegisterExtension
 
 class LvSubstationTest {
+
+    companion object {
+        @JvmField
+        @RegisterExtension
+        val systemErr: SystemLogExtension = SystemLogExtension.SYSTEM_ERR.captureLog().muteOnSuccess()
+    }
+
     @Test
     internal fun constructorCoverage() {
         assertThat(LvSubstation("id").mRID, equalTo("id"))

--- a/src/test/kotlin/com/zepben/ewb/cim/extensions/iec61970/base/protection/DistanceRelayTest.kt
+++ b/src/test/kotlin/com/zepben/ewb/cim/extensions/iec61970/base/protection/DistanceRelayTest.kt
@@ -11,12 +11,20 @@ package com.zepben.ewb.cim.extensions.iec61970.base.protection
 import com.zepben.ewb.services.common.testdata.generateId
 import com.zepben.ewb.services.network.NetworkService
 import com.zepben.ewb.services.network.testdata.fillFields
+import com.zepben.testutils.junit.SystemLogExtension
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.equalTo
 import org.hamcrest.Matchers.nullValue
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.RegisterExtension
 
 internal class DistanceRelayTest {
+
+    companion object {
+        @JvmField
+        @RegisterExtension
+        val systemErr: SystemLogExtension = SystemLogExtension.SYSTEM_ERR.captureLog().muteOnSuccess()
+    }
 
     @Test
     internal fun constructorCoverage() {

--- a/src/test/kotlin/com/zepben/ewb/cim/extensions/iec61970/base/protection/ProtectionRelayFunctionTest.kt
+++ b/src/test/kotlin/com/zepben/ewb/cim/extensions/iec61970/base/protection/ProtectionRelayFunctionTest.kt
@@ -16,11 +16,19 @@ import com.zepben.ewb.services.common.testdata.generateId
 import com.zepben.ewb.services.network.NetworkService
 import com.zepben.ewb.services.network.testdata.fillFields
 import com.zepben.ewb.utils.PrivateCollectionValidator
+import com.zepben.testutils.junit.SystemLogExtension
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.*
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.RegisterExtension
 
 internal class ProtectionRelayFunctionTest {
+
+    companion object {
+        @JvmField
+        @RegisterExtension
+        val systemErr: SystemLogExtension = SystemLogExtension.SYSTEM_ERR.captureLog().muteOnSuccess()
+    }
 
     @Test
     internal fun constructorCoverage() {

--- a/src/test/kotlin/com/zepben/ewb/cim/extensions/iec61970/base/protection/ProtectionRelaySchemeTest.kt
+++ b/src/test/kotlin/com/zepben/ewb/cim/extensions/iec61970/base/protection/ProtectionRelaySchemeTest.kt
@@ -12,11 +12,19 @@ import com.zepben.ewb.services.common.testdata.generateId
 import com.zepben.ewb.services.network.NetworkService
 import com.zepben.ewb.services.network.testdata.fillFields
 import com.zepben.ewb.utils.PrivateCollectionValidator
+import com.zepben.testutils.junit.SystemLogExtension
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.*
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.RegisterExtension
 
 internal class ProtectionRelaySchemeTest {
+
+    companion object {
+        @JvmField
+        @RegisterExtension
+        val systemErr: SystemLogExtension = SystemLogExtension.SYSTEM_ERR.captureLog().muteOnSuccess()
+    }
 
     @Test
     internal fun constructorCoverage() {

--- a/src/test/kotlin/com/zepben/ewb/cim/extensions/iec61970/base/protection/ProtectionRelaySystemTest.kt
+++ b/src/test/kotlin/com/zepben/ewb/cim/extensions/iec61970/base/protection/ProtectionRelaySystemTest.kt
@@ -12,11 +12,19 @@ import com.zepben.ewb.services.common.testdata.generateId
 import com.zepben.ewb.services.network.NetworkService
 import com.zepben.ewb.services.network.testdata.fillFields
 import com.zepben.ewb.utils.PrivateCollectionValidator
+import com.zepben.testutils.junit.SystemLogExtension
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.equalTo
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.RegisterExtension
 
 internal class ProtectionRelaySystemTest {
+
+    companion object {
+        @JvmField
+        @RegisterExtension
+        val systemErr: SystemLogExtension = SystemLogExtension.SYSTEM_ERR.captureLog().muteOnSuccess()
+    }
 
     @Test
     internal fun constructorCoverage() {

--- a/src/test/kotlin/com/zepben/ewb/cim/extensions/iec61970/base/protection/RelaySettingTest.kt
+++ b/src/test/kotlin/com/zepben/ewb/cim/extensions/iec61970/base/protection/RelaySettingTest.kt
@@ -9,11 +9,19 @@
 package com.zepben.ewb.cim.extensions.iec61970.base.protection
 
 import com.zepben.ewb.cim.iec61970.base.domain.UnitSymbol
+import com.zepben.testutils.junit.SystemLogExtension
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.*
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.RegisterExtension
 
 internal class RelaySettingTest {
+
+    companion object {
+        @JvmField
+        @RegisterExtension
+        val systemErr: SystemLogExtension = SystemLogExtension.SYSTEM_ERR.captureLog().muteOnSuccess()
+    }
 
     @Test
     internal fun constructorCoverage() {

--- a/src/test/kotlin/com/zepben/ewb/cim/iec61968/assetinfo/PowerTransformerInfoTest.kt
+++ b/src/test/kotlin/com/zepben/ewb/cim/iec61968/assetinfo/PowerTransformerInfoTest.kt
@@ -12,14 +12,22 @@ import com.zepben.ewb.services.common.testdata.generateId
 import com.zepben.ewb.services.network.ResistanceReactance
 import com.zepben.ewb.services.network.validateResistanceReactance
 import com.zepben.ewb.utils.PrivateCollectionValidator
+import com.zepben.testutils.junit.SystemLogExtension
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.equalTo
 import org.hamcrest.Matchers.nullValue
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.RegisterExtension
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.spy
 
 internal class PowerTransformerInfoTest {
+
+    companion object {
+        @JvmField
+        @RegisterExtension
+        val systemErr: SystemLogExtension = SystemLogExtension.SYSTEM_ERR.captureLog().muteOnSuccess()
+    }
 
     @Test
     internal fun constructorCoverage() {

--- a/src/test/kotlin/com/zepben/ewb/cim/iec61968/assetinfo/ShuntCompensatorInfoTest.kt
+++ b/src/test/kotlin/com/zepben/ewb/cim/iec61968/assetinfo/ShuntCompensatorInfoTest.kt
@@ -11,12 +11,20 @@ package com.zepben.ewb.cim.iec61968.assetinfo
 import com.zepben.ewb.services.common.testdata.generateId
 import com.zepben.ewb.services.network.NetworkService
 import com.zepben.ewb.services.network.testdata.fillFields
+import com.zepben.testutils.junit.SystemLogExtension
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.equalTo
 import org.hamcrest.Matchers.nullValue
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.RegisterExtension
 
 internal class ShuntCompensatorInfoTest {
+
+    companion object {
+        @JvmField
+        @RegisterExtension
+        val systemErr: SystemLogExtension = SystemLogExtension.SYSTEM_ERR.captureLog().muteOnSuccess()
+    }
 
     @Test
     internal fun constructorCoverage() {

--- a/src/test/kotlin/com/zepben/ewb/cim/iec61968/assetinfo/SwitchInfoTest.kt
+++ b/src/test/kotlin/com/zepben/ewb/cim/iec61968/assetinfo/SwitchInfoTest.kt
@@ -11,12 +11,20 @@ package com.zepben.ewb.cim.iec61968.assetinfo
 import com.zepben.ewb.services.common.testdata.generateId
 import com.zepben.ewb.services.network.NetworkService
 import com.zepben.ewb.services.network.testdata.fillFields
+import com.zepben.testutils.junit.SystemLogExtension
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.equalTo
 import org.hamcrest.Matchers.nullValue
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.RegisterExtension
 
 internal class SwitchInfoTest {
+
+    companion object {
+        @JvmField
+        @RegisterExtension
+        val systemErr: SystemLogExtension = SystemLogExtension.SYSTEM_ERR.captureLog().muteOnSuccess()
+    }
 
     @Test
     internal fun constructorCoverage() {

--- a/src/test/kotlin/com/zepben/ewb/cim/iec61970/base/protection/CurrentRelayTest.kt
+++ b/src/test/kotlin/com/zepben/ewb/cim/iec61970/base/protection/CurrentRelayTest.kt
@@ -11,12 +11,20 @@ package com.zepben.ewb.cim.iec61970.base.protection
 import com.zepben.ewb.services.common.testdata.generateId
 import com.zepben.ewb.services.network.NetworkService
 import com.zepben.ewb.services.network.testdata.fillFields
+import com.zepben.testutils.junit.SystemLogExtension
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.equalTo
 import org.hamcrest.Matchers.nullValue
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.RegisterExtension
 
 internal class CurrentRelayTest {
+
+    companion object {
+        @JvmField
+        @RegisterExtension
+        val systemErr: SystemLogExtension = SystemLogExtension.SYSTEM_ERR.captureLog().muteOnSuccess()
+    }
 
     @Test
     internal fun constructorCoverage() {

--- a/src/test/kotlin/com/zepben/ewb/cim/iec61970/base/wires/GroundDisconnectorTest.kt
+++ b/src/test/kotlin/com/zepben/ewb/cim/iec61970/base/wires/GroundDisconnectorTest.kt
@@ -8,11 +8,19 @@
 
 package com.zepben.ewb.cim.iec61970.base.wires
 
+import com.zepben.testutils.junit.SystemLogExtension
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.equalTo
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.RegisterExtension
 
 internal class GroundDisconnectorTest {
+
+    companion object {
+        @JvmField
+        @RegisterExtension
+        val systemErr: SystemLogExtension = SystemLogExtension.SYSTEM_ERR.captureLog().muteOnSuccess()
+    }
 
     @Test
     internal fun constructorCoverage() {

--- a/src/test/kotlin/com/zepben/ewb/cim/iec61970/base/wires/GroundTest.kt
+++ b/src/test/kotlin/com/zepben/ewb/cim/iec61970/base/wires/GroundTest.kt
@@ -8,11 +8,19 @@
 
 package com.zepben.ewb.cim.iec61970.base.wires
 
+import com.zepben.testutils.junit.SystemLogExtension
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.equalTo
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.RegisterExtension
 
 internal class GroundTest {
+
+    companion object {
+        @JvmField
+        @RegisterExtension
+        val systemErr: SystemLogExtension = SystemLogExtension.SYSTEM_ERR.captureLog().muteOnSuccess()
+    }
 
     @Test
     internal fun constructorCoverage() {

--- a/src/test/kotlin/com/zepben/ewb/cim/iec61970/base/wires/PhaseImpedanceDataTest.kt
+++ b/src/test/kotlin/com/zepben/ewb/cim/iec61970/base/wires/PhaseImpedanceDataTest.kt
@@ -8,11 +8,20 @@
 
 package com.zepben.ewb.cim.iec61970.base.wires
 
+import com.zepben.testutils.junit.SystemLogExtension
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.*
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.RegisterExtension
 
 class PhaseImpedanceDataTest {
+
+    companion object {
+        @JvmField
+        @RegisterExtension
+        val systemErr: SystemLogExtension = SystemLogExtension.SYSTEM_ERR.captureLog().muteOnSuccess()
+    }
+
     @Test
     internal fun constructorCoverage() {
         assertThat(PhaseImpedanceData(SinglePhaseKind.A, SinglePhaseKind.B, 0.0, 0.0, 0.0, 0.0), notNullValue())

--- a/src/test/kotlin/com/zepben/ewb/cim/iec61970/base/wires/SeriesCompensatorTest.kt
+++ b/src/test/kotlin/com/zepben/ewb/cim/iec61970/base/wires/SeriesCompensatorTest.kt
@@ -11,12 +11,20 @@ package com.zepben.ewb.cim.iec61970.base.wires
 import com.zepben.ewb.services.common.testdata.generateId
 import com.zepben.ewb.services.network.NetworkService
 import com.zepben.ewb.services.network.testdata.fillFields
+import com.zepben.testutils.junit.SystemLogExtension
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.equalTo
 import org.hamcrest.Matchers.nullValue
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.RegisterExtension
 
 internal class SeriesCompensatorTest {
+
+    companion object {
+        @JvmField
+        @RegisterExtension
+        val systemErr: SystemLogExtension = SystemLogExtension.SYSTEM_ERR.captureLog().muteOnSuccess()
+    }
 
     @Test
     internal fun constructorCoverage() {

--- a/src/test/kotlin/com/zepben/ewb/conn/grpc/CompressionInterceptorTest.kt
+++ b/src/test/kotlin/com/zepben/ewb/conn/grpc/CompressionInterceptorTest.kt
@@ -8,12 +8,20 @@
 
 package com.zepben.ewb.conn.grpc
 
+import com.zepben.testutils.junit.SystemLogExtension
 import io.grpc.Status
 import org.hamcrest.MatcherAssert
 import org.hamcrest.Matchers
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.RegisterExtension
 
 class CompressionInterceptorTest {
+
+    companion object {
+        @JvmField
+        @RegisterExtension
+        val systemErr: SystemLogExtension = SystemLogExtension.SYSTEM_ERR.captureLog().muteOnSuccess()
+    }
 
     @Test
     fun `test intercepts calls`() {

--- a/src/test/kotlin/com/zepben/ewb/conn/grpc/ExceptionInterceptorTest.kt
+++ b/src/test/kotlin/com/zepben/ewb/conn/grpc/ExceptionInterceptorTest.kt
@@ -8,13 +8,21 @@
 
 package com.zepben.ewb.conn.grpc
 
+import com.zepben.testutils.junit.SystemLogExtension
 import io.grpc.Status
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers
 import org.hamcrest.Matchers.nullValue
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.RegisterExtension
 
 class ExceptionInterceptorTest {
+
+    companion object {
+        @JvmField
+        @RegisterExtension
+        val systemErr: SystemLogExtension = SystemLogExtension.SYSTEM_ERR.captureLog().muteOnSuccess()
+    }
 
     @Test
     fun `test intercepts exceptions on close and propagates to status`() {

--- a/src/test/kotlin/com/zepben/ewb/database/paths/LocalEwbDataFilePathsTest.kt
+++ b/src/test/kotlin/com/zepben/ewb/database/paths/LocalEwbDataFilePathsTest.kt
@@ -9,15 +9,23 @@
 package com.zepben.ewb.database.paths
 
 import com.zepben.testutils.exception.ExpectException.Companion.expect
+import com.zepben.testutils.junit.SystemLogExtension
 import io.mockk.*
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.*
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.RegisterExtension
 import java.nio.file.Path
 import java.nio.file.Paths
 import java.time.LocalDate
 
 class LocalEwbDataFilePathsTest {
+
+    companion object {
+        @JvmField
+        @RegisterExtension
+        val systemErr: SystemLogExtension = SystemLogExtension.SYSTEM_ERR.captureLog().muteOnSuccess()
+    }
 
     private val today = LocalDate.now()
     private val baseDir = Paths.get("/some/path/to/ewb/data")

--- a/src/test/kotlin/com/zepben/ewb/database/sql/PreparedStatementExtensionsKtTest.kt
+++ b/src/test/kotlin/com/zepben/ewb/database/sql/PreparedStatementExtensionsKtTest.kt
@@ -10,12 +10,20 @@ package com.zepben.ewb.database.sql
 
 import com.zepben.ewb.database.sql.extensions.parameters
 import com.zepben.ewb.database.sql.extensions.sql
+import com.zepben.testutils.junit.SystemLogExtension
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.equalTo
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.RegisterExtension
 import java.sql.DriverManager
 
 class PreparedStatementExtensionsKtTest {
+
+    companion object {
+        @JvmField
+        @RegisterExtension
+        val systemErr: SystemLogExtension = SystemLogExtension.SYSTEM_ERR.captureLog().muteOnSuccess()
+    }
 
     @Test
     internal fun `can print sql statements and bound values`() {

--- a/src/test/kotlin/com/zepben/ewb/database/sql/cim/CimDatabaseTablesTest.kt
+++ b/src/test/kotlin/com/zepben/ewb/database/sql/cim/CimDatabaseTablesTest.kt
@@ -17,14 +17,22 @@ import com.zepben.ewb.database.sql.common.tables.SqlTable
 import com.zepben.ewb.database.sql.common.tables.TableVersion
 import com.zepben.ewb.database.sql.generators.SqlGenerator
 import com.zepben.testutils.exception.ExpectException.Companion.expect
+import com.zepben.testutils.junit.SystemLogExtension
 import io.mockk.mockk
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.equalTo
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.RegisterExtension
 import java.lang.reflect.Modifier
 import kotlin.reflect.full.isSubclassOf
 
 internal class CimDatabaseTablesTest {
+
+    companion object {
+        @JvmField
+        @RegisterExtension
+        val systemErr: SystemLogExtension = SystemLogExtension.SYSTEM_ERR.captureLog().muteOnSuccess()
+    }
 
     private val tables = object : CimDatabaseTables() {
         override val sqlGenerator: SqlGenerator

--- a/src/test/kotlin/com/zepben/ewb/database/sql/cim/customer/CustomerDatabaseSchemaTest.kt
+++ b/src/test/kotlin/com/zepben/ewb/database/sql/cim/customer/CustomerDatabaseSchemaTest.kt
@@ -22,9 +22,11 @@ import com.zepben.ewb.services.common.testdata.generateId
 import com.zepben.ewb.services.customer.CustomerService
 import com.zepben.ewb.services.customer.CustomerServiceComparator
 import com.zepben.ewb.services.customer.testdata.fillFields
+import com.zepben.testutils.junit.SystemLogExtension
 import org.hamcrest.MatcherAssert.assertThat
 import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.RegisterExtension
 import java.nio.file.Files
 import java.nio.file.Path
 import java.nio.file.Paths
@@ -32,6 +34,12 @@ import java.sql.Connection
 import java.sql.DriverManager
 
 class CustomerDatabaseSchemaTest : CimDatabaseSchemaTest<CustomerService, CustomerDatabaseWriter, CustomerDatabaseReader, CustomerServiceComparator>() {
+
+    companion object {
+        @JvmField
+        @RegisterExtension
+        val systemErr: SystemLogExtension = SystemLogExtension.SYSTEM_ERR.captureLog().muteOnSuccess()
+    }
 
     override fun createService(): CustomerService = CustomerService()
 

--- a/src/test/kotlin/com/zepben/ewb/database/sql/cim/customer/CustomerDatabaseTablesTest.kt
+++ b/src/test/kotlin/com/zepben/ewb/database/sql/cim/customer/CustomerDatabaseTablesTest.kt
@@ -10,11 +10,19 @@ package com.zepben.ewb.database.sql.cim.customer
 
 import com.zepben.ewb.database.sql.cim.CimDatabaseTables
 import com.zepben.ewb.database.sql.generators.SqlGenerator
+import com.zepben.testutils.junit.SystemLogExtension
 import io.mockk.mockk
 import org.hamcrest.MatcherAssert.assertThat
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.RegisterExtension
 
 internal class CustomerDatabaseTablesTest {
+
+    companion object {
+        @JvmField
+        @RegisterExtension
+        val systemErr: SystemLogExtension = SystemLogExtension.SYSTEM_ERR.captureLog().muteOnSuccess()
+    }
 
     @Test
     internal fun `contains base tables`() {

--- a/src/test/kotlin/com/zepben/ewb/database/sql/cim/customer/CustomerDatabaseWriterTest.kt
+++ b/src/test/kotlin/com/zepben/ewb/database/sql/cim/customer/CustomerDatabaseWriterTest.kt
@@ -8,10 +8,18 @@
 
 package com.zepben.ewb.database.sql.cim.customer
 
+import com.zepben.testutils.junit.SystemLogExtension
 import io.mockk.mockk
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.RegisterExtension
 
 class CustomerDatabaseWriterTest {
+
+    companion object {
+        @JvmField
+        @RegisterExtension
+        val systemErr: SystemLogExtension = SystemLogExtension.SYSTEM_ERR.captureLog().muteOnSuccess()
+    }
 
     @Test
     internal fun `constructor coverage`() {

--- a/src/test/kotlin/com/zepben/ewb/database/sql/cim/diagram/DiagramDatabaseSchemaTest.kt
+++ b/src/test/kotlin/com/zepben/ewb/database/sql/cim/diagram/DiagramDatabaseSchemaTest.kt
@@ -18,9 +18,11 @@ import com.zepben.ewb.services.common.testdata.generateId
 import com.zepben.ewb.services.diagram.DiagramService
 import com.zepben.ewb.services.diagram.DiagramServiceComparator
 import com.zepben.ewb.services.diagram.testdata.fillFields
+import com.zepben.testutils.junit.SystemLogExtension
 import org.hamcrest.MatcherAssert.assertThat
 import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.RegisterExtension
 import java.nio.file.Files
 import java.nio.file.Path
 import java.nio.file.Paths
@@ -28,6 +30,12 @@ import java.sql.Connection
 import java.sql.DriverManager
 
 class DiagramDatabaseSchemaTest : CimDatabaseSchemaTest<DiagramService, DiagramDatabaseWriter, DiagramDatabaseReader, DiagramServiceComparator>() {
+
+    companion object {
+        @JvmField
+        @RegisterExtension
+        val systemErr: SystemLogExtension = SystemLogExtension.SYSTEM_ERR.captureLog().muteOnSuccess()
+    }
 
     override fun createService(): DiagramService = DiagramService()
 

--- a/src/test/kotlin/com/zepben/ewb/database/sql/cim/diagram/DiagramDatabaseTablesTest.kt
+++ b/src/test/kotlin/com/zepben/ewb/database/sql/cim/diagram/DiagramDatabaseTablesTest.kt
@@ -10,11 +10,19 @@ package com.zepben.ewb.database.sql.cim.diagram
 
 import com.zepben.ewb.database.sql.cim.CimDatabaseTables
 import com.zepben.ewb.database.sql.generators.SqlGenerator
+import com.zepben.testutils.junit.SystemLogExtension
 import io.mockk.mockk
 import org.hamcrest.MatcherAssert.assertThat
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.RegisterExtension
 
 internal class DiagramDatabaseTablesTest {
+
+    companion object {
+        @JvmField
+        @RegisterExtension
+        val systemErr: SystemLogExtension = SystemLogExtension.SYSTEM_ERR.captureLog().muteOnSuccess()
+    }
 
     @Test
     internal fun `contains base tables`() {

--- a/src/test/kotlin/com/zepben/ewb/database/sql/cim/diagram/DiagramDatabaseWriterTest.kt
+++ b/src/test/kotlin/com/zepben/ewb/database/sql/cim/diagram/DiagramDatabaseWriterTest.kt
@@ -8,10 +8,18 @@
 
 package com.zepben.ewb.database.sql.cim.diagram
 
+import com.zepben.testutils.junit.SystemLogExtension
 import io.mockk.mockk
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.RegisterExtension
 
 class DiagramDatabaseWriterTest {
+
+    companion object {
+        @JvmField
+        @RegisterExtension
+        val systemErr: SystemLogExtension = SystemLogExtension.SYSTEM_ERR.captureLog().muteOnSuccess()
+    }
 
     @Test
     internal fun `constructor coverage`() {

--- a/src/test/kotlin/com/zepben/ewb/database/sql/cim/network/NetworkDatabaseSchemaTest.kt
+++ b/src/test/kotlin/com/zepben/ewb/database/sql/cim/network/NetworkDatabaseSchemaTest.kt
@@ -55,11 +55,13 @@ import com.zepben.ewb.services.network.NetworkServiceComparator
 import com.zepben.ewb.services.network.testdata.*
 import com.zepben.ewb.services.network.testdata.stupid.StupidlyLargeNetwork
 import com.zepben.ewb.testing.TestNetworkBuilder
+import com.zepben.testutils.junit.SystemLogExtension
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.containsString
 import org.hamcrest.Matchers.equalTo
 import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.RegisterExtension
 import java.nio.file.Files
 import java.nio.file.Path
 import java.nio.file.Paths
@@ -67,6 +69,12 @@ import java.sql.Connection
 import java.sql.DriverManager
 
 class NetworkDatabaseSchemaTest : CimDatabaseSchemaTest<NetworkService, NetworkDatabaseWriter, NetworkDatabaseReader, NetworkServiceComparator>() {
+
+    companion object {
+        @JvmField
+        @RegisterExtension
+        val systemErr: SystemLogExtension = SystemLogExtension.SYSTEM_ERR.captureLog().muteOnSuccess()
+    }
 
     override fun createService(): NetworkService = NetworkService()
 

--- a/src/test/kotlin/com/zepben/ewb/database/sql/cim/network/NetworkDatabaseTablesTest.kt
+++ b/src/test/kotlin/com/zepben/ewb/database/sql/cim/network/NetworkDatabaseTablesTest.kt
@@ -10,11 +10,19 @@ package com.zepben.ewb.database.sql.cim.network
 
 import com.zepben.ewb.database.sql.cim.CimDatabaseTables
 import com.zepben.ewb.database.sql.generators.SqlGenerator
+import com.zepben.testutils.junit.SystemLogExtension
 import io.mockk.mockk
 import org.hamcrest.MatcherAssert.assertThat
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.RegisterExtension
 
 internal class NetworkDatabaseTablesTest {
+
+    companion object {
+        @JvmField
+        @RegisterExtension
+        val systemErr: SystemLogExtension = SystemLogExtension.SYSTEM_ERR.captureLog().muteOnSuccess()
+    }
 
     @Test
     internal fun `contains base tables`() {

--- a/src/test/kotlin/com/zepben/ewb/database/sql/cim/network/NetworkDatabaseWriterTest.kt
+++ b/src/test/kotlin/com/zepben/ewb/database/sql/cim/network/NetworkDatabaseWriterTest.kt
@@ -8,10 +8,18 @@
 
 package com.zepben.ewb.database.sql.cim.network
 
+import com.zepben.testutils.junit.SystemLogExtension
 import io.mockk.mockk
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.RegisterExtension
 
 class NetworkDatabaseWriterTest {
+
+    companion object {
+        @JvmField
+        @RegisterExtension
+        val systemErr: SystemLogExtension = SystemLogExtension.SYSTEM_ERR.captureLog().muteOnSuccess()
+    }
 
     @Test
     internal fun `constructor coverage`() {

--- a/src/test/kotlin/com/zepben/ewb/database/sql/extensions/ResultSetExtensionsTest.kt
+++ b/src/test/kotlin/com/zepben/ewb/database/sql/extensions/ResultSetExtensionsTest.kt
@@ -10,14 +10,22 @@ package com.zepben.ewb.database.sql.extensions
 
 import com.zepben.ewb.cim.iec61968.infiec61968.infcommon.Ratio
 import com.zepben.ewb.utils.createMockResultSet
+import com.zepben.testutils.junit.SystemLogExtension
 import io.mockk.every
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.equalTo
 import org.hamcrest.Matchers.nullValue
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.RegisterExtension
 import java.time.Instant
 
 internal class ResultSetExtensionsTest {
+
+    companion object {
+        @JvmField
+        @RegisterExtension
+        val systemErr: SystemLogExtension = SystemLogExtension.SYSTEM_ERR.captureLog().muteOnSuccess()
+    }
 
     @Test
     internal fun `getNullableBoolean returns a bool`() {

--- a/src/test/kotlin/com/zepben/ewb/database/sql/generators/GeneratePostgresSql.kt
+++ b/src/test/kotlin/com/zepben/ewb/database/sql/generators/GeneratePostgresSql.kt
@@ -12,10 +12,22 @@ import com.zepben.ewb.database.sql.cim.customer.CustomerDatabaseTables
 import com.zepben.ewb.database.sql.cim.diagram.DiagramDatabaseTables
 import com.zepben.ewb.database.sql.cim.network.NetworkDatabaseTables
 import com.zepben.ewb.database.sql.common.tables.SqlTable
+import com.zepben.testutils.junit.SystemLogExtension
 import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.RegisterExtension
 
 class GeneratePostgresSql {
+
+    companion object {
+        //
+        // NOTE: Deliberately left unmuted and not capturing because these are all disabled tests that can be used to print SQL statements. It
+        //       is only here to pass the `TestsTest`.
+        //
+        @JvmField
+        @RegisterExtension
+        val systemErr: SystemLogExtension = SystemLogExtension.SYSTEM_ERR
+    }
 
     //
     // NOTE: These tests are deliberately disabled as they simply print the database SQL statements which

--- a/src/test/kotlin/com/zepben/ewb/database/sql/initialisers/NoOpDatabaseInitialiserTest.kt
+++ b/src/test/kotlin/com/zepben/ewb/database/sql/initialisers/NoOpDatabaseInitialiserTest.kt
@@ -9,16 +9,24 @@
 package com.zepben.ewb.database.sql.initialisers
 
 import com.zepben.ewb.database.sql.common.BaseDatabaseTables
+import com.zepben.testutils.junit.SystemLogExtension
 import io.mockk.every
 import io.mockk.mockk
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.equalTo
 import org.hamcrest.Matchers.sameInstance
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.RegisterExtension
 import java.sql.Connection
 import java.sql.DriverManager
 
 class NoOpDatabaseInitialiserTest {
+
+    companion object {
+        @JvmField
+        @RegisterExtension
+        val systemErr: SystemLogExtension = SystemLogExtension.SYSTEM_ERR.captureLog().muteOnSuccess()
+    }
 
     @Test
     internal fun `calls passed in connection factory on connect`() {

--- a/src/test/kotlin/com/zepben/ewb/database/sql/initialisers/SqliteDatabaseInitialiserTest.kt
+++ b/src/test/kotlin/com/zepben/ewb/database/sql/initialisers/SqliteDatabaseInitialiserTest.kt
@@ -13,10 +13,12 @@ import com.zepben.ewb.database.sql.common.tables.SqlTable
 import com.zepben.ewb.database.sql.common.tables.TableVersion
 import com.zepben.ewb.database.sql.generators.SqliteGenerator
 import com.zepben.testutils.exception.ExpectException.Companion.expect
+import com.zepben.testutils.junit.SystemLogExtension
 import io.mockk.*
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.sameInstance
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.RegisterExtension
 import org.slf4j.Logger
 import java.io.IOException
 import java.nio.file.Path
@@ -26,6 +28,12 @@ import java.sql.SQLException
 import java.sql.Statement
 
 class SqliteDatabaseInitialiserTest {
+
+    companion object {
+        @JvmField
+        @RegisterExtension
+        val systemErr: SystemLogExtension = SystemLogExtension.SYSTEM_ERR.captureLog().muteOnSuccess()
+    }
 
     private val databaseFile = "database file"
     private val deleteFile = mockk<(Path) -> Unit>()

--- a/src/test/kotlin/com/zepben/ewb/database/sql/metrics/MetricsDatabaseTablesTest.kt
+++ b/src/test/kotlin/com/zepben/ewb/database/sql/metrics/MetricsDatabaseTablesTest.kt
@@ -13,12 +13,20 @@ import com.zepben.ewb.database.sql.common.MissingTableConfigException
 import com.zepben.ewb.database.sql.common.tables.SqlTable
 import com.zepben.ewb.database.sql.common.tables.TableVersion
 import com.zepben.testutils.exception.ExpectException
+import com.zepben.testutils.junit.SystemLogExtension
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.equalTo
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.RegisterExtension
 import java.lang.reflect.Modifier
 
 internal class MetricsDatabaseTablesTest {
+
+    companion object {
+        @JvmField
+        @RegisterExtension
+        val systemErr: SystemLogExtension = SystemLogExtension.SYSTEM_ERR.captureLog().muteOnSuccess()
+    }
 
     private val tables = MetricsDatabaseTables()
 

--- a/src/test/kotlin/com/zepben/ewb/database/sqlite/GenerateSqliteSql.kt
+++ b/src/test/kotlin/com/zepben/ewb/database/sqlite/GenerateSqliteSql.kt
@@ -13,10 +13,22 @@ import com.zepben.ewb.database.sql.cim.diagram.DiagramDatabaseTables
 import com.zepben.ewb.database.sql.cim.network.NetworkDatabaseTables
 import com.zepben.ewb.database.sql.common.tables.SqlTable
 import com.zepben.ewb.database.sql.generators.SqliteGenerator
+import com.zepben.testutils.junit.SystemLogExtension
 import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.RegisterExtension
 
 class GenerateSqliteSql {
+
+    companion object {
+        //
+        // NOTE: Deliberately left unmuted and not capturing because these are all disabled tests that can be used to print SQL statements. It
+        //       is only here to pass the `TestsTest`.
+        //
+        @JvmField
+        @RegisterExtension
+        val systemErr: SystemLogExtension = SystemLogExtension.SYSTEM_ERR
+    }
 
     //
     // NOTE: These tests are deliberately disabled as they simply print the database SQL statements which

--- a/src/test/kotlin/com/zepben/ewb/metrics/AutoMapTest.kt
+++ b/src/test/kotlin/com/zepben/ewb/metrics/AutoMapTest.kt
@@ -8,11 +8,19 @@
 
 package com.zepben.ewb.metrics
 
+import com.zepben.testutils.junit.SystemLogExtension
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.*
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.RegisterExtension
 
 internal class AutoMapTest {
+
+    companion object {
+        @JvmField
+        @RegisterExtension
+        val systemErr: SystemLogExtension = SystemLogExtension.SYSTEM_ERR.captureLog().muteOnSuccess()
+    }
 
     private val autoMap = object : AutoMap<String, MutableList<Int>>() {
         override fun defaultValue(): MutableList<Int> = mutableListOf(5)

--- a/src/test/kotlin/com/zepben/ewb/metrics/IngestionJobTest.kt
+++ b/src/test/kotlin/com/zepben/ewb/metrics/IngestionJobTest.kt
@@ -8,14 +8,22 @@
 
 package com.zepben.ewb.metrics
 
+import com.zepben.testutils.junit.SystemLogExtension
 import io.mockk.mockk
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.empty
 import org.hamcrest.Matchers.equalTo
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.RegisterExtension
 import java.util.*
 
 internal class IngestionJobTest {
+
+    companion object {
+        @JvmField
+        @RegisterExtension
+        val systemErr: SystemLogExtension = SystemLogExtension.SYSTEM_ERR.captureLog().muteOnSuccess()
+    }
 
     private val uuid = UUID.randomUUID()
 

--- a/src/test/kotlin/com/zepben/ewb/metrics/IngestionMetadataTest.kt
+++ b/src/test/kotlin/com/zepben/ewb/metrics/IngestionMetadataTest.kt
@@ -8,12 +8,20 @@
 
 package com.zepben.ewb.metrics
 
+import com.zepben.testutils.junit.SystemLogExtension
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.equalTo
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.RegisterExtension
 import java.time.Instant
 
 internal class IngestionMetadataTest {
+
+    companion object {
+        @JvmField
+        @RegisterExtension
+        val systemErr: SystemLogExtension = SystemLogExtension.SYSTEM_ERR.captureLog().muteOnSuccess()
+    }
 
     @Test
     internal fun constructorCoverage() {

--- a/src/test/kotlin/com/zepben/ewb/metrics/JobSourcesTest.kt
+++ b/src/test/kotlin/com/zepben/ewb/metrics/JobSourcesTest.kt
@@ -8,11 +8,19 @@
 
 package com.zepben.ewb.metrics
 
+import com.zepben.testutils.junit.SystemLogExtension
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.equalTo
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.RegisterExtension
 
 internal class JobSourcesTest {
+
+    companion object {
+        @JvmField
+        @RegisterExtension
+        val systemErr: SystemLogExtension = SystemLogExtension.SYSTEM_ERR.captureLog().muteOnSuccess()
+    }
 
     @Test
     internal fun defaultValue() {

--- a/src/test/kotlin/com/zepben/ewb/metrics/NetworkContainerKtTest.kt
+++ b/src/test/kotlin/com/zepben/ewb/metrics/NetworkContainerKtTest.kt
@@ -13,11 +13,19 @@ import com.zepben.ewb.cim.iec61970.base.core.Feeder
 import com.zepben.ewb.cim.iec61970.base.core.GeographicalRegion
 import com.zepben.ewb.cim.iec61970.base.core.SubGeographicalRegion
 import com.zepben.ewb.cim.iec61970.base.core.Substation
+import com.zepben.testutils.junit.SystemLogExtension
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.equalTo
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.RegisterExtension
 
 internal class NetworkContainerTest {
+
+    companion object {
+        @JvmField
+        @RegisterExtension
+        val systemErr: SystemLogExtension = SystemLogExtension.SYSTEM_ERR.captureLog().muteOnSuccess()
+    }
 
     @Test
     internal fun `extension functions`() {

--- a/src/test/kotlin/com/zepben/ewb/metrics/NetworkContainerMetricsTest.kt
+++ b/src/test/kotlin/com/zepben/ewb/metrics/NetworkContainerMetricsTest.kt
@@ -8,11 +8,19 @@
 
 package com.zepben.ewb.metrics
 
+import com.zepben.testutils.junit.SystemLogExtension
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.equalTo
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.RegisterExtension
 
 internal class NetworkContainerMetricsTest {
+
+    companion object {
+        @JvmField
+        @RegisterExtension
+        val systemErr: SystemLogExtension = SystemLogExtension.SYSTEM_ERR.captureLog().muteOnSuccess()
+    }
 
     @Test
     internal fun plus() {

--- a/src/test/kotlin/com/zepben/ewb/metrics/NetworkMetricsTest.kt
+++ b/src/test/kotlin/com/zepben/ewb/metrics/NetworkMetricsTest.kt
@@ -8,11 +8,19 @@
 
 package com.zepben.ewb.metrics
 
+import com.zepben.testutils.junit.SystemLogExtension
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.anEmptyMap
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.RegisterExtension
 
 internal class NetworkMetricsTest {
+
+    companion object {
+        @JvmField
+        @RegisterExtension
+        val systemErr: SystemLogExtension = SystemLogExtension.SYSTEM_ERR.captureLog().muteOnSuccess()
+    }
 
     @Test
     internal fun defaultValue() {

--- a/src/test/kotlin/com/zepben/ewb/metrics/SourceMetadataTest.kt
+++ b/src/test/kotlin/com/zepben/ewb/metrics/SourceMetadataTest.kt
@@ -8,13 +8,21 @@
 
 package com.zepben.ewb.metrics
 
+import com.zepben.testutils.junit.SystemLogExtension
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.equalTo
 import org.hamcrest.Matchers.not
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.RegisterExtension
 import java.time.Instant
 
 internal class SourceMetadataTest {
+
+    companion object {
+        @JvmField
+        @RegisterExtension
+        val systemErr: SystemLogExtension = SystemLogExtension.SYSTEM_ERR.captureLog().muteOnSuccess()
+    }
 
     private val sourceMetadata1 = SourceMetadata(Instant.EPOCH, "ABC".toByteArray())
     private val sourceMetadata2 = SourceMetadata(Instant.EPOCH, "ABC".toByteArray())

--- a/src/test/kotlin/com/zepben/ewb/services/common/PropertyComparersKtTest.kt
+++ b/src/test/kotlin/com/zepben/ewb/services/common/PropertyComparersKtTest.kt
@@ -8,12 +8,20 @@
 
 package com.zepben.ewb.services.common
 
+import com.zepben.testutils.junit.SystemLogExtension
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.notNullValue
 import org.hamcrest.Matchers.nullValue
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.RegisterExtension
 
 class PropertyComparersKtTest {
+
+    companion object {
+        @JvmField
+        @RegisterExtension
+        val systemErr: SystemLogExtension = SystemLogExtension.SYSTEM_ERR.captureLog().muteOnSuccess()
+    }
 
     @Test
     internal fun `unordered list comparison`() {

--- a/src/test/kotlin/com/zepben/ewb/services/common/meta/MetadataTranslationsTest.kt
+++ b/src/test/kotlin/com/zepben/ewb/services/common/meta/MetadataTranslationsTest.kt
@@ -8,16 +8,24 @@
 
 package com.zepben.ewb.services.common.meta
 
+import com.zepben.testutils.junit.SystemLogExtension
 import io.mockk.*
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.*
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.RegisterExtension
 import java.time.Instant
 import com.google.protobuf.Timestamp as PBTimestamp
 import com.zepben.protobuf.metadata.DataSource as PBDataSource
 import com.zepben.protobuf.metadata.ServiceInfo as PBServiceInfo
 
 internal class MetadataTranslationsTest {
+
+    companion object {
+        @JvmField
+        @RegisterExtension
+        val systemErr: SystemLogExtension = SystemLogExtension.SYSTEM_ERR.captureLog().muteOnSuccess()
+    }
 
     @Test
     internal fun `DataSource from Protobuf`() {

--- a/src/test/kotlin/com/zepben/ewb/services/customer/CustomerServiceComparatorTest.kt
+++ b/src/test/kotlin/com/zepben/ewb/services/customer/CustomerServiceComparatorTest.kt
@@ -13,10 +13,18 @@ import com.zepben.ewb.cim.iec61968.customers.*
 import com.zepben.ewb.services.common.BaseServiceComparatorTest
 import com.zepben.ewb.services.common.ObjectCollectionDifference
 import com.zepben.ewb.utils.ServiceComparatorValidator
+import com.zepben.testutils.junit.SystemLogExtension
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.RegisterExtension
 
 @Suppress("SameParameterValue")
 internal class CustomerServiceComparatorTest : BaseServiceComparatorTest() {
+
+    companion object {
+        @JvmField
+        @RegisterExtension
+        val systemErr: SystemLogExtension = SystemLogExtension.SYSTEM_ERR.captureLog().muteOnSuccess()
+    }
 
     override val comparatorValidator: ServiceComparatorValidator<CustomerService, CustomerServiceComparator> = ServiceComparatorValidator(
         { CustomerService() },

--- a/src/test/kotlin/com/zepben/ewb/services/diagram/DiagramServiceComparatorTest.kt
+++ b/src/test/kotlin/com/zepben/ewb/services/diagram/DiagramServiceComparatorTest.kt
@@ -13,9 +13,17 @@ import com.zepben.ewb.services.common.BaseServiceComparatorTest
 import com.zepben.ewb.services.common.ObjectCollectionDifference
 import com.zepben.ewb.services.common.ValueCollectionDifference
 import com.zepben.ewb.utils.ServiceComparatorValidator
+import com.zepben.testutils.junit.SystemLogExtension
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.RegisterExtension
 
 internal class DiagramServiceComparatorTest : BaseServiceComparatorTest() {
+
+    companion object {
+        @JvmField
+        @RegisterExtension
+        val systemErr: SystemLogExtension = SystemLogExtension.SYSTEM_ERR.captureLog().muteOnSuccess()
+    }
 
     override val comparatorValidator: ServiceComparatorValidator<DiagramService, DiagramServiceComparator> = ServiceComparatorValidator(
         { DiagramService() },

--- a/src/test/kotlin/com/zepben/ewb/services/diagram/DiagramServiceTest.kt
+++ b/src/test/kotlin/com/zepben/ewb/services/diagram/DiagramServiceTest.kt
@@ -11,12 +11,20 @@ package com.zepben.ewb.services.diagram
 import com.zepben.ewb.cim.iec61970.base.diagramlayout.Diagram
 import com.zepben.ewb.cim.iec61970.base.diagramlayout.DiagramObject
 import com.zepben.ewb.services.common.testdata.generateId
+import com.zepben.testutils.junit.SystemLogExtension
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.*
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.RegisterExtension
 import kotlin.reflect.full.primaryConstructor
 
 internal class DiagramServiceTest {
+
+    companion object {
+        @JvmField
+        @RegisterExtension
+        val systemErr: SystemLogExtension = SystemLogExtension.SYSTEM_ERR.captureLog().muteOnSuccess()
+    }
 
     private val service = DiagramService()
 

--- a/src/test/kotlin/com/zepben/ewb/services/measurement/MeasurementServiceTest.kt
+++ b/src/test/kotlin/com/zepben/ewb/services/measurement/MeasurementServiceTest.kt
@@ -11,12 +11,20 @@ package com.zepben.ewb.services.measurement
 import com.zepben.ewb.cim.iec61970.base.meas.AccumulatorValue
 import com.zepben.ewb.cim.iec61970.base.meas.AnalogValue
 import com.zepben.ewb.cim.iec61970.base.meas.DiscreteValue
+import com.zepben.testutils.junit.SystemLogExtension
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.contains
 import org.hamcrest.Matchers.equalTo
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.RegisterExtension
 
 internal class MeasurementServiceTest {
+
+    companion object {
+        @JvmField
+        @RegisterExtension
+        val systemErr: SystemLogExtension = SystemLogExtension.SYSTEM_ERR.captureLog().muteOnSuccess()
+    }
 
     private val service = MeasurementService()
 

--- a/src/test/kotlin/com/zepben/ewb/services/measurement/translator/MeasurementCimToProtoTest.kt
+++ b/src/test/kotlin/com/zepben/ewb/services/measurement/translator/MeasurementCimToProtoTest.kt
@@ -12,9 +12,17 @@ import com.zepben.ewb.cim.iec61970.base.meas.AccumulatorValue
 import com.zepben.ewb.cim.iec61970.base.meas.AnalogValue
 import com.zepben.ewb.cim.iec61970.base.meas.DiscreteValue
 import com.zepben.ewb.services.measurement.testdata.fillFields
+import com.zepben.testutils.junit.SystemLogExtension
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.RegisterExtension
 
 internal class MeasurementCimToProtoTest {
+
+    companion object {
+        @JvmField
+        @RegisterExtension
+        val systemErr: SystemLogExtension = SystemLogExtension.SYSTEM_ERR.captureLog().muteOnSuccess()
+    }
 
     private val validator = MeasurementCimToProtoTestValidator()
 

--- a/src/test/kotlin/com/zepben/ewb/services/network/NetworkServiceComparatorOptionsTest.kt
+++ b/src/test/kotlin/com/zepben/ewb/services/network/NetworkServiceComparatorOptionsTest.kt
@@ -8,10 +8,18 @@
 
 package com.zepben.ewb.services.network
 
+import com.zepben.testutils.junit.SystemLogExtension
 import org.hamcrest.MatcherAssert.assertThat
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.RegisterExtension
 
 internal class NetworkServiceComparatorOptionsTest {
+
+    companion object {
+        @JvmField
+        @RegisterExtension
+        val systemErr: SystemLogExtension = SystemLogExtension.SYSTEM_ERR.captureLog().muteOnSuccess()
+    }
 
     @Test
     internal fun all() {

--- a/src/test/kotlin/com/zepben/ewb/services/network/NetworkServiceComparatorTest.kt
+++ b/src/test/kotlin/com/zepben/ewb/services/network/NetworkServiceComparatorTest.kt
@@ -49,11 +49,19 @@ import com.zepben.ewb.cim.iec61970.infiec61970.feeder.Circuit
 import com.zepben.ewb.services.common.*
 import com.zepben.ewb.services.network.tracing.feeder.FeederDirection
 import com.zepben.ewb.utils.ServiceComparatorValidator
+import com.zepben.testutils.junit.SystemLogExtension
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.RegisterExtension
 import java.time.Instant
 
 @Suppress("SameParameterValue")
 internal class NetworkServiceComparatorTest : BaseServiceComparatorTest() {
+
+    companion object {
+        @JvmField
+        @RegisterExtension
+        val systemErr: SystemLogExtension = SystemLogExtension.SYSTEM_ERR.captureLog().muteOnSuccess()
+    }
 
     override val comparatorValidator: ServiceComparatorValidator<NetworkService, NetworkServiceComparator> = ServiceComparatorValidator(
         { NetworkService() },

--- a/src/test/kotlin/com/zepben/ewb/services/network/equivalents/EquivalentNetworkCreatorTest.kt
+++ b/src/test/kotlin/com/zepben/ewb/services/network/equivalents/EquivalentNetworkCreatorTest.kt
@@ -21,15 +21,23 @@ import com.zepben.ewb.services.network.equivalents.EquivalentNetworkCreator.sing
 import com.zepben.ewb.services.network.equivalents.EquivalentNetworkCreator.singleEquivalentBranchCreator
 import com.zepben.ewb.services.network.testdata.createTerminal
 import com.zepben.ewb.services.network.testdata.createTerminals
+import com.zepben.testutils.junit.SystemLogExtension
 import io.mockk.*
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.*
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.RegisterExtension
 import kotlin.reflect.KClass
 import kotlin.reflect.full.primaryConstructor
 
 internal class EquivalentNetworkCreatorTest {
+
+    companion object {
+        @JvmField
+        @RegisterExtension
+        val systemErr: SystemLogExtension = SystemLogExtension.SYSTEM_ERR.captureLog().muteOnSuccess()
+    }
 
     @AfterEach
     internal fun afterEach() {

--- a/src/test/kotlin/com/zepben/ewb/services/network/tracing/feeder/UtilTest.kt
+++ b/src/test/kotlin/com/zepben/ewb/services/network/tracing/feeder/UtilTest.kt
@@ -18,11 +18,19 @@ import com.zepben.ewb.services.network.getT
 import com.zepben.ewb.services.network.lvFeederStartPoints
 import com.zepben.ewb.services.network.tracing.networktrace.operators.NetworkStateOperators
 import com.zepben.ewb.testing.TestNetworkBuilder
+import com.zepben.testutils.junit.SystemLogExtension
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.containsInAnyOrder
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.RegisterExtension
 
 class UtilTest {
+
+    companion object {
+        @JvmField
+        @RegisterExtension
+        val systemErr: SystemLogExtension = SystemLogExtension.SYSTEM_ERR.captureLog().muteOnSuccess()
+    }
 
     @Test
     fun `findLvFeeders excludes open switches`() {

--- a/src/test/kotlin/com/zepben/ewb/services/network/tracing/networktrace/NetworkTraceQueueNextTest.kt
+++ b/src/test/kotlin/com/zepben/ewb/services/network/tracing/networktrace/NetworkTraceQueueNextTest.kt
@@ -10,14 +10,22 @@ package com.zepben.ewb.services.network.tracing.networktrace
 
 import com.zepben.ewb.services.network.tracing.networktrace.operators.NetworkStateOperators
 import com.zepben.ewb.services.network.tracing.traversal.StepContext
+import com.zepben.testutils.junit.SystemLogExtension
 import io.mockk.every
 import io.mockk.mockk
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.equalTo
 import org.hamcrest.Matchers.hasSize
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.RegisterExtension
 
 class NetworkTraceQueueNextTest {
+
+    companion object {
+        @JvmField
+        @RegisterExtension
+        val systemErr: SystemLogExtension = SystemLogExtension.SYSTEM_ERR.captureLog().muteOnSuccess()
+    }
 
     private val stateOperators = mockk<NetworkStateOperators>()
     private val dataComputer = mockk<ComputeData<String>>()

--- a/src/test/kotlin/com/zepben/ewb/services/network/tracing/networktrace/NetworkTraceStepPathProviderTest.kt
+++ b/src/test/kotlin/com/zepben/ewb/services/network/tracing/networktrace/NetworkTraceStepPathProviderTest.kt
@@ -17,13 +17,21 @@ import com.zepben.ewb.services.network.testdata.CutsAndClampsNetwork
 import com.zepben.ewb.services.network.tracing.connectivity.NominalPhasePath
 import com.zepben.ewb.services.network.tracing.networktrace.operators.NetworkStateOperators
 import com.zepben.ewb.testing.TestNetworkBuilder
+import com.zepben.testutils.junit.SystemLogExtension
 import org.hamcrest.Matcher
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.containsInAnyOrder
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.RegisterExtension
 import com.zepben.ewb.cim.iec61970.base.wires.SinglePhaseKind as SPK
 
 class NetworkTraceStepPathProviderTest {
+
+    companion object {
+        @JvmField
+        @RegisterExtension
+        val systemErr: SystemLogExtension = SystemLogExtension.SYSTEM_ERR.captureLog().muteOnSuccess()
+    }
 
     private val pathProvider = NetworkTraceStepPathProvider(NetworkStateOperators.NORMAL)
 

--- a/src/test/kotlin/com/zepben/ewb/services/network/tracing/networktrace/NetworkTraceTest.kt
+++ b/src/test/kotlin/com/zepben/ewb/services/network/tracing/networktrace/NetworkTraceTest.kt
@@ -18,13 +18,21 @@ import com.zepben.ewb.services.network.tracing.traversal.StepActionWithContextVa
 import com.zepben.ewb.services.network.tracing.traversal.StepContext
 import com.zepben.ewb.services.network.tracing.traversal.TraversalQueue
 import com.zepben.ewb.testing.TestNetworkBuilder
+import com.zepben.testutils.junit.SystemLogExtension
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.*
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertTimeoutPreemptively
+import org.junit.jupiter.api.extension.RegisterExtension
 import java.time.Duration
 
 class NetworkTraceTest {
+
+    companion object {
+        @JvmField
+        @RegisterExtension
+        val systemErr: SystemLogExtension = SystemLogExtension.SYSTEM_ERR.captureLog().muteOnSuccess()
+    }
 
     @Test
     internal fun `adds start clamp terminal as traversed segment path`() {

--- a/src/test/kotlin/com/zepben/ewb/services/network/tracing/networktrace/TracingTest.kt
+++ b/src/test/kotlin/com/zepben/ewb/services/network/tracing/networktrace/TracingTest.kt
@@ -17,11 +17,19 @@ import com.zepben.ewb.services.network.tracing.networktrace.conditions.Condition
 import com.zepben.ewb.services.network.tracing.networktrace.conditions.Conditions.upstream
 import com.zepben.ewb.services.network.tracing.networktrace.operators.NetworkStateOperators
 import com.zepben.ewb.testing.TestNetworkBuilder
+import com.zepben.testutils.junit.SystemLogExtension
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.*
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.RegisterExtension
 
 class TracingTest {
+
+    companion object {
+        @JvmField
+        @RegisterExtension
+        val systemErr: SystemLogExtension = SystemLogExtension.SYSTEM_ERR.captureLog().muteOnSuccess()
+    }
 
     //
     //              1 b2 21--c3--21 ec4

--- a/src/test/kotlin/com/zepben/ewb/services/network/tracing/networktrace/conditions/ConditionsTest.kt
+++ b/src/test/kotlin/com/zepben/ewb/services/network/tracing/networktrace/conditions/ConditionsTest.kt
@@ -19,12 +19,20 @@ import com.zepben.ewb.services.network.tracing.networktrace.conditions.Condition
 import com.zepben.ewb.services.network.tracing.networktrace.conditions.Conditions.withDirection
 import com.zepben.ewb.services.network.tracing.networktrace.operators.NetworkStateOperators
 import com.zepben.ewb.services.network.tracing.networktrace.operators.OpenStateOperators
+import com.zepben.testutils.junit.SystemLogExtension
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.equalTo
 import org.hamcrest.Matchers.instanceOf
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.RegisterExtension
 
 class ConditionsTest {
+
+    companion object {
+        @JvmField
+        @RegisterExtension
+        val systemErr: SystemLogExtension = SystemLogExtension.SYSTEM_ERR.captureLog().muteOnSuccess()
+    }
 
     @Test
     fun stateOperatorsWithDirection() {

--- a/src/test/kotlin/com/zepben/ewb/services/network/tracing/networktrace/conditions/DirectionConditionTest.kt
+++ b/src/test/kotlin/com/zepben/ewb/services/network/tracing/networktrace/conditions/DirectionConditionTest.kt
@@ -19,14 +19,22 @@ import com.zepben.ewb.services.network.tracing.feeder.FeederDirection
 import com.zepben.ewb.services.network.tracing.feeder.FeederDirection.*
 import com.zepben.ewb.services.network.tracing.networktrace.NetworkTraceStep
 import com.zepben.ewb.services.network.tracing.networktrace.operators.NetworkStateOperators
+import com.zepben.testutils.junit.SystemLogExtension
 import io.mockk.every
 import io.mockk.mockk
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.equalTo
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
+import org.junit.jupiter.api.extension.RegisterExtension
 
 class DirectionConditionTest {
+
+    companion object {
+        @JvmField
+        @RegisterExtension
+        val systemErr: SystemLogExtension = SystemLogExtension.SYSTEM_ERR.captureLog().muteOnSuccess()
+    }
 
     @Test
     fun `shouldQueue for non cut or clamp path`() {

--- a/src/test/kotlin/com/zepben/ewb/services/network/tracing/networktrace/conditions/EquipmentStepLimitConditionTest.kt
+++ b/src/test/kotlin/com/zepben/ewb/services/network/tracing/networktrace/conditions/EquipmentStepLimitConditionTest.kt
@@ -9,12 +9,20 @@
 package com.zepben.ewb.services.network.tracing.networktrace.conditions
 
 import com.zepben.ewb.services.network.tracing.networktrace.NetworkTraceStep
+import com.zepben.testutils.junit.SystemLogExtension
 import io.mockk.mockk
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.equalTo
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.RegisterExtension
 
 class EquipmentStepLimitConditionTest {
+
+    companion object {
+        @JvmField
+        @RegisterExtension
+        val systemErr: SystemLogExtension = SystemLogExtension.SYSTEM_ERR.captureLog().muteOnSuccess()
+    }
 
     @Test
     fun `should stop when step number is equal to limit`() {

--- a/src/test/kotlin/com/zepben/ewb/services/network/tracing/networktrace/conditions/EquipmentTypeStepLimitConditionTest.kt
+++ b/src/test/kotlin/com/zepben/ewb/services/network/tracing/networktrace/conditions/EquipmentTypeStepLimitConditionTest.kt
@@ -13,6 +13,7 @@ import com.zepben.ewb.cim.iec61970.base.wires.Junction
 import com.zepben.ewb.cim.iec61970.base.wires.Switch
 import com.zepben.ewb.services.network.tracing.networktrace.NetworkTraceStep
 import com.zepben.ewb.services.network.tracing.traversal.StepContext
+import com.zepben.testutils.junit.SystemLogExtension
 import io.mockk.called
 import io.mockk.every
 import io.mockk.mockk
@@ -20,9 +21,15 @@ import io.mockk.verify
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.equalTo
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.RegisterExtension
 
 class EquipmentTypeStepLimitConditionTest {
 
+    companion object {
+        @JvmField
+        @RegisterExtension
+        val systemErr: SystemLogExtension = SystemLogExtension.SYSTEM_ERR.captureLog().muteOnSuccess()
+    }
 
     @Test
     fun `should stop when matched type count is equal to limit`() {

--- a/src/test/kotlin/com/zepben/ewb/services/network/tracing/networktrace/conditions/OpenConditionTest.kt
+++ b/src/test/kotlin/com/zepben/ewb/services/network/tracing/networktrace/conditions/OpenConditionTest.kt
@@ -12,14 +12,22 @@ import com.zepben.ewb.cim.iec61970.base.core.ConductingEquipment
 import com.zepben.ewb.cim.iec61970.base.wires.SinglePhaseKind
 import com.zepben.ewb.cim.iec61970.base.wires.Switch
 import com.zepben.ewb.services.network.tracing.networktrace.NetworkTraceStep
+import com.zepben.testutils.junit.SystemLogExtension
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.equalTo
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.RegisterExtension
 
 class OpenConditionTest {
+
+    companion object {
+        @JvmField
+        @RegisterExtension
+        val systemErr: SystemLogExtension = SystemLogExtension.SYSTEM_ERR.captureLog().muteOnSuccess()
+    }
 
     @Test
     fun `always queues external steps`() {

--- a/src/test/kotlin/com/zepben/ewb/services/network/tracing/networktrace/conditions/ShuntCompensatorConditionTest.kt
+++ b/src/test/kotlin/com/zepben/ewb/services/network/tracing/networktrace/conditions/ShuntCompensatorConditionTest.kt
@@ -14,13 +14,21 @@ import com.zepben.ewb.cim.iec61970.base.core.Terminal
 import com.zepben.ewb.cim.iec61970.base.wires.LinearShuntCompensator
 import com.zepben.ewb.services.common.testdata.generateId
 import com.zepben.ewb.services.network.tracing.networktrace.NetworkTraceStep
+import com.zepben.testutils.junit.SystemLogExtension
 import io.mockk.every
 import io.mockk.mockk
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.equalTo
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.RegisterExtension
 
 class ShuntCompensatorConditionTest {
+
+    companion object {
+        @JvmField
+        @RegisterExtension
+        val systemErr: SystemLogExtension = SystemLogExtension.SYSTEM_ERR.captureLog().muteOnSuccess()
+    }
 
     private val shuntCompensator = LinearShuntCompensator("sc")
     private val fromTerm = Terminal(mRID = generateId()).also { shuntCompensator.addTerminal(it) }

--- a/src/test/kotlin/com/zepben/ewb/services/network/tracing/networktrace/operators/EquipmentContainerStateOperatorsTest.kt
+++ b/src/test/kotlin/com/zepben/ewb/services/network/tracing/networktrace/operators/EquipmentContainerStateOperatorsTest.kt
@@ -10,15 +10,23 @@ package com.zepben.ewb.services.network.tracing.networktrace.operators
 
 import com.zepben.ewb.cim.iec61970.base.core.Equipment
 import com.zepben.ewb.cim.iec61970.base.core.EquipmentContainer
+import com.zepben.testutils.junit.SystemLogExtension
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
 import org.hamcrest.CoreMatchers.equalTo
 import org.hamcrest.MatcherAssert.assertThat
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.RegisterExtension
 import kotlin.reflect.KProperty1
 
 internal class EquipmentContainerStateOperatorsTest {
+
+    companion object {
+        @JvmField
+        @RegisterExtension
+        val systemErr: SystemLogExtension = SystemLogExtension.SYSTEM_ERR.captureLog().muteOnSuccess()
+    }
 
     private val normal = EquipmentContainerStateOperators.NORMAL
     private val current = EquipmentContainerStateOperators.CURRENT

--- a/src/test/kotlin/com/zepben/ewb/services/network/tracing/networktrace/operators/FeederDirectionStateOperatorsTest.kt
+++ b/src/test/kotlin/com/zepben/ewb/services/network/tracing/networktrace/operators/FeederDirectionStateOperatorsTest.kt
@@ -11,13 +11,21 @@ package com.zepben.ewb.services.network.tracing.networktrace.operators
 import com.zepben.ewb.cim.iec61970.base.core.Terminal
 import com.zepben.ewb.services.common.testdata.generateId
 import com.zepben.ewb.services.network.tracing.feeder.FeederDirection
+import com.zepben.testutils.junit.SystemLogExtension
 import org.hamcrest.CoreMatchers.equalTo
 import org.hamcrest.MatcherAssert.assertThat
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.RegisterExtension
 
 import kotlin.reflect.KMutableProperty1
 
 class FeederDirectionStateOperatorsTest {
+
+    companion object {
+        @JvmField
+        @RegisterExtension
+        val systemErr: SystemLogExtension = SystemLogExtension.SYSTEM_ERR.captureLog().muteOnSuccess()
+    }
 
     private val normal = FeederDirectionStateOperations.NORMAL
     private val current = FeederDirectionStateOperations.CURRENT

--- a/src/test/kotlin/com/zepben/ewb/services/network/tracing/networktrace/operators/InServiceStateOperatorsTest.kt
+++ b/src/test/kotlin/com/zepben/ewb/services/network/tracing/networktrace/operators/InServiceStateOperatorsTest.kt
@@ -9,13 +9,21 @@
 package com.zepben.ewb.services.network.tracing.networktrace.operators
 
 import com.zepben.ewb.cim.iec61970.base.core.Equipment
+import com.zepben.testutils.junit.SystemLogExtension
 import io.mockk.*
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.equalTo
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.RegisterExtension
 import kotlin.reflect.KMutableProperty1
 
 class InServiceStateOperatorsTest {
+
+    companion object {
+        @JvmField
+        @RegisterExtension
+        val systemErr: SystemLogExtension = SystemLogExtension.SYSTEM_ERR.captureLog().muteOnSuccess()
+    }
 
     private val normal = InServiceStateOperators.NORMAL
     private val current = InServiceStateOperators.CURRENT

--- a/src/test/kotlin/com/zepben/ewb/services/network/tracing/networktrace/operators/OpenStateOperatorsTest.kt
+++ b/src/test/kotlin/com/zepben/ewb/services/network/tracing/networktrace/operators/OpenStateOperatorsTest.kt
@@ -10,14 +10,22 @@ package com.zepben.ewb.services.network.tracing.networktrace.operators
 
 import com.zepben.ewb.cim.iec61970.base.wires.SinglePhaseKind
 import com.zepben.ewb.cim.iec61970.base.wires.Switch
+import com.zepben.testutils.junit.SystemLogExtension
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.equalTo
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.RegisterExtension
 
 class OpenStateOperatorsTest {
+
+    companion object {
+        @JvmField
+        @RegisterExtension
+        val systemErr: SystemLogExtension = SystemLogExtension.SYSTEM_ERR.captureLog().muteOnSuccess()
+    }
 
     private val normal = OpenStateOperators.NORMAL
     private val current = OpenStateOperators.CURRENT

--- a/src/test/kotlin/com/zepben/ewb/services/network/tracing/networktrace/operators/PhaseStateOperatorsTest.kt
+++ b/src/test/kotlin/com/zepben/ewb/services/network/tracing/networktrace/operators/PhaseStateOperatorsTest.kt
@@ -11,13 +11,21 @@ package com.zepben.ewb.services.network.tracing.networktrace.operators
 import com.zepben.ewb.cim.iec61970.base.core.Terminal
 import com.zepben.ewb.services.common.testdata.generateId
 import com.zepben.ewb.services.network.tracing.phases.PhaseStatus
+import com.zepben.testutils.junit.SystemLogExtension
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.sameInstance
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.RegisterExtension
 
 import kotlin.reflect.KProperty1
 
 class PhaseStateOperatorsTest {
+
+    companion object {
+        @JvmField
+        @RegisterExtension
+        val systemErr: SystemLogExtension = SystemLogExtension.SYSTEM_ERR.captureLog().muteOnSuccess()
+    }
 
     private val normal = PhaseStateOperators.NORMAL
     private val current = PhaseStateOperators.CURRENT

--- a/src/test/kotlin/com/zepben/ewb/services/network/tracing/traversal/TraversalTest.kt
+++ b/src/test/kotlin/com/zepben/ewb/services/network/tracing/traversal/TraversalTest.kt
@@ -9,15 +9,23 @@
 package com.zepben.ewb.services.network.tracing.traversal
 
 import com.zepben.testutils.exception.ExpectException.Companion.expect
+import com.zepben.testutils.junit.SystemLogExtension
 import io.mockk.mockk
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.contains
 import org.hamcrest.Matchers.equalTo
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.RegisterExtension
 import org.slf4j.Logger
 import kotlin.math.abs
 
 class TraversalTest {
+
+    companion object {
+        @JvmField
+        @RegisterExtension
+        val systemErr: SystemLogExtension = SystemLogExtension.SYSTEM_ERR.captureLog().muteOnSuccess()
+    }
 
     private class TestTraversal<T>(
         queueType: QueueType<T, TestTraversal<T>>,

--- a/src/test/kotlin/com/zepben/ewb/services/network/tracing/tree/TreeNodeTest.kt
+++ b/src/test/kotlin/com/zepben/ewb/services/network/tracing/tree/TreeNodeTest.kt
@@ -10,11 +10,19 @@ package com.zepben.ewb.services.network.tracing.tree
 
 import com.zepben.ewb.cim.iec61970.base.wires.Junction
 import com.zepben.ewb.services.network.tracing.networktrace.actions.TreeNode
+import com.zepben.testutils.junit.SystemLogExtension
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.*
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.RegisterExtension
 
 internal class TreeNodeTest {
+
+    companion object {
+        @JvmField
+        @RegisterExtension
+        val systemErr: SystemLogExtension = SystemLogExtension.SYSTEM_ERR.captureLog().muteOnSuccess()
+    }
 
     @Test
     internal fun accessors() {

--- a/src/test/kotlin/com/zepben/ewb/services/network/translator/NetworkTranslatorTest.kt
+++ b/src/test/kotlin/com/zepben/ewb/services/network/translator/NetworkTranslatorTest.kt
@@ -66,9 +66,11 @@ import com.zepben.ewb.services.common.translator.TranslatorTestBase
 import com.zepben.ewb.services.network.NetworkService
 import com.zepben.ewb.services.network.NetworkServiceComparator
 import com.zepben.ewb.services.network.testdata.fillFields
+import com.zepben.testutils.junit.SystemLogExtension
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.anEmptyMap
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.RegisterExtension
 
 internal class NetworkTranslatorTest : TranslatorTestBase<NetworkService>(
     ::NetworkService,
@@ -77,6 +79,12 @@ internal class NetworkTranslatorTest : TranslatorTestBase<NetworkService>(
     NetworkService::addFromPb,
     ::networkIdentifiedObject
 ) {
+
+    companion object {
+        @JvmField
+        @RegisterExtension
+        val systemErr: SystemLogExtension = SystemLogExtension.SYSTEM_ERR.captureLog().muteOnSuccess()
+    }
 
     private val nsToPb = NetworkCimToProto()
 

--- a/src/test/kotlin/com/zepben/ewb/streaming/data/CurrentStateEventTest.kt
+++ b/src/test/kotlin/com/zepben/ewb/streaming/data/CurrentStateEventTest.kt
@@ -11,11 +11,13 @@ package com.zepben.ewb.streaming.data
 import com.google.protobuf.Timestamp
 import com.zepben.ewb.cim.iec61970.base.core.PhaseCode
 import com.zepben.ewb.services.common.translator.toLocalDateTime
+import com.zepben.testutils.junit.SystemLogExtension
 import org.hamcrest.CoreMatchers.equalTo
 import org.hamcrest.CoreMatchers.instanceOf
 import org.hamcrest.MatcherAssert.assertThat
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
+import org.junit.jupiter.api.extension.RegisterExtension
 import com.zepben.protobuf.cim.iec61970.base.core.PhaseCode as PBPhaseCode
 import com.zepben.protobuf.ns.data.AddCutEvent as PBAddCutEvent
 import com.zepben.protobuf.ns.data.AddJumperEvent as PBAddJumperEvent
@@ -26,6 +28,12 @@ import com.zepben.protobuf.ns.data.SwitchAction as PBSwitchAction
 import com.zepben.protobuf.ns.data.SwitchStateEvent as PBSwitchStateEvent
 
 internal class CurrentStateEventTest {
+
+    companion object {
+        @JvmField
+        @RegisterExtension
+        val systemErr: SystemLogExtension = SystemLogExtension.SYSTEM_ERR.captureLog().muteOnSuccess()
+    }
 
     @Test
     internal fun `CurrentStateEvent from protobuf`() {

--- a/src/test/kotlin/com/zepben/ewb/streaming/data/SetCurrentStatesStatusTest.kt
+++ b/src/test/kotlin/com/zepben/ewb/streaming/data/SetCurrentStatesStatusTest.kt
@@ -8,12 +8,20 @@
 
 package com.zepben.ewb.streaming.data
 
+import com.zepben.testutils.junit.SystemLogExtension
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.*
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.RegisterExtension
 import com.zepben.protobuf.ns.data.StateEventFailure as PBStateEventFailure
 
 internal class SetCurrentStatesStatusTest {
+
+    companion object {
+        @JvmField
+        @RegisterExtension
+        val systemErr: SystemLogExtension = SystemLogExtension.SYSTEM_ERR.captureLog().muteOnSuccess()
+    }
 
     //
     // NOTE: We don't bother to check that the correct thing was put into the protobuf variants directly because it is

--- a/src/test/kotlin/com/zepben/ewb/streaming/get/CimConsumerClientTest.kt
+++ b/src/test/kotlin/com/zepben/ewb/streaming/get/CimConsumerClientTest.kt
@@ -16,13 +16,21 @@ import com.zepben.ewb.streaming.grpc.GrpcResult
 import com.zepben.protobuf.metadata.GetMetadataRequest
 import com.zepben.protobuf.metadata.GetMetadataResponse
 import com.zepben.protobuf.nc.NetworkConsumerGrpc.NetworkConsumerStub
+import com.zepben.testutils.junit.SystemLogExtension
 import io.mockk.*
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.equalTo
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.RegisterExtension
 import com.zepben.protobuf.metadata.ServiceInfo as PBServiceInfo
 
 internal class TestCimConsumerClient {
+
+    companion object {
+        @JvmField
+        @RegisterExtension
+        val systemErr: SystemLogExtension = SystemLogExtension.SYSTEM_ERR.captureLog().muteOnSuccess()
+    }
 
     @Test
     internal fun `getMetadata returns non-cached response, and caches it`() {

--- a/src/test/kotlin/com/zepben/ewb/streaming/get/CimConsumerClientTest.kt
+++ b/src/test/kotlin/com/zepben/ewb/streaming/get/CimConsumerClientTest.kt
@@ -24,11 +24,7 @@ import com.zepben.protobuf.metadata.ServiceInfo as PBServiceInfo
 
 internal class TestCimConsumerClient {
 
-    private val baseConsumerClient = mockk<CimConsumerClient<BaseService, BaseProtoToCim, NetworkConsumerStub>>()
-
-    // @Test
-    // Test disabled as the mocking in this test no longer works with Mockk
-    // as it is confused between mocking a field and the getter
+    @Test
     internal fun `getMetadata returns non-cached response, and caches it`() {
         val metadataResponse = GetMetadataResponse.newBuilder().apply {
             serviceInfoBuilder.apply {
@@ -42,59 +38,34 @@ internal class TestCimConsumerClient {
                         nanos = 456
                     }.build()
                 }
-                addDataSourcesBuilder().apply {
-                    source = "source two"
-                    version = "source version two"
-                    timestamp = timestampBuilder.apply {
-                        seconds = 654L
-                        nanos = 321
-                    }.build()
-                }
             }.build()
         }.build()
 
         val returnedServiceInfo = metadataResponse.serviceInfo.fromPb()
-
-        every { baseConsumerClient.runGetMetadata(ofType(GetMetadataRequest::class), any()) } answers {
-            secondArg<AwaitableStreamObserver<GetMetadataResponse>>().onNext(metadataResponse)
-            secondArg<AwaitableStreamObserver<GetMetadataResponse>>().onCompleted()
-        }
-
-        every { baseConsumerClient.getMetadata() } answers { callOriginal() }
-        every { baseConsumerClient.tryRpc(any<() -> ServiceInfo>()) } answers {
-            GrpcResult.of(firstArg<() -> ServiceInfo>().invoke())
-        }
-
-        //Because serviceInfo was made internal for other testing, everyone else has to mockk it themselves...
-        every { baseConsumerClient.serviceInfo } returns null
-        every { baseConsumerClient.serviceInfo = any() } answers {
-            every { baseConsumerClient.serviceInfo } returns firstArg()
-        }
+        val baseConsumerClient = spyk(createClient(metadataResponse))
 
         mockkStatic(PBServiceInfo::fromPb) {
             every { any<PBServiceInfo>().fromPb() } returns returnedServiceInfo
             val result = baseConsumerClient.getMetadata()
 
+            //
+            // NOTE: Property (i.e. `serviceInfo`) calls inside classes are no longer captured by Mockk, so there are no
+            //       recorded interactions with `baseConsumerClient.serviceInfo`.
+            //
             verifySequence {
                 baseConsumerClient.getMetadata()
                 baseConsumerClient.tryRpc<GrpcResult<ServiceInfo>>(any())
-                baseConsumerClient.serviceInfo
                 baseConsumerClient.runGetMetadata(GetMetadataRequest.newBuilder().build(), any())
                 metadataResponse.serviceInfo.fromPb()
-                baseConsumerClient.serviceInfo = returnedServiceInfo //verify response cached
-                baseConsumerClient.serviceInfo
             }
+
             assertThat(result.value, equalTo(returnedServiceInfo))
             assertThat(baseConsumerClient.serviceInfo, equalTo(returnedServiceInfo))
         }
     }
 
-    // @Test
-    // Test disabled as the mocking in this test no longer works with Mockk
-    // as it is confused between mocking a field and the getter
+    @Test
     internal fun `getMetadata returns cached response`() {
-        val uncachedServiceInfo = mockk<ServiceInfo>()
-
         val cachedResponse = PBServiceInfo.newBuilder().apply {
             title = "cached title"
             version = "cached version"
@@ -108,27 +79,45 @@ internal class TestCimConsumerClient {
             }
         }.build().fromPb()
 
-        every { baseConsumerClient.serviceInfo } returns cachedResponse
+        // We create this with a mockk to prove it isn't used, as it should use the cached version.
+        val baseConsumerClient = spyk(createClient(mockk()).apply { serviceInfo = cachedResponse })
 
-        every { baseConsumerClient.getMetadata() } answers { callOriginal() }
-        every { baseConsumerClient.tryRpc(any<() -> ServiceInfo>()) } answers {
-            GrpcResult.of(firstArg<() -> ServiceInfo>().invoke())
-        }
         mockkStatic(PBServiceInfo::fromPb) {
-            every { any<PBServiceInfo>().fromPb() } returns uncachedServiceInfo
+            every { any<PBServiceInfo>().fromPb() } throws AssertionError("shouldn't have been called")
             val result = baseConsumerClient.getMetadata()
 
+            //
+            // NOTE: Property (i.e. `serviceInfo`) calls inside classes are no longer captured by Mockk, so there are no
+            //       recorded interactions with `baseConsumerClient.serviceInfo`.
+            //
             verifySequence {
                 baseConsumerClient.getMetadata()
                 baseConsumerClient.tryRpc<GrpcResult<ServiceInfo>>(any())
-                baseConsumerClient.serviceInfo
-                baseConsumerClient.serviceInfo
             }
-            verify {
-                any<PBServiceInfo>().fromPb() wasNot called
-                uncachedServiceInfo wasNot called
-            }
+
             assertThat(result.value, equalTo(cachedResponse))
         }
     }
+
+    private fun createClient(response: GetMetadataResponse) = object : CimConsumerClient<BaseService, BaseProtoToCim, NetworkConsumerStub>() {
+        override val service: BaseService get() = assertNotCalled()
+        override val protoToCim: BaseProtoToCim get() = assertNotCalled()
+
+        override fun processIdentifiables(mRIDs: Sequence<String>): Sequence<ExtractResult> = assertNotCalled()
+
+        override fun runGetMetadata(
+            getMetadataRequest: GetMetadataRequest,
+            streamObserver: AwaitableStreamObserver<GetMetadataResponse>
+        ) {
+            streamObserver.onNext(response)
+            streamObserver.onCompleted()
+        }
+
+        override val stub: NetworkConsumerStub get() = assertNotCalled()
+
+        private fun assertNotCalled(): Nothing =
+            throw AssertionError("shouldn't have been called")
+
+    }
+
 }

--- a/src/test/kotlin/com/zepben/ewb/streaming/grpc/CallCredentialApplierTest.kt
+++ b/src/test/kotlin/com/zepben/ewb/streaming/grpc/CallCredentialApplierTest.kt
@@ -8,14 +8,22 @@
 
 package com.zepben.ewb.streaming.grpc
 
+import com.zepben.testutils.junit.SystemLogExtension
 import io.grpc.*
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.equalTo
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.RegisterExtension
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.mock
 
 internal class CallCredentialApplierTest {
+
+    companion object {
+        @JvmField
+        @RegisterExtension
+        val systemErr: SystemLogExtension = SystemLogExtension.SYSTEM_ERR.captureLog().muteOnSuccess()
+    }
 
     @Test
     internal fun interceptCallAppliesCallCredentials() {

--- a/src/test/kotlin/com/zepben/ewb/streaming/grpc/ConnectTest.kt
+++ b/src/test/kotlin/com/zepben/ewb/streaming/grpc/ConnectTest.kt
@@ -15,6 +15,7 @@ import com.zepben.ewb.auth.client.createTokenFetcherManagedIdentity
 import com.zepben.ewb.auth.common.AuthException
 import com.zepben.ewb.auth.common.AuthMethod
 import com.zepben.testutils.exception.ExpectException
+import com.zepben.testutils.junit.SystemLogExtension
 import io.mockk.*
 import io.vertx.core.json.JsonObject
 import org.hamcrest.MatcherAssert.assertThat
@@ -22,10 +23,17 @@ import org.hamcrest.Matchers.equalTo
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.RegisterExtension
 import java.net.http.HttpClient
 import javax.net.ssl.SSLContext
 
 internal class ConnectTest {
+
+    companion object {
+        @JvmField
+        @RegisterExtension
+        val systemErr: SystemLogExtension = SystemLogExtension.SYSTEM_ERR.captureLog().muteOnSuccess()
+    }
 
     private val gcbWithAddress = mockk<GrpcChannelBuilder>()
     private val gcbWithTls = mockk<GrpcChannelBuilder>()

--- a/src/test/kotlin/com/zepben/ewb/streaming/grpc/GrpcChannelBuilderTest.kt
+++ b/src/test/kotlin/com/zepben/ewb/streaming/grpc/GrpcChannelBuilderTest.kt
@@ -19,6 +19,7 @@ import com.zepben.ewb.streaming.get.QueryNetworkStateClient
 import com.zepben.ewb.streaming.mutations.UpdateNetworkStateClient
 import com.zepben.protobuf.connection.CheckConnectionRequest
 import com.zepben.testutils.exception.ExpectException.Companion.expect
+import com.zepben.testutils.junit.SystemLogExtension
 import io.grpc.*
 import io.grpc.netty.shaded.io.grpc.netty.NettyChannelBuilder
 import io.grpc.stub.ClientCalls
@@ -27,11 +28,18 @@ import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.equalTo
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.RegisterExtension
 import java.io.File
 import java.lang.reflect.Modifier
 import kotlin.reflect.KClass
 
 internal class GrpcChannelBuilderTest {
+
+    companion object {
+        @JvmField
+        @RegisterExtension
+        val systemErr: SystemLogExtension = SystemLogExtension.SYSTEM_ERR.captureLog().muteOnSuccess()
+    }
 
     @AfterEach
     internal fun teardownMockks() {

--- a/src/test/kotlin/com/zepben/ewb/streaming/grpc/TokenCallCredentialsTest.kt
+++ b/src/test/kotlin/com/zepben/ewb/streaming/grpc/TokenCallCredentialsTest.kt
@@ -9,6 +9,7 @@
 package com.zepben.ewb.streaming.grpc
 
 import com.zepben.ewb.auth.common.AuthException
+import com.zepben.testutils.junit.SystemLogExtension
 import io.grpc.CallCredentials.MetadataApplier
 import io.grpc.CallCredentials.RequestInfo
 import io.grpc.Metadata
@@ -18,10 +19,17 @@ import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.equalTo
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.RegisterExtension
 import java.io.IOException
 import java.util.concurrent.Executor
 
 internal class TokenCallCredentialsTest {
+
+    companion object {
+        @JvmField
+        @RegisterExtension
+        val systemErr: SystemLogExtension = SystemLogExtension.SYSTEM_ERR.captureLog().muteOnSuccess()
+    }
 
     @AfterEach
     fun teardownMockks() {

--- a/src/test/kotlin/com/zepben/ewb/streaming/mutations/UpdateNetworkStateClientTest.kt
+++ b/src/test/kotlin/com/zepben/ewb/streaming/mutations/UpdateNetworkStateClientTest.kt
@@ -17,6 +17,7 @@ import com.zepben.ewb.streaming.mutations.testservices.TestUpdateNetworkStateSer
 import com.zepben.protobuf.ns.SetCurrentStatesRequest
 import com.zepben.protobuf.ns.SetCurrentStatesResponse
 import com.zepben.protobuf.ns.UpdateNetworkStateServiceGrpc
+import com.zepben.testutils.junit.SystemLogExtension
 import io.grpc.inprocess.InProcessChannelBuilder
 import io.grpc.inprocess.InProcessServerBuilder
 import io.grpc.testing.GrpcCleanupRule
@@ -24,12 +25,12 @@ import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.*
 import org.junit.Rule
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.RegisterExtension
 import org.mockito.kotlin.argumentCaptor
 import org.mockito.kotlin.atLeastOnce
 import org.mockito.kotlin.spy
 import org.mockito.kotlin.verify
 import java.time.LocalDateTime
-import kotlin.streams.toList
 import com.zepben.protobuf.ns.data.BatchFailure as PBBatchFailure
 import com.zepben.protobuf.ns.data.BatchNotProcessed as PBBatchNotProcessed
 import com.zepben.protobuf.ns.data.BatchSuccessful as PBBatchSuccessful
@@ -41,6 +42,12 @@ import com.zepben.protobuf.ns.data.StateEventUnsupportedPhasing as PBStateEventU
 import org.mockito.kotlin.any as mockitoAny
 
 internal class UpdateNetworkStateClientTest {
+
+    companion object {
+        @JvmField
+        @RegisterExtension
+        val systemErr: SystemLogExtension = SystemLogExtension.SYSTEM_ERR.captureLog().muteOnSuccess()
+    }
 
     @JvmField
     @Rule


### PR DESCRIPTION
# Description

Re-enabled tests that were disabled when updating to Kotlin 2.3. They were disabled because the tests were failing in strange ways.

The root cause was discovered to be changes in the byte code introduced in the upgrade, which results in Mockk no longer seeing access to properties from within a mocked class (it now accesses the backing field directly)

# Test Steps

N/A, they are tests.

# Checklist

If any of these are not applicable, strikethrough the line `~like this~`. **Do not delete it!**. Let the reviewer decide if you should have done it.

### Code
- [x] I have performed a self review of my own code (including checking issues raised when creating the PR).
- [x] I have added/updated unit tests for these changes, and if not I have explained why they are not necessary.
- [x] I have commented my code in any hard-to-understand or hacky areas.
- [x] I have handled all new warnings generated by the compiler or IDE.
- [x] I have rebased onto the target branch (usually main).

### Security
When developing applications, use following guidelines for information security considerations:
* Access to applications should be protected with security keys/tokens or usernames and passwords;
* All sessions are encrypted if possible;
* All application input is sanitised before being acted on (ie SQL statements, etc);
* Log messages, and especially client-facing ones, must be handled securely and must not leak credentials information (internal URLs, passwords, tokens).

- [x] I have considered if this change impacts information security and made sure those impacts are handled.

### Documentation
~- [ ] I have updated the changelog.~ No change, just tests.
~- [ ] I have updated any documentation required for these changes.~

# Breaking Changes
- [x] I have considered if this is a breaking change and will communicate it with other team members by posting it on the Slack **breaking-changes** channel.

Non-breaking, its just tests.