### PR TITLE
[DEV-8825] Fixed errors in handling phase energisation of `LinearShuntCompensator` instances with a `groundingTerminal`.

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -10,7 +10,7 @@
 * None.
 
 ### Fixes
-* None.
+* Fixed errors in handling phase energisation of `LinearShuntCompensator` instances with a `groundingTerminal`.
 
 ### Notes
 * None.

--- a/changelog.md
+++ b/changelog.md
@@ -1,19 +1,7 @@
 # Zepben EWB SDK changelog
-## [1.11.0] - UNRELEASED
-### Breaking Changes
-* None.
-
-### New Features
-* None.
-
-### Enhancements
-* None.
-
+## [1.11.1] - UNRELEASED
 ### Fixes
 * Fixed errors in handling phase energisation of `LinearShuntCompensator` instances with a `groundingTerminal`.
-
-### Notes
-* None.
 
 ## [1.10.0] - 2026-05-05
 ### Breaking Changes

--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
 
     <groupId>com.zepben</groupId>
     <artifactId>ewb-sdk</artifactId>
-    <version>1.11.0b2</version>
+    <version>1.11.1b1</version>
     <packaging>jar</packaging>
     <name>${project.groupId}:${project.artifactId}</name>
     <description>SDK for interaction with the evolve platform</description>

--- a/src/main/kotlin/com/zepben/ewb/services/network/tracing/phases/SetPhases.kt
+++ b/src/main/kotlin/com/zepben/ewb/services/network/tracing/phases/SetPhases.kt
@@ -22,6 +22,7 @@ import com.zepben.ewb.services.network.tracing.networktrace.ComputeData
 import com.zepben.ewb.services.network.tracing.networktrace.NetworkTrace
 import com.zepben.ewb.services.network.tracing.networktrace.NetworkTraceActionType
 import com.zepben.ewb.services.network.tracing.networktrace.Tracing
+import com.zepben.ewb.services.network.tracing.networktrace.conditions.Conditions.stopOnShuntCompensatorGround
 import com.zepben.ewb.services.network.tracing.networktrace.operators.NetworkStateOperators
 import com.zepben.ewb.services.network.tracing.traversal.WeightedPriorityQueue
 import org.slf4j.Logger
@@ -207,6 +208,9 @@ class SetPhases(
             computeData = computeNextPhasesToFlow(stateOperators)
         )
             .addQueueCondition { nextStep, _, _, _ -> nextStep.data.nominalPhasePaths.isNotEmpty() }
