### PR TITLE
[DEV-9051] Update superpom to include apache.sshd dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
     <parent>
         <groupId>com.zepben.maven</groupId>
         <artifactId>evolve-super-pom</artifactId>
-        <version>0.49.0</version>
+        <version>0.50.0</version>
     </parent>
 
     <groupId>com.zepben</groupId>


### PR DESCRIPTION
# Description

Superpom version update due to added `org.apache.sshd` dependency. 