### PR TITLE
[DEV-9316] Allow update to terminal conductingEquipment after setting it.

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -4,7 +4,7 @@
 * None.
 
 ### New Features
-* None.
+* Adds `compareRunTimeVariables` to `NetworkServiceComparatorOptions` to allow the users to ignore variables that are only populated during EWB spin up.
 
 ### Enhancements
 * Terminal can now update its conductingEquipment after its set. 

--- a/changelog.md
+++ b/changelog.md
@@ -7,7 +7,8 @@
 * None.
 
 ### Enhancements
-* None.
+* Terminal can now update its conductingEquipment after its set. 
+  To do this, first remove the terminal from associated conducting equipment then add the terminal to new conducting equipment.
 
 ### Fixes
 * None.

--- a/changelog.md
+++ b/changelog.md
@@ -1,7 +1,7 @@
 # Zepben EWB SDK changelog
 ## [1.13.0] - UNRELEASED
 ### Breaking Changes
-* None.
+* Deprecated `NetworkServiceComparatorOptions.Builder`. This will be removed in a future release.
 
 ### New Features
 * Adds `compareRunTimeVariables` to `NetworkServiceComparatorOptions` to allow the users to ignore variables that are only populated during EWB spin up.

--- a/changelog.md
+++ b/changelog.md
@@ -4,11 +4,11 @@
 * Deprecated `NetworkServiceComparatorOptions.Builder`. This will be removed in a future release.
 
 ### New Features
-* Adds `compareRunTimeVariables` to `NetworkServiceComparatorOptions` to allow the users to ignore variables that are only populated during EWB spin up.
+* Adds `compareRunTime` to `NetworkServiceComparatorOptions` to allow the users to ignore variables/references that are only populated during EWB spin up.
 
 ### Enhancements
-* Terminal can now update its conductingEquipment after its set. 
-  To do this, first remove the terminal from associated conducting equipment then add the terminal to new conducting equipment.
+* `Terminal` can now update its `conductingEquipment` as long as there is no back reference. If you want to reassign a terminal,
+  first remove the terminal from associated conducting equipment, then add the terminal to new conducting equipment.
 
 ### Fixes
 * None.