+            // We don't want to "energise" the neutral from the primary or vise versa for `ShuntCompensator` grounding terminals. These sides should
+            // have their "energisation" via other connectivity.
+            .addCondition { stopOnShuntCompensatorGround() }
             .addStepAction { (path, phasesToFlow), ctx ->
                 // We always assume the first step terminal already has the phases applied, so we don't do anything on the first step
                 phasesToFlow.stepFlowedPhases =

--- a/src/main/kotlin/com/zepben/ewb/testing/TestNetworkBuilder.kt
+++ b/src/main/kotlin/com/zepben/ewb/testing/TestNetworkBuilder.kt
@@ -384,6 +384,7 @@ open class TestNetworkBuilder {
      * @param nominalPhases The nominal phases for the new [ConductingEquipment].
      * @param numTerminals The number of terminals to create on the new [ConductingEquipment]. Defaults to 2.
      * @param mRID Optional mRID for the new [ConductingEquipment].
+     * @param defaultMridPrefix Optional default prefix to add to any generated mRID. defaults to "o". Only used if no [mRID] is provided.
      * @param action An action that accepts the new [ConductingEquipment] to allow for additional initialisation.
      *
      * @return This [TestNetworkBuilder] to allow for fluent use.
@@ -408,6 +409,7 @@ open class TestNetworkBuilder {
      * @param nominalPhases The nominal phases for the new [ConductingEquipment].
      * @param numTerminals The number of terminals to create on the new [ConductingEquipment]. Defaults to 2.
      * @param mRID Optional mRID for the new [ConductingEquipment].
+     * @param defaultMridPrefix Optional default prefix to add to any generated mRID. defaults to "o". Only used if no [mRID] is provided.
      * @param action An action that accepts the new [ConductingEquipment] to allow for additional initialisation.
      *
      * @return This [TestNetworkBuilder] to allow for fluent use.
@@ -430,6 +432,7 @@ open class TestNetworkBuilder {
      * @param mRID Optional mRID for the new [ConductingEquipment].
      * @param connectivityNodeMrid Optional id of the connectivity node used to connect this [ConductingEquipment] to the previous item. Will only be used if
      * the previous item is not already connected.
+     * @param defaultMridPrefix Optional default prefix to add to any generated mRID. defaults to "o". Only used if no [mRID] is provided.
      * @param action An action that accepts the new [ConductingEquipment] to allow for additional initialisation.
      *
      * @return This [TestNetworkBuilder] to allow for fluent use.
@@ -460,6 +463,7 @@ open class TestNetworkBuilder {
      * @param mRID Optional mRID for the new [ConductingEquipment].
      * @param connectivityNodeMrid Optional id of the connectivity node used to connect this [ConductingEquipment] to the previous item. Will only be used if
      * the previous item is not already connected.
+     * @param defaultMridPrefix Optional default prefix to add to any generated mRID. defaults to "o". Only used if no [mRID] is provided.
      * @param action An action that accepts the new [ConductingEquipment] to allow for additional initialisation.
      *
      * @return This [TestNetworkBuilder] to allow for fluent use.

--- a/src/test/kotlin/com/zepben/ewb/services/network/tracing/phases/SetPhasesTest.kt
+++ b/src/test/kotlin/com/zepben/ewb/services/network/tracing/phases/SetPhasesTest.kt
@@ -12,8 +12,7 @@ package com.zepben.ewb.services.network.tracing.phases
 import com.zepben.ewb.cim.iec61970.base.core.ConductingEquipment
 import com.zepben.ewb.cim.iec61970.base.core.PhaseCode
 import com.zepben.ewb.cim.iec61970.base.core.Terminal
-import com.zepben.ewb.cim.iec61970.base.wires.AcLineSegment
-import com.zepben.ewb.cim.iec61970.base.wires.EnergySource
+import com.zepben.ewb.cim.iec61970.base.wires.*
 import com.zepben.ewb.services.network.NetworkService
 import com.zepben.ewb.services.network.testdata.PhaseSwapLoopNetwork
 import com.zepben.ewb.services.network.tracing.networktrace.operators.NetworkStateOperators
@@ -624,6 +623,32 @@ internal class SetPhasesTest {
         PhaseValidator.validatePhases(ns, "tx9", PhaseCode.A, PhaseCode.ABN)
         PhaseValidator.validatePhases(ns, "c10", PhaseCode.ABN, PhaseCode.ABN)
         PhaseValidator.validatePhases(ns, "c11", PhaseCode.ABN, PhaseCode.ABN)
+    }
+
+    @Test
+    internal fun `doesn't set phases either way through a grounding terminal of a shunt compensator`() {
+        //
+        // s0 11--c1--21 lsc2 21--c3--2
+        //
+        // s4 11--c5--21 lsc6 21--c7--2
+        //
+        val ns = TestNetworkBuilder()
+            .fromSource() // s0
+            .toAcls() // c1
+            .toOther<LinearShuntCompensator>(defaultMridPrefix = "lsc") { groundingTerminal = terminals.last().apply { phases = PhaseCode.N } } // lsc2
+            .toAcls(nominalPhases = PhaseCode.N) // c3
+            .fromSource(phases = PhaseCode.N) // s4
+            .toAcls(nominalPhases = PhaseCode.N) // c5
+            .toOther<LinearShuntCompensator>(defaultMridPrefix = "lsc") { groundingTerminal = terminals.first().apply { phases = PhaseCode.N } } // lcs6
+            .toAcls() // c7
+            .buildAndLog()
+
+        PhaseValidator.validatePhases(ns, "c1", PhaseCode.ABC, PhaseCode.ABC)
+        PhaseValidator.validatePhases(ns, "lsc2", PhaseCode.ABC, PhaseCode.NONE)
+        PhaseValidator.validatePhases(ns, "c3", PhaseCode.NONE, PhaseCode.NONE)
+        PhaseValidator.validatePhases(ns, "c5", PhaseCode.N, PhaseCode.N)
+        PhaseValidator.validatePhases(ns, "lsc6", PhaseCode.N, PhaseCode.NONE)
+        PhaseValidator.validatePhases(ns, "c7", PhaseCode.NONE, PhaseCode.NONE)
     }
 
     private fun validateTxPhases(sourcePhases: PhaseCode, txPhase1: PhaseCode, txPhase2: PhaseCode, expectedPhases1: PhaseCode, expectedPhases2: PhaseCode) =


### PR DESCRIPTION
# Description

Made the `SetPhases` algorithm stop at the transition between the grounding terminals and normal terminals of a `LinearShuntCompensator` (which previously caused a crash). I am unsure how this has ever worked, so perhaps all previous testing had errors in the data.

# Associated tasks

- https://github.com/zepben/commons/pull/174

# Test Steps

Add a `LinearShuntCompensator` to your database with a `groundingTerminal` and ensure it can load.

# Checklist

If any of these are not applicable, strikethrough the line `~like this~`. **Do not delete it!**. Let the reviewer decide if you should have done it.

### Code
- [x] I have performed a self review of my own code (including checking issues raised when creating the PR).
- [x] I have added/updated unit tests for these changes, and if not I have explained why they are not necessary.
- [x] I have commented my code in any hard-to-understand or hacky areas.
- [x] I have handled all new warnings generated by the compiler or IDE.
- [x] I have rebased onto the target branch (usually main).

### Security
When developing applications, use following guidelines for information security considerations:
* Access to applications should be protected with security keys/tokens or usernames and passwords;
* All sessions are encrypted if possible;
* All application input is sanitised before being acted on (ie SQL statements, etc);
* Log messages, and especially client-facing ones, must be handled securely and must not leak credentials information (internal URLs, passwords, tokens).

- [x] I have considered if this change impacts information security and made sure those impacts are handled.

### Documentation
- [x] I have updated the changelog.
~- [ ] I have updated any documentation required for these changes.~

# Breaking Changes
- [x] I have considered if this is a breaking change and will communicate it with other team members by posting it on the Slack **breaking-changes** channel.

Non-breaking