### PR TITLE
[DEV-8783] Named GRPC threads

### DIFF
--- a/src/main/kotlin/com/zepben/ewb/streaming/get/CustomerConsumerClient.kt
+++ b/src/main/kotlin/com/zepben/ewb/streaming/get/CustomerConsumerClient.kt
@@ -48,7 +48,7 @@ class CustomerConsumerClient @JvmOverloads constructor(
     @JvmOverloads
     constructor(channel: Channel, callCredentials: CallCredentials? = null) :
         this(
-            CustomerConsumerGrpc.newStub(channel).withExecutor(Executors.newSingleThreadExecutor()).apply { callCredentials?.let { withCallCredentials(it) } },
+            CustomerConsumerGrpc.newStub(channel).withExecutor(GrpcExecutorFactory.create("customer-consumer")).apply { callCredentials?.let { withCallCredentials(it) } },
         )
 
     /**

--- a/src/main/kotlin/com/zepben/ewb/streaming/get/DiagramConsumerClient.kt
+++ b/src/main/kotlin/com/zepben/ewb/streaming/get/DiagramConsumerClient.kt
@@ -46,7 +46,7 @@ class DiagramConsumerClient(
     @JvmOverloads
     constructor(channel: Channel, callCredentials: CallCredentials? = null) :
         this(
-            DiagramConsumerGrpc.newStub(channel).withExecutor(Executors.newSingleThreadExecutor()).apply { callCredentials?.let { withCallCredentials(it) } },
+            DiagramConsumerGrpc.newStub(channel).withExecutor(GrpcExecutorFactory.create("diagram-consumer")).apply { callCredentials?.let { withCallCredentials(it) } },
         )
 
     /**

--- a/src/main/kotlin/com/zepben/ewb/streaming/get/GrpcExecutorFactory.kt
+++ b/src/main/kotlin/com/zepben/ewb/streaming/get/GrpcExecutorFactory.kt
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2026 Zeppelin Bend Pty Ltd
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+package com.zepben.ewb.streaming.get
+
+import java.util.concurrent.ExecutorService
+import java.util.concurrent.Executors
+import java.util.concurrent.atomic.AtomicInteger
+
+object GrpcExecutorFactory {
+    private val globalThreadCount = AtomicInteger(1)
+
+    fun create(serviceName: String): ExecutorService {
+        return Executors.newSingleThreadExecutor { runnable ->
+            Thread(runnable).apply {
+                name = "ewb-sdk-$serviceName-${globalThreadCount.getAndIncrement()}"
+            }
+        }
+    }
+}

--- a/src/main/kotlin/com/zepben/ewb/streaming/get/NetworkConsumerClient.kt
+++ b/src/main/kotlin/com/zepben/ewb/streaming/get/NetworkConsumerClient.kt
@@ -65,7 +65,7 @@ class NetworkConsumerClient(
     @JvmOverloads
     constructor(channel: Channel, callCredentials: CallCredentials? = null) :
         this(
-            NetworkConsumerGrpc.newStub(channel).withExecutor(Executors.newSingleThreadExecutor()).apply { callCredentials?.let { withCallCredentials(it) } }
+            NetworkConsumerGrpc.newStub(channel).withExecutor(GrpcExecutorFactory.create("network-consumer")).apply { callCredentials?.let { withCallCredentials(it) } }
         )
 
     /**

--- a/src/main/kotlin/com/zepben/ewb/streaming/get/QueryNetworkStateClient.kt
+++ b/src/main/kotlin/com/zepben/ewb/streaming/get/QueryNetworkStateClient.kt
@@ -47,7 +47,7 @@ class QueryNetworkStateClient(
     @JvmOverloads
     constructor(channel: Channel, networkStateIssues: NetworkStateIssues, callCredentials: CallCredentials? = null) :
         this(
-            QueryNetworkStateServiceGrpc.newStub(channel).withExecutor(Executors.newSingleThreadExecutor()).apply {
+            QueryNetworkStateServiceGrpc.newStub(channel).withExecutor(GrpcExecutorFactory.create("query-network-state")).apply {
                 callCredentials?.let { withCallCredentials(it) }
             },
             networkStateIssues,

--- a/src/main/kotlin/com/zepben/ewb/streaming/mutations/UpdateNetworkStateClient.kt
+++ b/src/main/kotlin/com/zepben/ewb/streaming/mutations/UpdateNetworkStateClient.kt
@@ -12,6 +12,7 @@ import com.zepben.ewb.streaming.data.CurrentStateEvent
 import com.zepben.ewb.streaming.data.CurrentStateEventBatch
 import com.zepben.ewb.streaming.data.SetCurrentStatesStatus
 import com.zepben.ewb.streaming.get.AwaitableStreamObserver
+import com.zepben.ewb.streaming.get.GrpcExecutorFactory
 import com.zepben.ewb.streaming.grpc.GrpcChannel
 import com.zepben.ewb.streaming.grpc.GrpcClient
 import com.zepben.protobuf.ns.UpdateNetworkStateServiceGrpc
@@ -43,7 +44,7 @@ class UpdateNetworkStateClient(
     @JvmOverloads
     constructor(channel: Channel, callCredentials: CallCredentials? = null) :
         this(
-            UpdateNetworkStateServiceGrpc.newStub(channel).withExecutor(Executors.newSingleThreadExecutor()).apply {
+            UpdateNetworkStateServiceGrpc.newStub(channel).withExecutor(GrpcExecutorFactory.create("update-network-state")).apply {
                 callCredentials?.let { withCallCredentials(it) }
             },
         )


### PR DESCRIPTION
# Description

We have previously struggled with debugging issues where open gRPC connections in applications prevents the application from shutting down cleanly, leading to hanging containers in production. Eventually we figured out it was the SDK gRPC threads that cause the issuer, but if we had more Executor pools, it would have been even more of a struggle as the names of the threads are `pool-N-thread-M`. 

This PR add a helper function to the SDK that will create named threads to allow tracing the source of these threads. The intent is that this function is used by the SDK whenever it needs threads. This change is local to the SDK and downstream applications will automatically inherit this as they upgrade.

Regarding the methodology of creating the threads, the previously used interface would use the internal `DefaultThreadFactory` which sets the default name and sets thread priority to normal. It will also inherit thread group based on the JVMs SecurityManager. I have chosen to not replicate this behavior as the Security Manager is deprecated and I believe we don't depend on the behavior.

Open to feedback on testing as I have no idea if its applicable here or overkill.

# Associated tasks

None.

# Test Steps

1. Create a NetworkConsumerclient
2. Have intellij dump threads
3. See sexy thread name
4. Great Success!

# Checklist

If any of these are not applicable, strikethrough the line `~like this~`. **Do not delete it!**. Let the reviewer decide if you should have done it.

### Code
- [x] I have performed a self review of my own code (including checking issues raised when creating the PR).
- [x] I have added/updated unit tests for these changes, and if not I have explained why they are not necessary.
- [x] I have commented my code in any hard-to-understand or hacky areas.
- [x] I have handled all new warnings generated by the compiler or IDE.
- [x] I have rebased onto the target branch (usually main).

### Security
When developing applications, use following guidelines for information security considerations:
* Access to applications should be protected with security keys/tokens or usernames and passwords;
* All sessions are encrypted if possible;
* All application input is sanitised before being acted on (ie SQL statements, etc);
* Log messages, and especially client-facing ones, must be handled securely and must not leak credentials information (internal URLs, passwords, tokens).

- [ ] I have considered if this change impacts information security and made sure those impacts are handled.

### Documentation
- [ ] I have updated the changelog.
- [ ] I have updated any documentation required for these changes.

# Breaking Changes
- [ ] I have considered if this is a breaking change and will communicate it with other team members by posting it on the Slack **breaking-changes** channel.

Please leave a summary of the breaking changes here and then post it on the Slack **breaking-changes** channel to notify the team about it.

# Screenshots

Remove this section if the change cannot be shown through screenshots. Frontend changes should mostly include this section.
Screenshots can be copy-pasted into Github textboxes and a link will automatically be generated.
Remove this text if you choose to use this section.

| Before | After |
| --- | --- |
| ![image](image-link-here) | ![image](image-link-here) |