--- a/src/main/kotlin/com/zepben/ewb/cim/iec61970/base/core/ConductingEquipment.kt
+++ b/src/main/kotlin/com/zepben/ewb/cim/iec61970/base/core/ConductingEquipment.kt
@@ -94,12 +94,16 @@ abstract class ConductingEquipment(mRID: String) : Equipment(mRID) {
     open val maxTerminals: Int get() = Int.MAX_VALUE
 
     /**
-     * Remove a [Terminal] from this [ConductingEquipment].
+     * Remove a [Terminal] from this [ConductingEquipment]. If the [terminal] is removed,
+     * the reverse link to this [ConductingEquipment] will also be cleared.
      *
      * @param terminal The [Terminal] to remove.
      * @return true if [terminal] is removed from the collection.
      */
-    fun removeTerminal(terminal: Terminal): Boolean = _terminals.remove(terminal).also { terminal._conductingEquipment = null }
+    fun removeTerminal(terminal: Terminal): Boolean = _terminals.remove(terminal).also { removed ->
+        if (removed)
+            terminal._conductingEquipment = null
+    }
 
     /**
      * Clear all [Terminal]'s from this [ConductingEquipment].

--- a/src/main/kotlin/com/zepben/ewb/cim/iec61970/base/core/ConductingEquipment.kt
+++ b/src/main/kotlin/com/zepben/ewb/cim/iec61970/base/core/ConductingEquipment.kt
@@ -99,7 +99,7 @@ abstract class ConductingEquipment(mRID: String) : Equipment(mRID) {
      * @param terminal The [Terminal] to remove.
      * @return true if [terminal] is removed from the collection.
      */
-    fun removeTerminal(terminal: Terminal): Boolean = _terminals.remove(terminal)
+    fun removeTerminal(terminal: Terminal): Boolean = _terminals.remove(terminal).also { terminal._conductingEquipment = null }
 
     /**
      * Clear all [Terminal]'s from this [ConductingEquipment].
@@ -107,7 +107,9 @@ abstract class ConductingEquipment(mRID: String) : Equipment(mRID) {
      * @return This [ConductingEquipment] for fluent use.
      */
     fun clearTerminals(): ConductingEquipment {
+        val toClearAssociation = _terminals.toList()
         _terminals.clear()
+        toClearAssociation.forEach { terminal -> terminal._conductingEquipment = null }
         return this
     }
 
@@ -116,7 +118,7 @@ abstract class ConductingEquipment(mRID: String) : Equipment(mRID) {
             return true
 
         if (terminal.conductingEquipment == null)
-            terminal.conductingEquipment = this
+            terminal._conductingEquipment = this
 
         require(terminal.conductingEquipment === this) {
             "${terminal.typeNameAndMRID()} `conductingEquipment` property references ${terminal.conductingEquipment!!.typeNameAndMRID()}, expected ${typeNameAndMRID()}."

--- a/src/main/kotlin/com/zepben/ewb/cim/iec61970/base/core/ConductingEquipment.kt
+++ b/src/main/kotlin/com/zepben/ewb/cim/iec61970/base/core/ConductingEquipment.kt
@@ -111,6 +111,10 @@ abstract class ConductingEquipment(mRID: String) : Equipment(mRID) {
      * @return This [ConductingEquipment] for fluent use.
      */
     fun clearTerminals(): ConductingEquipment {
+        //
+        // NOTE: We can only set the terminals `conductingEquiment` if it doesn't belong to the terminals list,
+        //       so we must clear our list of terminals before removing each terminals conducting equipemnt.
+        //
         val toClearAssociation = _terminals.toList()
         _terminals.clear()
         toClearAssociation.forEach { terminal -> terminal._conductingEquipment = null }

--- a/src/main/kotlin/com/zepben/ewb/cim/iec61970/base/core/Terminal.kt
+++ b/src/main/kotlin/com/zepben/ewb/cim/iec61970/base/core/Terminal.kt
@@ -34,7 +34,7 @@ class Terminal(mRID: String) : AcDcTerminal(mRID) {
         internal set(value) {
             field?.also {
                 require((value == null && this !in it.terminals) || field === value) {
-                    "conductingEquipment has already been set to $field. Please remove this terminal from the conducting equipment before setting this field again."
+                    "This terminal is currently being used by ${it.typeNameAndMRID()}. Please remove this terminal from the conducting equipment before setting this field again."
                 }
             }
             field = value

--- a/src/main/kotlin/com/zepben/ewb/cim/iec61970/base/core/Terminal.kt
+++ b/src/main/kotlin/com/zepben/ewb/cim/iec61970/base/core/Terminal.kt
@@ -28,10 +28,24 @@ import java.lang.ref.WeakReference
  */
 class Terminal(mRID: String) : AcDcTerminal(mRID) {
 
-    var conductingEquipment: ConductingEquipment? = null
+    // When deprecating original set for conductingEquipment, this variable is a replacement for the original conductingEquipment variable. (Set should remain to be internal)
+    @Suppress("RedundantVisibilityModifier")
+    internal var _conductingEquipment: ConductingEquipment? = null
+        internal set(value) {
+            field?.also {
+                require((value == null && this !in it.terminals) || field === value) {
+                    "conductingEquipment has already been set to $field. Please remove this terminal from the conducting equipment before setting this field again."
+                }
+            }
+            field = value
+        }
+
+    var conductingEquipment: ConductingEquipment?
+        get() = _conductingEquipment
+        @Deprecated("Setting Conducting Equipment Directly has been deprecated. Replace with Adding/Removing Terminal from the conducting equipment.")
         set(value) {
-            field =
-                if (field == null || field === value) value else throw IllegalStateException("conductingEquipment has already been set to $field. Cannot set this field again")
+            _conductingEquipment =
+                if (_conductingEquipment == null || _conductingEquipment === value) value else throw IllegalStateException("conductingEquipment has already been set to $_conductingEquipment. Cannot set this field again")
         }
 
     var phases: PhaseCode = PhaseCode.ABC

--- a/src/main/kotlin/com/zepben/ewb/services/common/PropertyComparers.kt
+++ b/src/main/kotlin/com/zepben/ewb/services/common/PropertyComparers.kt
@@ -91,21 +91,29 @@ fun <T, R : Identifiable> KProperty1<in T, R?>.compareIdReference(source: T?, ta
  * @param target The second object to compare.
  * @return The [ObjectCollectionDifference] if there were any differences, otherwise `null`.
  */
-fun <T, R : Identifiable> KProperty1<in T, Collection<R>>.compareIdReferenceCollection(source: T, target: T): ObjectCollectionDifference? {
+fun <T, R : Identifiable> KProperty1<in T, Collection<R>>.compareIdReferenceCollection(source: T, target: T): ObjectCollectionDifference? =
+    compareIdReferenceCollection(get(source), get(target))
+
+/**
+ * Compare the mRID references of all items in a collection, in any order, between [source] and [target].
+ *
+ * @param source The first collection to compare.
+ * @param target The second collection to compare.
+ * @return The [ObjectCollectionDifference] if there were any differences, otherwise `null`.
+ */
+fun <T : Identifiable> compareIdReferenceCollection(source: Collection<T>, target: Collection<T>): ObjectCollectionDifference? {
     val differences = ObjectCollectionDifference()
-    val sourceCollection = this.get(source)
-    val targetCollection = this.get(target)
 
     val sourceMRIDs = mutableSetOf<String>()
-    sourceCollection.forEach { sourceIdObj ->
+    source.forEach { sourceIdObj ->
         sourceMRIDs.add(sourceIdObj.mRID)
-        val targetIdObj = targetCollection.find { it.mRID == sourceIdObj.mRID }
+        val targetIdObj = target.find { it.mRID == sourceIdObj.mRID }
         if (targetIdObj == null) {
             differences.missingFromTarget.add(sourceIdObj)
         }
     }
 
-    targetCollection.forEach {
+    target.forEach {
         if (!sourceMRIDs.contains(it.mRID))
             differences.missingFromSource.add(it)
     }

--- a/src/main/kotlin/com/zepben/ewb/services/network/NetworkServiceComparator.kt
+++ b/src/main/kotlin/com/zepben/ewb/services/network/NetworkServiceComparator.kt
@@ -45,10 +45,7 @@ import com.zepben.ewb.cim.iec61970.base.scada.RemotePoint
 import com.zepben.ewb.cim.iec61970.base.scada.RemoteSource
 import com.zepben.ewb.cim.iec61970.base.wires.*
 import com.zepben.ewb.cim.iec61970.infiec61970.feeder.Circuit
-import com.zepben.ewb.services.common.BaseServiceComparator
-import com.zepben.ewb.services.common.ObjectDifference
-import com.zepben.ewb.services.common.ValueDifference
-import com.zepben.ewb.services.common.compareValues
+import com.zepben.ewb.services.common.*
 
 /**
  * @param options Indicates which optional checks to perform
@@ -111,9 +108,7 @@ class NetworkServiceComparator @JvmOverloads constructor(
         ObjectDifference(source, target).apply {
             compareIdentifiedObject()
 
-            if (options.compareRunTimeVariables) {
-                compareIdReferenceCollections(Loop::circuits, Loop::substations, Loop::energizingSubstations)
-            }
+            compareIdReferenceCollections(Loop::circuits, Loop::substations, Loop::energizingSubstations)
         }
 
     private fun compareLvFeeder(source: LvFeeder, target: LvFeeder): ObjectDifference<LvFeeder> =
@@ -121,10 +116,11 @@ class NetworkServiceComparator @JvmOverloads constructor(
             compareEquipmentContainer()
 
             compareIdReferences(LvFeeder::normalHeadTerminal)
+            compareIdReferences(LvFeeder::normalEnergizingLvSubstation)
+
             if (options.compareRunTimeVariables) {
                 compareIdReferenceCollections(LvFeeder::normalEnergizingFeeders)
                 compareIdReferenceCollections(LvFeeder::currentEnergizingFeeders)
-                compareIdReferences(LvFeeder::normalEnergizingLvSubstation)
                 if (options.compareFeederEquipment) {
                     compareIdReferenceCollections(LvFeeder::currentEquipment)
                 }
@@ -135,10 +131,11 @@ class NetworkServiceComparator @JvmOverloads constructor(
         ObjectDifference(source, target).apply {
             compareEquipmentContainer()
 
+            compareIdReferenceCollections(LvSubstation::normalEnergizedLvFeeders)
+
             if (options.compareRunTimeVariables) {
                 compareIdReferenceCollections(LvSubstation::normalEnergizingFeeders)
                 compareIdReferenceCollections(LvSubstation::currentEnergizingFeeders)
-                compareIdReferenceCollections(LvSubstation::normalEnergizedLvFeeders)
             }
         }
 
@@ -586,9 +583,7 @@ class NetworkServiceComparator @JvmOverloads constructor(
         apply {
             compareEquipment()
 
-            if (options.compareRunTimeVariables) {
-                compareIdReferences(ConductingEquipment::baseVoltage)
-            }
+            compareIdReferences(ConductingEquipment::baseVoltage)
             if (options.compareTerminals)
                 compareIndexedIdReferenceCollections(ConductingEquipment::terminals)
         }
@@ -616,10 +611,14 @@ class NetworkServiceComparator @JvmOverloads constructor(
 
             compareValues(Equipment::inService, Equipment::normallyInService, Equipment::commissionedDate)
 
-            if (options.compareRunTimeVariables) {
-                if (options.compareEquipmentContainers) {
+            if (options.compareEquipmentContainers) {
+                if (options.compareRunTimeVariables)
                     compareIdReferenceCollections(Equipment::containers)
-                    compareIdReferenceCollections(Equipment::currentContainers)
+                else {
+                    compareIdReferenceCollection(
+                        source.containers.filterNot { it.populatedAtRuntTime },
+                        target.containers.filterNot { it.populatedAtRuntTime },
+                    )
                 }
             }
 
@@ -627,24 +626,25 @@ class NetworkServiceComparator @JvmOverloads constructor(
                 compareIdReferenceCollections(Equipment::usagePoints)
 
             compareIdReferenceCollections(Equipment::operationalRestrictions)
+
+            if (options.compareEquipmentContainers && options.compareRunTimeVariables)
+                compareIdReferenceCollections(Equipment::currentContainers)
         }
 
     private fun ObjectDifference<out EquipmentContainer>.compareEquipmentContainer(): ObjectDifference<out EquipmentContainer> =
         apply {
             compareConnectivityNodeContainer()
 
-            if (options.compareRunTimeVariables) {
+            if (options.compareRunTimeVariables || !source.populatedAtRuntTime)
                 compareIdReferenceCollections(EquipmentContainer::equipment)
-            }
         }
 
     private fun compareFeeder(source: Feeder, target: Feeder): ObjectDifference<Feeder> =
         ObjectDifference(source, target).apply {
             compareEquipmentContainer()
 
-            compareIdReferences(Feeder::normalHeadTerminal)
+            compareIdReferences(Feeder::normalHeadTerminal, Feeder::normalEnergizingSubstation)
             if (options.compareRunTimeVariables) {
-                compareIdReferences(Feeder::normalEnergizingSubstation)
                 compareIdReferenceCollections(Feeder::normalEnergizedLvFeeders)
                 compareIdReferenceCollections(Feeder::currentEnergizedLvFeeders)
                 compareIdReferenceCollections(Feeder::normalEnergizedLvSubstations)
@@ -685,9 +685,7 @@ class NetworkServiceComparator @JvmOverloads constructor(
             compareEquipmentContainer()
 
             compareIdReferences(Substation::subGeographicalRegion)
-            if (options.compareRunTimeVariables) {
-                compareIdReferenceCollections(Substation::feeders)
-            }
+            compareIdReferenceCollections(Substation::feeders)
         }
 
     private fun compareTerminal(source: Terminal, target: Terminal): ObjectDifference<Terminal> =
@@ -695,9 +693,9 @@ class NetworkServiceComparator @JvmOverloads constructor(
             compareAcDcTerminal()
 
             compareIdReferences(Terminal::conductingEquipment, Terminal::connectivityNode)
-            compareValues(Terminal::sequenceNumber)
+            compareValues(Terminal::phases, Terminal::sequenceNumber)
             if (options.compareRunTimeVariables) {
-                compareValues(Terminal::phases, Terminal::normalFeederDirection, Terminal::currentFeederDirection)
+                compareValues(Terminal::normalFeederDirection, Terminal::currentFeederDirection)
                 addIfDifferent(Terminal::normalPhases.name, Terminal::normalPhases.compareValues(source, target) { it.phaseStatusInternal })
                 addIfDifferent(Terminal::currentPhases.name, Terminal::currentPhases.compareValues(source, target) { it.phaseStatusInternal })
             }
@@ -917,9 +915,7 @@ class NetworkServiceComparator @JvmOverloads constructor(
         ObjectDifference(source, target).apply {
             compareEnergyConnection()
 
-            if (options.compareRunTimeVariables) {
-                compareIdReferenceCollections(EnergyConsumer::phases)
-            }
+            compareIdReferenceCollections(EnergyConsumer::phases)
             compareValues(
                 EnergyConsumer::customerCount,
                 EnergyConsumer::grounded,
@@ -943,9 +939,7 @@ class NetworkServiceComparator @JvmOverloads constructor(
         ObjectDifference(source, target).apply {
             compareEnergyConnection()
 
-            if (options.compareRunTimeVariables) {
-                compareIdReferenceCollections(EnergySource::phases)
-            }
+            compareIdReferenceCollections(EnergySource::phases)
             compareValues(
                 EnergySource::activePower,
                 EnergySource::reactivePower,
@@ -1082,10 +1076,7 @@ class NetworkServiceComparator @JvmOverloads constructor(
         ObjectDifference(source, target).apply {
             compareRegulatingCondEq()
 
-            compareIdReferenceCollections(PowerElectronicsConnection::units)
-            if (options.compareRunTimeVariables) {
-                compareIdReferenceCollections(PowerElectronicsConnection::phases)
-            }
+            compareIdReferenceCollections(PowerElectronicsConnection::units, PowerElectronicsConnection::phases)
             compareValues(
                 PowerElectronicsConnection::maxIFault,
                 PowerElectronicsConnection::maxQ,
@@ -1338,10 +1329,7 @@ class NetworkServiceComparator @JvmOverloads constructor(
             compareIdentifiedObject()
 
             compareValues(TransformerEnd::grounded, TransformerEnd::rGround, TransformerEnd::xGround, TransformerEnd::endNumber)
-            compareIdReferences(TransformerEnd::ratioTapChanger, TransformerEnd::terminal, TransformerEnd::starImpedance)
-            if (options.compareRunTimeVariables){
-                compareIdReferences(TransformerEnd::baseVoltage)
-            }
+            compareIdReferences(TransformerEnd::baseVoltage, TransformerEnd::ratioTapChanger, TransformerEnd::terminal, TransformerEnd::starImpedance)
         }
 
     private fun compareTransformerStarImpedance(
@@ -1367,6 +1355,10 @@ class NetworkServiceComparator @JvmOverloads constructor(
             compareIdReferenceCollections(Circuit::endTerminals, Circuit::endSubstations)
         }
 
+    // ###########
+    // # Helpers #
+    // ###########
+
     private fun compareOpenStatus(source: Switch, target: Switch, openTest: (Switch, SinglePhaseKind) -> Boolean): ValueDifference? {
         val sourceStatus = PhaseCode.ABCN.singlePhases.associateWith { openTest(source, it) }
         val targetStatus = PhaseCode.ABCN.singlePhases.associateWith { openTest(target, it) }
@@ -1377,5 +1369,12 @@ class NetworkServiceComparator @JvmOverloads constructor(
             null
         }
     }
+
+    private val EquipmentContainer.populatedAtRuntTime: Boolean
+        get() = when (this) {
+            is LvFeeder -> true
+            is Feeder -> true
+            else -> false
+        }
 
 }

--- a/src/main/kotlin/com/zepben/ewb/services/network/NetworkServiceComparator.kt
+++ b/src/main/kotlin/com/zepben/ewb/services/network/NetworkServiceComparator.kt
@@ -118,7 +118,7 @@ class NetworkServiceComparator @JvmOverloads constructor(
             compareIdReferences(LvFeeder::normalHeadTerminal)
             compareIdReferences(LvFeeder::normalEnergizingLvSubstation)
 
-            if (options.compareRunTimeVariables) {
+            if (options.compareRunTime) {
                 compareIdReferenceCollections(LvFeeder::normalEnergizingFeeders)
                 compareIdReferenceCollections(LvFeeder::currentEnergizingFeeders)
                 if (options.compareFeederEquipment) {
@@ -133,7 +133,7 @@ class NetworkServiceComparator @JvmOverloads constructor(
 
             compareIdReferenceCollections(LvSubstation::normalEnergizedLvFeeders)
 
-            if (options.compareRunTimeVariables) {
+            if (options.compareRunTime) {
                 compareIdReferenceCollections(LvSubstation::normalEnergizingFeeders)
                 compareIdReferenceCollections(LvSubstation::currentEnergizingFeeders)
             }
@@ -612,7 +612,7 @@ class NetworkServiceComparator @JvmOverloads constructor(
             compareValues(Equipment::inService, Equipment::normallyInService, Equipment::commissionedDate)
 
             if (options.compareEquipmentContainers) {
-                if (options.compareRunTimeVariables)
+                if (options.compareRunTime)
                     compareIdReferenceCollections(Equipment::containers)
                 else {
                     compareIdReferenceCollection(
@@ -627,7 +627,7 @@ class NetworkServiceComparator @JvmOverloads constructor(
 
             compareIdReferenceCollections(Equipment::operationalRestrictions)
 
-            if (options.compareEquipmentContainers && options.compareRunTimeVariables)
+            if (options.compareEquipmentContainers && options.compareRunTime)
                 compareIdReferenceCollections(Equipment::currentContainers)
         }
 
@@ -635,7 +635,7 @@ class NetworkServiceComparator @JvmOverloads constructor(
         apply {
             compareConnectivityNodeContainer()
 
-            if (options.compareRunTimeVariables || !source.populatedAtRuntTime)
+            if (options.compareRunTime || !source.populatedAtRuntTime)
                 compareIdReferenceCollections(EquipmentContainer::equipment)
         }
 
@@ -644,7 +644,7 @@ class NetworkServiceComparator @JvmOverloads constructor(
             compareEquipmentContainer()
 
             compareIdReferences(Feeder::normalHeadTerminal, Feeder::normalEnergizingSubstation)
-            if (options.compareRunTimeVariables) {
+            if (options.compareRunTime) {
                 compareIdReferenceCollections(Feeder::normalEnergizedLvFeeders)
                 compareIdReferenceCollections(Feeder::currentEnergizedLvFeeders)
                 compareIdReferenceCollections(Feeder::normalEnergizedLvSubstations)
@@ -694,7 +694,7 @@ class NetworkServiceComparator @JvmOverloads constructor(
 
             compareIdReferences(Terminal::conductingEquipment, Terminal::connectivityNode)
             compareValues(Terminal::phases, Terminal::sequenceNumber)
-            if (options.compareRunTimeVariables) {
+            if (options.compareRunTime) {
                 compareValues(Terminal::normalFeederDirection, Terminal::currentFeederDirection)
                 addIfDifferent(Terminal::normalPhases.name, Terminal::normalPhases.compareValues(source, target) { it.phaseStatusInternal })
                 addIfDifferent(Terminal::currentPhases.name, Terminal::currentPhases.compareValues(source, target) { it.phaseStatusInternal })

--- a/src/main/kotlin/com/zepben/ewb/services/network/NetworkServiceComparator.kt
+++ b/src/main/kotlin/com/zepben/ewb/services/network/NetworkServiceComparator.kt
@@ -111,7 +111,9 @@ class NetworkServiceComparator @JvmOverloads constructor(
         ObjectDifference(source, target).apply {
             compareIdentifiedObject()
 
-            compareIdReferenceCollections(Loop::circuits, Loop::substations, Loop::energizingSubstations)
+            if (options.compareRunTimeVariables) {
+                compareIdReferenceCollections(Loop::circuits, Loop::substations, Loop::energizingSubstations)
+            }
         }
 
     private fun compareLvFeeder(source: LvFeeder, target: LvFeeder): ObjectDifference<LvFeeder> =
@@ -119,11 +121,13 @@ class NetworkServiceComparator @JvmOverloads constructor(
             compareEquipmentContainer()
 
             compareIdReferences(LvFeeder::normalHeadTerminal)
-            compareIdReferenceCollections(LvFeeder::normalEnergizingFeeders)
-            compareIdReferenceCollections(LvFeeder::currentEnergizingFeeders)
-            compareIdReferences(LvFeeder::normalEnergizingLvSubstation)
-            if (options.compareFeederEquipment) {
-                compareIdReferenceCollections(LvFeeder::currentEquipment)
+            if (options.compareRunTimeVariables) {
+                compareIdReferenceCollections(LvFeeder::normalEnergizingFeeders)
+                compareIdReferenceCollections(LvFeeder::currentEnergizingFeeders)
+                compareIdReferences(LvFeeder::normalEnergizingLvSubstation)
+                if (options.compareFeederEquipment) {
+                    compareIdReferenceCollections(LvFeeder::currentEquipment)
+                }
             }
         }
 
@@ -131,9 +135,11 @@ class NetworkServiceComparator @JvmOverloads constructor(
         ObjectDifference(source, target).apply {
             compareEquipmentContainer()
 
-            compareIdReferenceCollections(LvSubstation::normalEnergizingFeeders)
-            compareIdReferenceCollections(LvSubstation::currentEnergizingFeeders)
-            compareIdReferenceCollections(LvSubstation::normalEnergizedLvFeeders)
+            if (options.compareRunTimeVariables) {
+                compareIdReferenceCollections(LvSubstation::normalEnergizingFeeders)
+                compareIdReferenceCollections(LvSubstation::currentEnergizingFeeders)
+                compareIdReferenceCollections(LvSubstation::normalEnergizedLvFeeders)
+            }
         }
 
     // ##################################################
@@ -580,7 +586,9 @@ class NetworkServiceComparator @JvmOverloads constructor(
         apply {
             compareEquipment()
 
-            compareIdReferences(ConductingEquipment::baseVoltage)
+            if (options.compareRunTimeVariables) {
+                compareIdReferences(ConductingEquipment::baseVoltage)
+            }
             if (options.compareTerminals)
                 compareIndexedIdReferenceCollections(ConductingEquipment::terminals)
         }
@@ -608,36 +616,43 @@ class NetworkServiceComparator @JvmOverloads constructor(
 
             compareValues(Equipment::inService, Equipment::normallyInService, Equipment::commissionedDate)
 
-            if (options.compareEquipmentContainers)
-                compareIdReferenceCollections(Equipment::containers)
+            if (options.compareRunTimeVariables) {
+                if (options.compareEquipmentContainers) {
+                    compareIdReferenceCollections(Equipment::containers)
+                    compareIdReferenceCollections(Equipment::currentContainers)
+                }
+            }
 
             if (options.compareLvSimplification)
                 compareIdReferenceCollections(Equipment::usagePoints)
 
             compareIdReferenceCollections(Equipment::operationalRestrictions)
-
-            if (options.compareEquipmentContainers)
-                compareIdReferenceCollections(Equipment::currentContainers)
         }
 
     private fun ObjectDifference<out EquipmentContainer>.compareEquipmentContainer(): ObjectDifference<out EquipmentContainer> =
         apply {
             compareConnectivityNodeContainer()
 
-            compareIdReferenceCollections(EquipmentContainer::equipment)
+            if (options.compareRunTimeVariables) {
+                compareIdReferenceCollections(EquipmentContainer::equipment)
+            }
         }
 
     private fun compareFeeder(source: Feeder, target: Feeder): ObjectDifference<Feeder> =
         ObjectDifference(source, target).apply {
             compareEquipmentContainer()
 
-            compareIdReferences(Feeder::normalHeadTerminal, Feeder::normalEnergizingSubstation)
-            compareIdReferenceCollections(Feeder::normalEnergizedLvFeeders)
-            compareIdReferenceCollections(Feeder::currentEnergizedLvFeeders)
-            compareIdReferenceCollections(Feeder::normalEnergizedLvSubstations)
-            compareIdReferenceCollections(Feeder::currentEnergizedLvSubstations)
-            if (options.compareFeederEquipment)
-                compareIdReferenceCollections(Feeder::currentEquipment)
+            compareIdReferences(Feeder::normalHeadTerminal)
+            if (options.compareRunTimeVariables) {
+                compareIdReferences(Feeder::normalEnergizingSubstation)
+                compareIdReferenceCollections(Feeder::normalEnergizedLvFeeders)
+                compareIdReferenceCollections(Feeder::currentEnergizedLvFeeders)
+                compareIdReferenceCollections(Feeder::normalEnergizedLvSubstations)
+                compareIdReferenceCollections(Feeder::currentEnergizedLvSubstations)
+                if (options.compareFeederEquipment) {
+                    compareIdReferenceCollections(Feeder::currentEquipment)
+                }
+            }
         }
 
     private fun compareGeographicalRegion(source: GeographicalRegion, target: GeographicalRegion): ObjectDifference<GeographicalRegion> =
@@ -670,7 +685,9 @@ class NetworkServiceComparator @JvmOverloads constructor(
             compareEquipmentContainer()
 
             compareIdReferences(Substation::subGeographicalRegion)
-            compareIdReferenceCollections(Substation::feeders)
+            if (options.compareRunTimeVariables) {
+                compareIdReferenceCollections(Substation::feeders)
+            }
         }
 
     private fun compareTerminal(source: Terminal, target: Terminal): ObjectDifference<Terminal> =
@@ -678,10 +695,12 @@ class NetworkServiceComparator @JvmOverloads constructor(
             compareAcDcTerminal()
 
             compareIdReferences(Terminal::conductingEquipment, Terminal::connectivityNode)
-            compareValues(Terminal::phases, Terminal::sequenceNumber, Terminal::normalFeederDirection, Terminal::currentFeederDirection)
-
-            addIfDifferent(Terminal::normalPhases.name, Terminal::normalPhases.compareValues(source, target) { it.phaseStatusInternal })
-            addIfDifferent(Terminal::currentPhases.name, Terminal::currentPhases.compareValues(source, target) { it.phaseStatusInternal })
+            compareValues(Terminal::sequenceNumber)
+            if (options.compareRunTimeVariables) {
+                compareValues(Terminal::phases, Terminal::normalFeederDirection, Terminal::currentFeederDirection)
+                addIfDifferent(Terminal::normalPhases.name, Terminal::normalPhases.compareValues(source, target) { it.phaseStatusInternal })
+                addIfDifferent(Terminal::currentPhases.name, Terminal::currentPhases.compareValues(source, target) { it.phaseStatusInternal })
+            }
         }
 
     // #############################
@@ -898,7 +917,9 @@ class NetworkServiceComparator @JvmOverloads constructor(
         ObjectDifference(source, target).apply {
             compareEnergyConnection()
 
-            compareIdReferenceCollections(EnergyConsumer::phases)
+            if (options.compareRunTimeVariables) {
+                compareIdReferenceCollections(EnergyConsumer::phases)
+            }
             compareValues(
                 EnergyConsumer::customerCount,
                 EnergyConsumer::grounded,
@@ -922,7 +943,9 @@ class NetworkServiceComparator @JvmOverloads constructor(
         ObjectDifference(source, target).apply {
             compareEnergyConnection()
 
-            compareIdReferenceCollections(EnergySource::phases)
+            if (options.compareRunTimeVariables) {
+                compareIdReferenceCollections(EnergySource::phases)
+            }
             compareValues(
                 EnergySource::activePower,
                 EnergySource::reactivePower,
@@ -1059,7 +1082,10 @@ class NetworkServiceComparator @JvmOverloads constructor(
         ObjectDifference(source, target).apply {
             compareRegulatingCondEq()
 
-            compareIdReferenceCollections(PowerElectronicsConnection::units, PowerElectronicsConnection::phases)
+            compareIdReferenceCollections(PowerElectronicsConnection::units)
+            if (options.compareRunTimeVariables) {
+                compareIdReferenceCollections(PowerElectronicsConnection::phases)
+            }
             compareValues(
                 PowerElectronicsConnection::maxIFault,
                 PowerElectronicsConnection::maxQ,
@@ -1312,7 +1338,10 @@ class NetworkServiceComparator @JvmOverloads constructor(
             compareIdentifiedObject()
 
             compareValues(TransformerEnd::grounded, TransformerEnd::rGround, TransformerEnd::xGround, TransformerEnd::endNumber)
-            compareIdReferences(TransformerEnd::baseVoltage, TransformerEnd::ratioTapChanger, TransformerEnd::terminal, TransformerEnd::starImpedance)
+            compareIdReferences(TransformerEnd::ratioTapChanger, TransformerEnd::terminal, TransformerEnd::starImpedance)
+            if (options.compareRunTimeVariables){
+                compareIdReferences(TransformerEnd::baseVoltage)
+            }
         }
 
     private fun compareTransformerStarImpedance(

--- a/src/main/kotlin/com/zepben/ewb/services/network/NetworkServiceComparatorOptions.kt
+++ b/src/main/kotlin/com/zepben/ewb/services/network/NetworkServiceComparatorOptions.kt
@@ -14,6 +14,7 @@ data class NetworkServiceComparatorOptions(
     val compareFeederEquipment: Boolean,
     val compareEquipmentContainers: Boolean,
     val compareLvSimplification: Boolean,
+    val compareRunTimeVariables: Boolean,
 ) {
 
     companion object {
@@ -25,6 +26,7 @@ data class NetworkServiceComparatorOptions(
                 compareFeederEquipment = true,
                 compareEquipmentContainers = true,
                 compareLvSimplification = true,
+                compareRunTimeVariables = true,
             )
 
         @JvmStatic
@@ -35,6 +37,7 @@ data class NetworkServiceComparatorOptions(
                 compareFeederEquipment = false,
                 compareEquipmentContainers = false,
                 compareLvSimplification = false,
+                compareRunTimeVariables = false,
             )
 
         @JvmStatic
@@ -47,6 +50,7 @@ data class NetworkServiceComparatorOptions(
         private var compareFeederEquipment = false
         private var compareEquipmentContainers = false
         private var compareLvSimplification = false
+        private var compareRunTimeVariables = false
         fun compareTerminals(): Builder {
             compareTerminals = true
             return this
@@ -72,6 +76,11 @@ data class NetworkServiceComparatorOptions(
             return this
         }
 
+        fun compareRunTimeVariables(): Builder {
+            compareRunTimeVariables = true
+            return this
+        }
+
         fun build(): NetworkServiceComparatorOptions {
             return NetworkServiceComparatorOptions(
                 compareTerminals,
@@ -79,6 +88,7 @@ data class NetworkServiceComparatorOptions(
                 compareFeederEquipment,
                 compareEquipmentContainers,
                 compareLvSimplification,
+                compareRunTimeVariables,
             )
         }
     }

--- a/src/main/kotlin/com/zepben/ewb/services/network/NetworkServiceComparatorOptions.kt
+++ b/src/main/kotlin/com/zepben/ewb/services/network/NetworkServiceComparatorOptions.kt
@@ -8,27 +8,43 @@
 
 package com.zepben.ewb.services.network
 
+/**
+ * Contains the options that are used to customise how the network service comparison is completed.
+ *
+ * @param compareTerminals Indicates if terminals should be compared.
+ * @param compareTracedPhases Flag that is unused by the comparator and has been deprecated.
+ * @param compareFeederEquipment Indicates if the equipment belonging to a Feeder (or an LvFeeder) should be compared.
+ * @param compareEquipmentContainers Indicates if equipment containers of any kind should be compared.
+ * @param compareLvSimplification Indicates if LV simplification should be compared. This will also apply to LV
+ * equipment <-> usage point <-> end device links.
+ * @param compareRunTime Indicates if variables/relationships that are calculated at runtime should be compared.
+ */
 data class NetworkServiceComparatorOptions(
-    val compareTerminals: Boolean,
-    val compareTracedPhases: Boolean,
-    val compareFeederEquipment: Boolean,
-    val compareEquipmentContainers: Boolean,
-    val compareLvSimplification: Boolean,
-    val compareRunTimeVariables: Boolean,
+    val compareTerminals: Boolean = true,
+    @Deprecated("compareTracedPhases is unused, use compareRunTime instead")
+    val compareTracedPhases: Boolean = true,
+    val compareFeederEquipment: Boolean = true,
+    val compareEquipmentContainers: Boolean = true,
+    val compareLvSimplification: Boolean = true,
+    val compareRunTime: Boolean = true,
 ) {
 
     companion object {
+
+        /**
+         * Create a [NetworkServiceComparatorOptions] with all options enabled.
+         *
+         * @return The [NetworkServiceComparatorOptions] with all options enabled.
+         */
         @JvmStatic
         fun all(): NetworkServiceComparatorOptions =
-            NetworkServiceComparatorOptions(
-                compareTerminals = true,
-                compareTracedPhases = true,
-                compareFeederEquipment = true,
-                compareEquipmentContainers = true,
-                compareLvSimplification = true,
-                compareRunTimeVariables = true,
-            )
+            NetworkServiceComparatorOptions()
 
+        /**
+         * Create a [NetworkServiceComparatorOptions] with all options disabled.
+         *
+         * @return The [NetworkServiceComparatorOptions] with all options disabled.
+         */
         @JvmStatic
         fun none(): NetworkServiceComparatorOptions =
             NetworkServiceComparatorOptions(
@@ -37,50 +53,53 @@ data class NetworkServiceComparatorOptions(
                 compareFeederEquipment = false,
                 compareEquipmentContainers = false,
                 compareLvSimplification = false,
-                compareRunTimeVariables = false,
+                compareRunTime = false,
             )
 
         @JvmStatic
+        @Deprecated("The builder has been deprecated. Replace with a direct call to the constructor, passing the appropriate arguments.")
         fun of(): Builder = Builder()
     }
 
+    @Deprecated("The builder has been deprecated. Replace with a direct call to the constructor, passing the appropriate arguments.")
     class Builder internal constructor() {
         private var compareTerminals = false
         private var comparePhases = false
         private var compareFeederEquipment = false
         private var compareEquipmentContainers = false
         private var compareLvSimplification = false
-        private var compareRunTimeVariables = false
+
+        @Deprecated("The builder has been deprecated. Replace with a direct call to the constructor, passing `true` for the `compareTerminals` argument.")
         fun compareTerminals(): Builder {
             compareTerminals = true
             return this
         }
 
+        @Deprecated("comparePhases is unused in the comparator, so this value has no effect.")
         fun comparePhases(): Builder {
             comparePhases = true
             return this
         }
 
+        @Deprecated("The builder has been deprecated. Replace with a direct call to the constructor, passing `true` for the `compareFeederEquipment` argument.")
         fun compareFeederEquipment(): Builder {
             compareFeederEquipment = true
             return this
         }
 
+        @Deprecated("The builder has been deprecated. Replace with a direct call to the constructor, passing `true` for the `compareEquipmentContainers` argument.")
         fun compareEquipmentContainers(): Builder {
             compareEquipmentContainers = true
             return this
         }
 
+        @Deprecated("The builder has been deprecated. Replace with a direct call to the constructor, passing `true` for the `compareLvSimplification` argument.")
         fun compareLvSimplification(): Builder {
             compareLvSimplification = true
             return this
         }
 
-        fun compareRunTimeVariables(): Builder {
-            compareRunTimeVariables = true
-            return this
-        }
-
+        @Deprecated("The builder has been deprecated. Replace with a direct call to the constructor, passing the appropriate arguments.")
         fun build(): NetworkServiceComparatorOptions {
             return NetworkServiceComparatorOptions(
                 compareTerminals,
@@ -88,7 +107,8 @@ data class NetworkServiceComparatorOptions(
                 compareFeederEquipment,
                 compareEquipmentContainers,
                 compareLvSimplification,
-                compareRunTimeVariables,
+                // You can't turn on the new `compareRunTime` option via the deprecated builder.
+                compareRunTime = false,
             )
         }
     }

--- a/src/test/kotlin/com/zepben/ewb/cim/iec61970/base/core/ConductingEquipmentTest.kt
+++ b/src/test/kotlin/com/zepben/ewb/cim/iec61970/base/core/ConductingEquipmentTest.kt
@@ -193,4 +193,17 @@ internal class ConductingEquipmentTest {
         ce.addTerminal(t)
     }
 
+    @Test
+    internal fun `doesn't remove terminals conducting equipment link if it's not removed`() {
+        val ce1 = object : ConductingEquipment(generateId()) {}
+        val ce2 = object : ConductingEquipment(generateId()) {}
+
+        val t = Terminal(generateId())
+        ce1.addTerminal(t)
+
+        ce2.removeTerminal(t)
+
+        assertThat(t.conductingEquipment, sameInstance(ce1))
+    }
+
 }

--- a/src/test/kotlin/com/zepben/ewb/cim/iec61970/base/core/ConductingEquipmentTest.kt
+++ b/src/test/kotlin/com/zepben/ewb/cim/iec61970/base/core/ConductingEquipmentTest.kt
@@ -66,44 +66,24 @@ internal class ConductingEquipmentTest {
     }
 
     @Test
-    internal fun rejectsAddingTerminalBelongingToAnotherEquipment() {
+    internal fun removingTerminalClearsTheTerminalsConductingEquipment() {
         val ce1 = object : ConductingEquipment(generateId()) {}
-        val ce2 = object : ConductingEquipment(generateId()) {}
-        val terminal = Terminal(generateId()).apply { ce2.addTerminal(this) }
-
-        expect { ce1.addTerminal(terminal) }
-            .toThrow<IllegalArgumentException>()
-            .withMessage(
-                "${terminal.typeNameAndMRID()} `conductingEquipment` property references ${terminal.conductingEquipment!!.typeNameAndMRID()}, expected ${ce1.typeNameAndMRID()}."
-            )
-    }
-
-    @Test
-    internal fun addingTerminalAssignsTheEquipmentToTheTerminal() {
-        val ce1 = object : ConductingEquipment(generateId()) {}
-        val terminal = Terminal(generateId()).apply { ce1.addTerminal(this) }
-
-        assertThat(terminal.conductingEquipment, equalTo(ce1))
-    }
-
-    @Test
-    internal fun removingTerminalFromTheEquipmentSetTerminalConductingEquipmentToNull() {
-        val ce1 = object : ConductingEquipment(generateId()) {}
-        val terminal = Terminal(generateId()).apply { ce1.addTerminal(this) }
+        val terminal = Terminal(generateId()).also { ce1.addTerminal(it) }
         ce1.removeTerminal(terminal)
 
-        assertThat(terminal.conductingEquipment, equalTo(null))
+        assertThat(terminal.conductingEquipment, nullValue())
     }
 
     @Test
-    internal fun clearTerminalFromTheEquipmentSetAllTerminalConductingEquipmentToNull() {
+    internal fun clearingTerminalClearsAllTerminalsConductingEquipment() {
         val ce1 = object : ConductingEquipment(generateId()) {}
-        val terminal1 = Terminal(generateId()).apply { ce1.addTerminal(this) }
-        val terminal2 = Terminal(generateId()).apply { ce1.addTerminal(this) }
+        val terminal1 = Terminal(generateId()).also { ce1.addTerminal(it) }
+        val terminal2 = Terminal(generateId()).also { ce1.addTerminal(it) }
+
         ce1.clearTerminals()
 
-        assertThat(terminal1.conductingEquipment, equalTo(null))
-        assertThat(terminal2.conductingEquipment, equalTo(null))
+        assertThat(terminal1.conductingEquipment, nullValue())
+        assertThat(terminal2.conductingEquipment, nullValue())
     }
 
     @Test

--- a/src/test/kotlin/com/zepben/ewb/cim/iec61970/base/core/ConductingEquipmentTest.kt
+++ b/src/test/kotlin/com/zepben/ewb/cim/iec61970/base/core/ConductingEquipmentTest.kt
@@ -66,6 +66,47 @@ internal class ConductingEquipmentTest {
     }
 
     @Test
+    internal fun rejectsAddingTerminalBelongingToAnotherEquipment() {
+        val ce1 = object : ConductingEquipment(generateId()) {}
+        val ce2 = object : ConductingEquipment(generateId()) {}
+        val terminal = Terminal(generateId()).apply { ce2.addTerminal(this) }
+
+        expect { ce1.addTerminal(terminal) }
+            .toThrow<IllegalArgumentException>()
+            .withMessage(
+                "${terminal.typeNameAndMRID()} `conductingEquipment` property references ${terminal.conductingEquipment!!.typeNameAndMRID()}, expected ${ce1.typeNameAndMRID()}."
+            )
+    }
+
+    @Test
+    internal fun addingTerminalAssignsTheEquipmentToTheTerminal() {
+        val ce1 = object : ConductingEquipment(generateId()) {}
+        val terminal = Terminal(generateId()).apply { ce1.addTerminal(this) }
+
+        assertThat(terminal.conductingEquipment, equalTo(ce1))
+    }
+
+    @Test
+    internal fun removingTerminalFromTheEquipmentSetTerminalConductingEquipmentToNull() {
+        val ce1 = object : ConductingEquipment(generateId()) {}
+        val terminal = Terminal(generateId()).apply { ce1.addTerminal(this) }
+        ce1.removeTerminal(terminal)
+
+        assertThat(terminal.conductingEquipment, equalTo(null))
+    }
+
+    @Test
+    internal fun clearTerminalFromTheEquipmentSetAllTerminalConductingEquipmentToNull() {
+        val ce1 = object : ConductingEquipment(generateId()) {}
+        val terminal1 = Terminal(generateId()).apply { ce1.addTerminal(this) }
+        val terminal2 = Terminal(generateId()).apply { ce1.addTerminal(this) }
+        ce1.clearTerminals()
+
+        assertThat(terminal1.conductingEquipment, equalTo(null))
+        assertThat(terminal2.conductingEquipment, equalTo(null))
+    }
+
+    @Test
     internal fun terminals() {
         PrivateCollectionValidator.validateOrdered(
             { id -> object : ConductingEquipment(id) {} },

--- a/src/test/kotlin/com/zepben/ewb/cim/iec61970/base/core/TerminalTest.kt
+++ b/src/test/kotlin/com/zepben/ewb/cim/iec61970/base/core/TerminalTest.kt
@@ -60,30 +60,43 @@ internal class TerminalTest {
     }
 
     @Test
-    internal fun internalConductingEquipmentSetFunctionThrowsWhenChangingFromNonNullValueToAnotherNonNullValue() {
-        val terminal = Terminal(generateId())
+    internal fun `can only reassign conducting equipment for unused terminals`() {
         val acls = AcLineSegment(generateId())
         val acls2 = AcLineSegment(generateId())
-        terminal._conductingEquipment = acls
+        val terminal = Terminal(generateId())
 
+        fun confirmReassign() {
+            terminal._conductingEquipment = acls
+            terminal._conductingEquipment = null
+            terminal._conductingEquipment = acls2
+            terminal._conductingEquipment = null
+        }
+
+        // Should be able to freely reassign the conducting equipment without a back reference.
+        confirmReassign()
+
+        // Create a back reference.
+        acls.addTerminal(terminal)
+
+        // We shouldn't be able to reassign the terminal to another condcuting equipment while it is still assigned to acls.
         expect { terminal._conductingEquipment = acls2 }
             .toThrow<IllegalArgumentException>()
             .withMessage(
-                "conductingEquipment has already been set to $acls. Please remove this terminal from the conducting equipment before setting this field again."
+                "This terminal is currently being used by ${acls.typeNameAndMRID()}. Please remove this terminal from the conducting equipment before setting this field again."
             )
-    }
 
-    @Test
-    internal fun internalConductingEquipmentSetFunctionThrowsWhenChangingFromNonNullValueToNullIfItStillBelongsToOutgoingConductingEquipment() {
-        val terminal = Terminal(generateId())
-        val acls = AcLineSegment(generateId())
-        acls.addTerminal(terminal)
-
+        // We shouldn't be able to clear the terminals condcuting equipment while it is still assigned to acls.
         expect { terminal._conductingEquipment = null }
             .toThrow<IllegalArgumentException>()
             .withMessage(
-                "conductingEquipment has already been set to $acls. Please remove this terminal from the conducting equipment before setting this field again."
+                "This terminal is currently being used by ${acls.typeNameAndMRID()}. Please remove this terminal from the conducting equipment before setting this field again.",
             )
+
+        // Remove the back reference.
+        acls.removeTerminal(terminal)
+
+        // Should be able to freely reassign the conducting equipment after removing the back reference.
+        confirmReassign()
     }
 
     @Test

--- a/src/test/kotlin/com/zepben/ewb/cim/iec61970/base/core/TerminalTest.kt
+++ b/src/test/kotlin/com/zepben/ewb/cim/iec61970/base/core/TerminalTest.kt
@@ -8,11 +8,13 @@
 
 package com.zepben.ewb.cim.iec61970.base.core
 
+import com.zepben.ewb.cim.iec61970.base.wires.AcLineSegment
 import com.zepben.ewb.cim.iec61970.base.wires.Junction
 import com.zepben.ewb.services.common.testdata.generateId
 import com.zepben.ewb.services.network.NetworkService
 import com.zepben.ewb.services.network.testdata.fillFields
 import com.zepben.ewb.services.network.tracing.feeder.FeederDirection
+import com.zepben.testutils.exception.ExpectException.Companion.expect
 import com.zepben.testutils.junit.SystemLogExtension
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.*
@@ -55,6 +57,33 @@ internal class TerminalTest {
         assertThat(terminal.currentPhases.phaseStatusInternal, equalTo(2u))
         assertThat(terminal.normalFeederDirection, equalTo(FeederDirection.UPSTREAM))
         assertThat(terminal.currentFeederDirection, equalTo(FeederDirection.DOWNSTREAM))
+    }
+
+    @Test
+    internal fun internalConductingEquipmentSetFunctionThrowsWhenChangingFromNonNullValueToAnotherNonNullValue() {
+        val terminal = Terminal(generateId())
+        val acls = AcLineSegment(generateId())
+        val acls2 = AcLineSegment(generateId())
+        terminal._conductingEquipment = acls
+
+        expect { terminal._conductingEquipment = acls2 }
+            .toThrow<IllegalArgumentException>()
+            .withMessage(
+                "conductingEquipment has already been set to $acls. Please remove this terminal from the conducting equipment before setting this field again."
+            )
+    }
+
+    @Test
+    internal fun internalConductingEquipmentSetFunctionThrowsWhenChangingFromNonNullValueToNullIfItStillBelongsToOutgoingConductingEquipment() {
+        val terminal = Terminal(generateId())
+        val acls = AcLineSegment(generateId())
+        acls.addTerminal(terminal)
+
+        expect { terminal._conductingEquipment = null }
+            .toThrow<IllegalArgumentException>()
+            .withMessage(
+                "conductingEquipment has already been set to $acls. Please remove this terminal from the conducting equipment before setting this field again."
+            )
     }
 
     @Test

--- a/src/test/kotlin/com/zepben/ewb/services/network/NetworkServiceComparatorOptionsTest.kt
+++ b/src/test/kotlin/com/zepben/ewb/services/network/NetworkServiceComparatorOptionsTest.kt
@@ -24,23 +24,23 @@ internal class NetworkServiceComparatorOptionsTest {
     @Test
     internal fun all() {
         val options = NetworkServiceComparatorOptions.all()
-        assertThat("compareTracedPhases should be true for all()", options.compareTracedPhases)
-        assertThat("compareTerminals should be true for all()", options.compareTerminals)
-        assertThat("compareFeederEquipment should be true for all()", options.compareFeederEquipment)
-        assertThat("compareEquipmentContainers should be true for all()", options.compareEquipmentContainers)
-        assertThat("compareLvSimplification should be true for all()", options.compareLvSimplification)
-        assertThat("compareRunTimeVariables should be true for all()", options.compareRunTimeVariables)
+        assertThat("compareTracedPhases should be enabled for all()", options.compareTracedPhases)
+        assertThat("compareTerminals should be enabled for all()", options.compareTerminals)
+        assertThat("compareFeederEquipment should be enabled for all()", options.compareFeederEquipment)
+        assertThat("compareEquipmentContainers should be enabled for all()", options.compareEquipmentContainers)
+        assertThat("compareLvSimplification should be enabled for all()", options.compareLvSimplification)
+        assertThat("compareRunTime should be enabled for all()", options.compareRunTime)
     }
 
     @Test
     internal fun none() {
         val options = NetworkServiceComparatorOptions.none()
-        assertThat("compareTracedPhases should be false for none()", !options.compareTracedPhases)
-        assertThat("compareTerminals should be false for none()", !options.compareTerminals)
-        assertThat("compareFeederEquipment should be false for none()", !options.compareFeederEquipment)
-        assertThat("compareEquipmentContainers should be false for none()", !options.compareEquipmentContainers)
-        assertThat("compareLvSimplification should be false for none()", !options.compareLvSimplification)
-        assertThat("compareRunTimeVariables should be false for none()", !options.compareRunTimeVariables)
+        assertThat("compareTracedPhases should be disabled for none()", !options.compareTracedPhases)
+        assertThat("compareTerminals should be disabled for none()", !options.compareTerminals)
+        assertThat("compareFeederEquipment should be disabled for none()", !options.compareFeederEquipment)
+        assertThat("compareEquipmentContainers should be disabled for none()", !options.compareEquipmentContainers)
+        assertThat("compareLvSimplification should be disabled for none()", !options.compareLvSimplification)
+        assertThat("compareRunTime should be disabled for none()", !options.compareRunTime)
     }
 
     @Test
@@ -51,26 +51,36 @@ internal class NetworkServiceComparatorOptionsTest {
             .compareFeederEquipment()
             .compareEquipmentContainers()
             .compareLvSimplification()
-            .compareRunTimeVariables()
             .build()
 
-        assertThat("compareTracedPhases should be true when building with all options enabled", options.compareTracedPhases)
-        assertThat("compareTerminals should be true when building with all options enabled", options.compareTerminals)
-        assertThat("compareFeederEquipment should be true when building with all options enabled", options.compareFeederEquipment)
-        assertThat("compareEquipmentContainers should be true when building with all options enabled", options.compareEquipmentContainers)
-        assertThat("compareLvSimplification should be true when building with all options enabled", options.compareLvSimplification)
-        assertThat("compareRunTimeVariables should be true when building with all options enabled", options.compareRunTimeVariables)
+        assertThat("compareTracedPhases should be enabled when building with all options enabled", options.compareTracedPhases)
+        assertThat("compareTerminals should be enabled when building with all options enabled", options.compareTerminals)
+        assertThat("compareFeederEquipment should be enabled when building with all options enabled", options.compareFeederEquipment)
+        assertThat("compareEquipmentContainers should be enabled when building with all options enabled", options.compareEquipmentContainers)
+        assertThat("compareLvSimplification should be enabled when building with all options enabled", options.compareLvSimplification)
+
+        // You can't turn on the new `compareRunTime` option via the deprecated builder.
+        assertThat("compareRunTime should be disabled in the deprecated builder", !options.compareRunTime)
     }
 
     @Test
     internal fun builderNone() {
         val options = NetworkServiceComparatorOptions.of().build()
 
-        assertThat("compareTracedPhases should be false when building without any options enabled", !options.compareTracedPhases)
-        assertThat("compareTerminals should be false when building without any options enabled", !options.compareTerminals)
-        assertThat("compareFeederEquipment should be false when building without any options enabled", !options.compareFeederEquipment)
-        assertThat("compareEquipmentContainers should be false when building without any options enabled", !options.compareEquipmentContainers)
-        assertThat("compareLvSimplification should be false when building without any options enabled", !options.compareLvSimplification)
-        assertThat("compareRunTimeVariables should be false when building without any options enabled", !options.compareRunTimeVariables)
+        assertThat("compareTracedPhases should be disabled when building without any options enabled", !options.compareTracedPhases)
+        assertThat("compareTerminals should be disabled when building without any options enabled", !options.compareTerminals)
+        assertThat("compareFeederEquipment should be disabled when building without any options enabled", !options.compareFeederEquipment)
+        assertThat("compareEquipmentContainers should be disabled when building without any options enabled", !options.compareEquipmentContainers)
+        assertThat("compareLvSimplification should be disabled when building without any options enabled", !options.compareLvSimplification)
+        assertThat("compareRunTime should be disabled in the deprecated builder", !options.compareRunTime)
     }
+
+    @Test
+    internal fun constructorCoverage() {
+        // Stupid test to give coverage to generated Kotlin code that is guaranteed to work.
+        NetworkServiceComparatorOptions()
+        NetworkServiceComparatorOptions(compareTerminals = false)
+        NetworkServiceComparatorOptions(compareRunTime = false)
+    }
+
 }

--- a/src/test/kotlin/com/zepben/ewb/services/network/NetworkServiceComparatorOptionsTest.kt
+++ b/src/test/kotlin/com/zepben/ewb/services/network/NetworkServiceComparatorOptionsTest.kt
@@ -29,6 +29,7 @@ internal class NetworkServiceComparatorOptionsTest {
         assertThat("compareFeederEquipment should be true for all()", options.compareFeederEquipment)
         assertThat("compareEquipmentContainers should be true for all()", options.compareEquipmentContainers)
         assertThat("compareLvSimplification should be true for all()", options.compareLvSimplification)
+        assertThat("compareRunTimeVariables should be true for all()", options.compareRunTimeVariables)
     }
 
     @Test
@@ -39,6 +40,7 @@ internal class NetworkServiceComparatorOptionsTest {
         assertThat("compareFeederEquipment should be false for none()", !options.compareFeederEquipment)
         assertThat("compareEquipmentContainers should be false for none()", !options.compareEquipmentContainers)
         assertThat("compareLvSimplification should be false for none()", !options.compareLvSimplification)
+        assertThat("compareRunTimeVariables should be false for none()", !options.compareRunTimeVariables)
     }
 
     @Test
@@ -49,6 +51,7 @@ internal class NetworkServiceComparatorOptionsTest {
             .compareFeederEquipment()
             .compareEquipmentContainers()
             .compareLvSimplification()
+            .compareRunTimeVariables()
             .build()
 
         assertThat("compareTracedPhases should be true when building with all options enabled", options.compareTracedPhases)
@@ -56,6 +59,7 @@ internal class NetworkServiceComparatorOptionsTest {
         assertThat("compareFeederEquipment should be true when building with all options enabled", options.compareFeederEquipment)
         assertThat("compareEquipmentContainers should be true when building with all options enabled", options.compareEquipmentContainers)
         assertThat("compareLvSimplification should be true when building with all options enabled", options.compareLvSimplification)
+        assertThat("compareRunTimeVariables should be true when building with all options enabled", options.compareRunTimeVariables)
     }
 
     @Test
@@ -67,5 +71,6 @@ internal class NetworkServiceComparatorOptionsTest {
         assertThat("compareFeederEquipment should be false when building without any options enabled", !options.compareFeederEquipment)
         assertThat("compareEquipmentContainers should be false when building without any options enabled", !options.compareEquipmentContainers)
         assertThat("compareLvSimplification should be false when building without any options enabled", !options.compareLvSimplification)
+        assertThat("compareRunTimeVariables should be false when building without any options enabled", !options.compareRunTimeVariables)
     }
 }

--- a/src/test/kotlin/com/zepben/ewb/services/network/testdata/FillFields.kt
+++ b/src/test/kotlin/com/zepben/ewb/services/network/testdata/FillFields.kt
@@ -1024,7 +1024,7 @@ fun Substation.fillFields(service: NetworkService, includeRuntime: Boolean = tru
 fun Terminal.fillFields(service: NetworkService, includeRuntime: Boolean = true): Terminal {
     (this as AcDcTerminal).fillFields(service, includeRuntime)
 
-    conductingEquipment = Junction(generateId()).also { service.add(it) }
+    _conductingEquipment = Junction(generateId()).also { service.add(it) }
     conductingEquipment?.addTerminal(this)
 
     phases = PhaseCode.X

--- a/src/test/kotlin/com/zepben/ewb/services/network/testdata/FillFields.kt
+++ b/src/test/kotlin/com/zepben/ewb/services/network/testdata/FillFields.kt
@@ -218,6 +218,13 @@ fun LvFeeder.fillFields(service: NetworkService, includeRuntime: Boolean = true)
 fun LvSubstation.fillFields(service: NetworkService, includeRuntime: Boolean = true): LvSubstation {
     (this as EquipmentContainer).fillFields(service, includeRuntime)
 
+    repeat(2) {
+        addNormalEnergizedLvFeeder(LvFeeder(generateId()).also {
+            it.normalEnergizingLvSubstation = this
+            service.add(it)
+        })
+    }
+
     if (includeRuntime) {
         repeat(2) {
             addNormalEnergizingFeeder(Feeder(generateId()).also {
@@ -229,17 +236,6 @@ fun LvSubstation.fillFields(service: NetworkService, includeRuntime: Boolean = t
                 it.addCurrentEnergizedLvSubstation(this)
                 service.add(it)
             })
-
-            addCurrentEquipment(Junction(generateId()).also {
-                it.addCurrentContainer(this)
-                service.add(it)
-            })
-
-            addNormalEnergizedLvFeeder(LvFeeder(generateId()).also {
-                it.normalEnergizingLvSubstation = this
-                service.add(it)
-            })
-
         }
     } else {
         equipment.forEach { it.removeContainer(this) }


### PR DESCRIPTION
# Description

1. Allow conductingEquipment value to be changed on Terminal once it has been set. This is done through calling addTerminal and removeTerminal (or clearTerminal) on ConductingEquipment.
2. Add a compareRunTimeVariables option to NetworkServiceComparatorOptions to allow the users to ignore variables that are populated during EWB spin up.

# Associated tasks

This task is associated with fixing conflict detection / handler in commons, which would be off the variant branch.

also:
- https://github.com/zepben/commons/pull/198

# Test Steps

Explain in detail how your reviewer can test the changes proposed in this PR. If it cannot be tested, leave an explanation on why.

# Checklist

If any of these are not applicable, strikethrough the line `~like this~`. **Do not delete it!**. Let the reviewer decide if you should have done it.

### Code
- [x] I have performed a self review of my own code (including checking issues raised when creating the PR).
- [x] I have added/updated unit tests for these changes, and if not I have explained why they are not necessary.
- [x] I have commented my code in any hard-to-understand or hacky areas.
- [x] I have handled all new warnings generated by the compiler or IDE.
- [x] I have rebased onto the target branch (usually main).

### Security
When developing applications, use following guidelines for information security considerations:
* Access to applications should be protected with security keys/tokens or usernames and passwords;
* All sessions are encrypted if possible;
* All application input is sanitised before being acted on (ie SQL statements, etc);
* Log messages, and especially client-facing ones, must be handled securely and must not leak credentials information (internal URLs, passwords, tokens).

- [x] I have considered if this change impacts information security and made sure those impacts are handled.

### Documentation
- [x] I have updated the changelog.
~- [ ] I have updated any documentation required for these changes.~

# Breaking Changes
- [x] I have considered if this is a breaking change and will communicate it with other team members by posting it on the Slack **breaking-changes** channel.

Marked old value setting as deprecated and left a comment on what to do when removing the old way in the future.