### PR TITLE
[DEV-9588] Unify tests to use validateBackfill; add missing checks for cuts and clamps

### DIFF
--- a/src/test/kotlin/com/zepben/ewb/cim/iec61970/base/core/GeographicalRegionTest.kt
+++ b/src/test/kotlin/com/zepben/ewb/cim/iec61970/base/core/GeographicalRegionTest.kt
@@ -47,9 +47,7 @@ internal class GeographicalRegionTest {
         PrivateCollectionValidator.validateBackfill(
             ::GeographicalRegion,
             ::SubGeographicalRegion,
-            "geographicalRegion",
-            { it, other -> other.geographicalRegion = it },
-            { other -> other.geographicalRegion },
+            SubGeographicalRegion::geographicalRegion,
             GeographicalRegion::numSubGeographicalRegions,
             GeographicalRegion::addSubGeographicalRegion,
         )

--- a/src/test/kotlin/com/zepben/ewb/cim/iec61970/base/core/GeographicalRegionTest.kt
+++ b/src/test/kotlin/com/zepben/ewb/cim/iec61970/base/core/GeographicalRegionTest.kt
@@ -8,9 +8,7 @@
 
 package com.zepben.ewb.cim.iec61970.base.core
 
-import com.zepben.ewb.services.common.testdata.generateId
 import com.zepben.ewb.utils.PrivateCollectionValidator
-import com.zepben.testutils.exception.ExpectException
 import com.zepben.testutils.junit.SystemLogExtension
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.equalTo
@@ -31,26 +29,6 @@ internal class GeographicalRegionTest {
     }
 
     @Test
-    internal fun assignsGeographicalRegionToSubGeographicalRegionIfMissing() {
-        val geographicalRegion = GeographicalRegion(generateId())
-        val subGeographicalRegion = SubGeographicalRegion(generateId())
-
-        geographicalRegion.addSubGeographicalRegion(subGeographicalRegion)
-        assertThat(subGeographicalRegion.geographicalRegion, equalTo(geographicalRegion))
-    }
-
-    @Test
-    internal fun rejectsSubGeographicalRegionWithWrongGeographicalRegion() {
-        val geographicalRegion1 = GeographicalRegion(generateId())
-        val geographicalRegion2 = GeographicalRegion(generateId())
-        val subGeographicalRegion = SubGeographicalRegion(generateId()).apply { geographicalRegion = geographicalRegion2 }
-
-        ExpectException.expect { geographicalRegion1.addSubGeographicalRegion(subGeographicalRegion) }
-            .toThrow<IllegalArgumentException>()
-            .withMessage("${subGeographicalRegion.typeNameAndMRID()} `geographicalRegion` property references ${geographicalRegion2.typeNameAndMRID()}, expected ${geographicalRegion1.typeNameAndMRID()}.")
-    }
-
-    @Test
     internal fun subGeographicalRegions() {
         PrivateCollectionValidator.validateUnordered(
             ::GeographicalRegion,
@@ -61,6 +39,19 @@ internal class GeographicalRegionTest {
             GeographicalRegion::addSubGeographicalRegion,
             GeographicalRegion::removeSubGeographicalRegion,
             GeographicalRegion::clearSubGeographicalRegions
+        )
+    }
+
+    @Test
+    internal fun subGeographicalRegionsBackfill() {
+        PrivateCollectionValidator.validateBackfill(
+            ::GeographicalRegion,
+            ::SubGeographicalRegion,
+            "geographicalRegion",
+            { it, other -> other.geographicalRegion = it },
+            { other -> other.geographicalRegion },
+            GeographicalRegion::numSubGeographicalRegions,
+            GeographicalRegion::addSubGeographicalRegion,
         )
     }
 

--- a/src/test/kotlin/com/zepben/ewb/cim/iec61970/base/core/SubGeographicalRegionTest.kt
+++ b/src/test/kotlin/com/zepben/ewb/cim/iec61970/base/core/SubGeographicalRegionTest.kt
@@ -10,7 +10,6 @@ package com.zepben.ewb.cim.iec61970.base.core
 
 import com.zepben.ewb.services.common.testdata.generateId
 import com.zepben.ewb.utils.PrivateCollectionValidator
-import com.zepben.testutils.exception.ExpectException
 import com.zepben.testutils.junit.SystemLogExtension
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.equalTo
@@ -44,26 +43,6 @@ internal class SubGeographicalRegionTest {
     }
 
     @Test
-    internal fun assignsSubGeographicalRegionToSubstationIfMissing() {
-        val subGeographicalRegion = SubGeographicalRegion(generateId())
-        val substation = Substation(generateId())
-
-        subGeographicalRegion.addSubstation(substation)
-        assertThat(substation.subGeographicalRegion, equalTo(subGeographicalRegion))
-    }
-
-    @Test
-    internal fun rejectsSubstationWithWrongSubGeographicalRegion() {
-        val subGeographicalRegion1 = SubGeographicalRegion(generateId())
-        val subGeographicalRegion2 = SubGeographicalRegion(generateId())
-        val substation = Substation(generateId()).apply { subGeographicalRegion = subGeographicalRegion2 }
-
-        ExpectException.expect { subGeographicalRegion1.addSubstation(substation) }
-            .toThrow<IllegalArgumentException>()
-            .withMessage("${substation.typeNameAndMRID()} `subGeographicalRegion` property references ${subGeographicalRegion2.typeNameAndMRID()}, expected ${subGeographicalRegion1.typeNameAndMRID()}.")
-    }
-
-    @Test
     internal fun substations() {
         PrivateCollectionValidator.validateUnordered(
             ::SubGeographicalRegion,
@@ -74,6 +53,19 @@ internal class SubGeographicalRegionTest {
             SubGeographicalRegion::addSubstation,
             SubGeographicalRegion::removeSubstation,
             SubGeographicalRegion::clearSubstations
+        )
+    }
+
+    @Test
+    internal fun substationsBackfill() {
+        PrivateCollectionValidator.validateBackfill(
+            ::SubGeographicalRegion,
+            ::Substation,
+            "subGeographicalRegion",
+            { it, other -> other.subGeographicalRegion = it },
+            { other -> other.subGeographicalRegion },
+            SubGeographicalRegion::numSubstations,
+            SubGeographicalRegion::addSubstation,
         )
     }
 

--- a/src/test/kotlin/com/zepben/ewb/cim/iec61970/base/core/SubGeographicalRegionTest.kt
+++ b/src/test/kotlin/com/zepben/ewb/cim/iec61970/base/core/SubGeographicalRegionTest.kt
@@ -61,9 +61,7 @@ internal class SubGeographicalRegionTest {
         PrivateCollectionValidator.validateBackfill(
             ::SubGeographicalRegion,
             ::Substation,
-            "subGeographicalRegion",
-            { it, other -> other.subGeographicalRegion = it },
-            { other -> other.subGeographicalRegion },
+            Substation::subGeographicalRegion,
             SubGeographicalRegion::numSubstations,
             SubGeographicalRegion::addSubstation,
         )

--- a/src/test/kotlin/com/zepben/ewb/cim/iec61970/base/core/SubstationTest.kt
+++ b/src/test/kotlin/com/zepben/ewb/cim/iec61970/base/core/SubstationTest.kt
@@ -63,9 +63,7 @@ internal class SubstationTest {
         PrivateCollectionValidator.validateBackfill(
             ::Substation,
             ::Feeder,
-            "normalEnergizingSubstation",
-            { it, other -> other.normalEnergizingSubstation = it },
-            { other -> other.normalEnergizingSubstation },
+            Feeder::normalEnergizingSubstation,
             Substation::numFeeders,
             Substation::addFeeder,
         )

--- a/src/test/kotlin/com/zepben/ewb/cim/iec61970/base/core/SubstationTest.kt
+++ b/src/test/kotlin/com/zepben/ewb/cim/iec61970/base/core/SubstationTest.kt
@@ -12,7 +12,6 @@ import com.zepben.ewb.cim.extensions.iec61970.base.feeder.Loop
 import com.zepben.ewb.cim.iec61970.infiec61970.feeder.Circuit
 import com.zepben.ewb.services.common.testdata.generateId
 import com.zepben.ewb.utils.PrivateCollectionValidator
-import com.zepben.testutils.exception.ExpectException
 import com.zepben.testutils.junit.SystemLogExtension
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.equalTo
@@ -46,26 +45,6 @@ internal class SubstationTest {
     }
 
     @Test
-    internal fun assignsSubstationToFeederIfMissing() {
-        val substation = Substation(generateId())
-        val feeder = Feeder(generateId())
-
-        substation.addFeeder(feeder)
-        assertThat(feeder.normalEnergizingSubstation, equalTo(substation))
-    }
-
-    @Test
-    internal fun rejectsFeederWithWrongSubstation() {
-        val substation1 = Substation(generateId())
-        val substation2 = Substation(generateId())
-        val feeder = Feeder(generateId()).apply { normalEnergizingSubstation = substation2 }
-
-        ExpectException.expect { substation1.addFeeder(feeder) }
-            .toThrow<IllegalArgumentException>()
-            .withMessage("${feeder.typeNameAndMRID()} `normalEnergizingSubstation` property references ${substation2.typeNameAndMRID()}, expected ${substation1.typeNameAndMRID()}.")
-    }
-
-    @Test
     internal fun feederAssociations() {
         PrivateCollectionValidator.validateUnordered(
             ::Substation,
@@ -76,6 +55,19 @@ internal class SubstationTest {
             Substation::addFeeder,
             Substation::removeFeeder,
             Substation::clearFeeders
+        )
+    }
+
+    @Test
+    internal fun feederAssociationsBackfill() {
+        PrivateCollectionValidator.validateBackfill(
+            ::Substation,
+            ::Feeder,
+            "normalEnergizingSubstation",
+            { it, other -> other.normalEnergizingSubstation = it },
+            { other -> other.normalEnergizingSubstation },
+            Substation::numFeeders,
+            Substation::addFeeder,
         )
     }
 

--- a/src/test/kotlin/com/zepben/ewb/cim/iec61970/base/diagramlayout/DiagramTest.kt
+++ b/src/test/kotlin/com/zepben/ewb/cim/iec61970/base/diagramlayout/DiagramTest.kt
@@ -62,9 +62,7 @@ internal class DiagramTest {
         PrivateCollectionValidator.validateBackfill(
             ::Diagram,
             ::DiagramObject,
-            "diagram",
-            { it, other -> other.diagram = it },
-            { other -> other.diagram },
+            DiagramObject::diagram,
             Diagram::numDiagramObjects,
             Diagram::addDiagramObject,
         )

--- a/src/test/kotlin/com/zepben/ewb/cim/iec61970/base/diagramlayout/DiagramTest.kt
+++ b/src/test/kotlin/com/zepben/ewb/cim/iec61970/base/diagramlayout/DiagramTest.kt
@@ -10,7 +10,6 @@ package com.zepben.ewb.cim.iec61970.base.diagramlayout
 
 import com.zepben.ewb.services.common.testdata.generateId
 import com.zepben.ewb.utils.PrivateCollectionValidator
-import com.zepben.testutils.exception.ExpectException
 import com.zepben.testutils.junit.SystemLogExtension
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.equalTo
@@ -45,26 +44,6 @@ internal class DiagramTest {
     }
 
     @Test
-    internal fun assignsDiagramToObjectsIfMissing() {
-        val diagram = Diagram(generateId())
-        val diagramObject = DiagramObject(generateId())
-
-        diagram.addDiagramObject(diagramObject)
-        assertThat(diagramObject.diagram, equalTo(diagram))
-    }
-
-    @Test
-    internal fun rejectsObjectWithWrongDiagram() {
-        val d1 = Diagram(generateId())
-        val d2 = Diagram(generateId())
-        val obj = DiagramObject(generateId()).apply { diagram = d2 }
-
-        ExpectException.expect { d1.addDiagramObject(obj) }
-            .toThrow<IllegalArgumentException>()
-            .withMessage("${obj.typeNameAndMRID()} `diagram` property references ${d2.typeNameAndMRID()}, expected ${d1.typeNameAndMRID()}.")
-    }
-
-    @Test
     internal fun diagramObjects() {
         PrivateCollectionValidator.validateUnordered(
             ::Diagram,
@@ -75,6 +54,19 @@ internal class DiagramTest {
             Diagram::addDiagramObject,
             Diagram::removeDiagramObject,
             Diagram::clearDiagramObjects
+        )
+    }
+
+    @Test
+    internal fun diagramObjectsBackfill() {
+        PrivateCollectionValidator.validateBackfill(
+            ::Diagram,
+            ::DiagramObject,
+            "diagram",
+            { it, other -> other.diagram = it },
+            { other -> other.diagram },
+            Diagram::numDiagramObjects,
+            Diagram::addDiagramObject,
         )
     }
 

--- a/src/test/kotlin/com/zepben/ewb/cim/iec61970/base/wires/AcLineSegmentTest.kt
+++ b/src/test/kotlin/com/zepben/ewb/cim/iec61970/base/wires/AcLineSegmentTest.kt
@@ -78,9 +78,7 @@ internal class AcLineSegmentTest {
         PrivateCollectionValidator.validateBackfill(
             ::AcLineSegment,
             ::Cut,
-            "acLineSegment",
-            { it, other -> other.acLineSegment = it },
-            { other -> other.acLineSegment },
+            Cut::acLineSegment,
             AcLineSegment::numCuts,
             AcLineSegment::addCut,
         )
@@ -105,9 +103,7 @@ internal class AcLineSegmentTest {
         PrivateCollectionValidator.validateBackfill(
             ::AcLineSegment,
             ::Clamp,
-            "acLineSegment",
-            { it, other -> other.acLineSegment = it },
-            { other -> other.acLineSegment },
+            Clamp::acLineSegment,
             AcLineSegment::numClamps,
             AcLineSegment::addClamp,
         )
@@ -149,9 +145,7 @@ internal class AcLineSegmentTest {
         PrivateCollectionValidator.validateBackfill(
             ::AcLineSegment,
             ::AcLineSegmentPhase,
-            "acLineSegment",
-            { it, other -> other.acLineSegment = it },
-            { other -> other.acLineSegment },
+            AcLineSegmentPhase::acLineSegment,
             AcLineSegment::numPhases,
             AcLineSegment::addPhase,
         )

--- a/src/test/kotlin/com/zepben/ewb/cim/iec61970/base/wires/AcLineSegmentTest.kt
+++ b/src/test/kotlin/com/zepben/ewb/cim/iec61970/base/wires/AcLineSegmentTest.kt
@@ -11,7 +11,6 @@ package com.zepben.ewb.cim.iec61970.base.wires
 import com.zepben.ewb.cim.iec61968.assetinfo.OverheadWireInfo
 import com.zepben.ewb.services.common.testdata.generateId
 import com.zepben.ewb.utils.PrivateCollectionValidator
-import com.zepben.testutils.exception.ExpectException.Companion.expect
 import com.zepben.testutils.junit.SystemLogExtension
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.*
@@ -75,6 +74,19 @@ internal class AcLineSegmentTest {
     }
 
     @Test
+    internal fun cutsBackfill() {
+        PrivateCollectionValidator.validateBackfill(
+            ::AcLineSegment,
+            ::Cut,
+            "acLineSegment",
+            { it, other -> other.acLineSegment = it },
+            { other -> other.acLineSegment },
+            AcLineSegment::numCuts,
+            AcLineSegment::addCut,
+        )
+    }
+
+    @Test
     internal fun clamps() {
         PrivateCollectionValidator.validateUnordered(
             { id -> AcLineSegment(id) },
@@ -85,6 +97,19 @@ internal class AcLineSegmentTest {
             AcLineSegment::addClamp,
             AcLineSegment::removeClamp,
             AcLineSegment::clearClamps,
+        )
+    }
+
+    @Test
+    internal fun clampsBackfill() {
+        PrivateCollectionValidator.validateBackfill(
+            ::AcLineSegment,
+            ::Clamp,
+            "acLineSegment",
+            { it, other -> other.acLineSegment = it },
+            { other -> other.acLineSegment },
+            AcLineSegment::numClamps,
+            AcLineSegment::addClamp,
         )
     }
 
@@ -106,26 +131,6 @@ internal class AcLineSegmentTest {
     }
 
     @Test
-    internal fun assignsAcLineSegmentToPhaseIfMissing() {
-        val acls = AcLineSegment(generateId())
-        val phase = AcLineSegmentPhase(generateId())
-
-        acls.addPhase(phase)
-        assertThat(phase.acLineSegment, equalTo(acls))
-    }
-
-    @Test
-    internal fun rejectsAcLineSegmentPhaseWithWrongAcLineSegment() {
-        val acls1 = AcLineSegment(generateId())
-        val acls2 = AcLineSegment(generateId())
-        val phase = AcLineSegmentPhase(generateId()).apply { acLineSegment = acls2 }
-
-        expect { acls1.addPhase(phase) }
-            .toThrow<IllegalArgumentException>()
-            .withMessage("${phase.typeNameAndMRID()} `acLineSegment` property references ${acls2.typeNameAndMRID()}, expected ${acls1.typeNameAndMRID()}.")
-    }
-
-    @Test
     internal fun acLineSegmentPhases() {
         PrivateCollectionValidator.validateUnordered(
             ::AcLineSegment,
@@ -136,6 +141,19 @@ internal class AcLineSegmentTest {
             AcLineSegment::addPhase,
             AcLineSegment::removePhase,
             AcLineSegment::clearPhases
+        )
+    }
+
+    @Test
+    internal fun acLineSegmentPhasesBackfill() {
+        PrivateCollectionValidator.validateBackfill(
+            ::AcLineSegment,
+            ::AcLineSegmentPhase,
+            "acLineSegment",
+            { it, other -> other.acLineSegment = it },
+            { other -> other.acLineSegment },
+            AcLineSegment::numPhases,
+            AcLineSegment::addPhase,
         )
     }
 

--- a/src/test/kotlin/com/zepben/ewb/cim/iec61970/base/wires/EnergyConsumerTest.kt
+++ b/src/test/kotlin/com/zepben/ewb/cim/iec61970/base/wires/EnergyConsumerTest.kt
@@ -10,7 +10,6 @@ package com.zepben.ewb.cim.iec61970.base.wires
 
 import com.zepben.ewb.services.common.testdata.generateId
 import com.zepben.ewb.utils.PrivateCollectionValidator
-import com.zepben.testutils.exception.ExpectException
 import com.zepben.testutils.junit.SystemLogExtension
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.equalTo
@@ -61,26 +60,6 @@ internal class EnergyConsumerTest {
     }
 
     @Test
-    internal fun assignsEnergyConsumerToEnergyConsumerPhaseIfMissing() {
-        val energyConsumer = EnergyConsumer(generateId())
-        val phase = EnergyConsumerPhase(generateId())
-
-        energyConsumer.addPhase(phase)
-        assertThat(phase.energyConsumer, equalTo(energyConsumer))
-    }
-
-    @Test
-    internal fun rejectsEnergyConsumerPhaseWithWrongEnergyConsumer() {
-        val energyConsumer1 = EnergyConsumer(generateId())
-        val energyConsumer2 = EnergyConsumer(generateId())
-        val phase = EnergyConsumerPhase(generateId()).apply { energyConsumer = energyConsumer2 }
-
-        ExpectException.expect { energyConsumer1.addPhase(phase) }
-            .toThrow<IllegalArgumentException>()
-            .withMessage("${phase.typeNameAndMRID()} `energyConsumer` property references ${energyConsumer2.typeNameAndMRID()}, expected ${energyConsumer1.typeNameAndMRID()}.")
-    }
-
-    @Test
     internal fun energyConsumerPhases() {
         PrivateCollectionValidator.validateUnordered(
             ::EnergyConsumer,
@@ -93,5 +72,19 @@ internal class EnergyConsumerTest {
             EnergyConsumer::clearPhases
         )
     }
+
+    @Test
+    internal fun energyConsumerPhasesBackfill() {
+        PrivateCollectionValidator.validateBackfill(
+            ::EnergyConsumer,
+            ::EnergyConsumerPhase,
+            "energyConsumer",
+            { it, other -> other.energyConsumer = it },
+            { other -> other.energyConsumer },
+            EnergyConsumer::numPhases,
+            EnergyConsumer::addPhase,
+        )
+    }
+
 
 }

--- a/src/test/kotlin/com/zepben/ewb/cim/iec61970/base/wires/EnergyConsumerTest.kt
+++ b/src/test/kotlin/com/zepben/ewb/cim/iec61970/base/wires/EnergyConsumerTest.kt
@@ -78,9 +78,7 @@ internal class EnergyConsumerTest {
         PrivateCollectionValidator.validateBackfill(
             ::EnergyConsumer,
             ::EnergyConsumerPhase,
-            "energyConsumer",
-            { it, other -> other.energyConsumer = it },
-            { other -> other.energyConsumer },
+            EnergyConsumerPhase::energyConsumer,
             EnergyConsumer::numPhases,
             EnergyConsumer::addPhase,
         )

--- a/src/test/kotlin/com/zepben/ewb/cim/iec61970/base/wires/EnergySourceTest.kt
+++ b/src/test/kotlin/com/zepben/ewb/cim/iec61970/base/wires/EnergySourceTest.kt
@@ -132,9 +132,7 @@ internal class EnergySourceTest {
         PrivateCollectionValidator.validateBackfill(
             ::EnergySource,
             ::EnergySourcePhase,
-            "energySource",
-            { it, other -> other.energySource = it },
-            { other -> other.energySource },
+            EnergySourcePhase::energySource,
             EnergySource::numPhases,
             EnergySource::addPhase,
         )

--- a/src/test/kotlin/com/zepben/ewb/cim/iec61970/base/wires/EnergySourceTest.kt
+++ b/src/test/kotlin/com/zepben/ewb/cim/iec61970/base/wires/EnergySourceTest.kt
@@ -10,7 +10,6 @@ package com.zepben.ewb.cim.iec61970.base.wires
 
 import com.zepben.ewb.services.common.testdata.generateId
 import com.zepben.ewb.utils.PrivateCollectionValidator
-import com.zepben.testutils.exception.ExpectException
 import com.zepben.testutils.junit.SystemLogExtension
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.equalTo
@@ -115,26 +114,6 @@ internal class EnergySourceTest {
     }
 
     @Test
-    internal fun assignsEnergySourceToEnergySourcePhaseIfMissing() {
-        val energySource = EnergySource(generateId())
-        val phase = EnergySourcePhase(generateId())
-
-        energySource.addPhase(phase)
-        assertThat(phase.energySource, equalTo(energySource))
-    }
-
-    @Test
-    internal fun rejectsEnergySourcePhaseWithWrongEnergySource() {
-        val energySource1 = EnergySource(generateId())
-        val energySource2 = EnergySource(generateId())
-        val phase = EnergySourcePhase(generateId()).apply { energySource = energySource2 }
-
-        ExpectException.expect { energySource1.addPhase(phase) }
-            .toThrow<IllegalArgumentException>()
-            .withMessage("${phase.typeNameAndMRID()} `energySource` property references ${energySource2.typeNameAndMRID()}, expected ${energySource1.typeNameAndMRID()}.")
-    }
-
-    @Test
     internal fun energySourcePhases() {
         PrivateCollectionValidator.validateUnordered(
             ::EnergySource,
@@ -145,6 +124,19 @@ internal class EnergySourceTest {
             EnergySource::addPhase,
             EnergySource::removePhase,
             EnergySource::clearPhases
+        )
+    }
+
+    @Test
+    internal fun energySourcePhasesBackfill() {
+        PrivateCollectionValidator.validateBackfill(
+            ::EnergySource,
+            ::EnergySourcePhase,
+            "energySource",
+            { it, other -> other.energySource = it },
+            { other -> other.energySource },
+            EnergySource::numPhases,
+            EnergySource::addPhase,
         )
     }
 

--- a/src/test/kotlin/com/zepben/ewb/cim/iec61970/base/wires/PowerElectronicsConnectionTest.kt
+++ b/src/test/kotlin/com/zepben/ewb/cim/iec61970/base/wires/PowerElectronicsConnectionTest.kt
@@ -213,26 +213,6 @@ internal class PowerElectronicsConnectionTest {
     }
 
     @Test
-    internal fun assignsPowerElectronicsConnectionToPowerElectronicsConnectionPhaseIfMissing() {
-        val powerElectronicsConnection = PowerElectronicsConnection(generateId())
-        val phase = PowerElectronicsConnectionPhase(generateId())
-
-        powerElectronicsConnection.addPhase(phase)
-        assertThat(phase.powerElectronicsConnection, equalTo(powerElectronicsConnection))
-    }
-
-    @Test
-    internal fun rejectsPowerElectronicsConnectionPhaseWithWrongPowerElectronicsConnection() {
-        val powerElectronicsConnection1 = PowerElectronicsConnection(generateId())
-        val powerElectronicsConnection2 = PowerElectronicsConnection(generateId())
-        val phase = PowerElectronicsConnectionPhase(generateId()).apply { powerElectronicsConnection = powerElectronicsConnection2 }
-
-        expect { powerElectronicsConnection1.addPhase(phase) }
-            .toThrow<IllegalArgumentException>()
-            .withMessage("${phase.typeNameAndMRID()} `powerElectronicsConnection` property references ${powerElectronicsConnection2.typeNameAndMRID()}, expected ${powerElectronicsConnection1.typeNameAndMRID()}.")
-    }
-
-    @Test
     internal fun powerElectronicsConnectionUnits() {
         PrivateCollectionValidator.validateUnordered(
             ::PowerElectronicsConnection,
@@ -257,6 +237,19 @@ internal class PowerElectronicsConnectionTest {
             PowerElectronicsConnection::addPhase,
             PowerElectronicsConnection::removePhase,
             PowerElectronicsConnection::clearPhases
+        )
+    }
+
+    @Test
+    internal fun powerElectronicsConnectionPhasesBackfill() {
+        PrivateCollectionValidator.validateBackfill(
+            ::PowerElectronicsConnection,
+            ::PowerElectronicsConnectionPhase,
+            "powerElectronicsConnection",
+            { it, other -> other.powerElectronicsConnection = it },
+            { other -> other.powerElectronicsConnection },
+            PowerElectronicsConnection::numPhases,
+            PowerElectronicsConnection::addPhase,
         )
     }
 

--- a/src/test/kotlin/com/zepben/ewb/cim/iec61970/base/wires/PowerElectronicsConnectionTest.kt
+++ b/src/test/kotlin/com/zepben/ewb/cim/iec61970/base/wires/PowerElectronicsConnectionTest.kt
@@ -245,9 +245,7 @@ internal class PowerElectronicsConnectionTest {
         PrivateCollectionValidator.validateBackfill(
             ::PowerElectronicsConnection,
             ::PowerElectronicsConnectionPhase,
-            "powerElectronicsConnection",
-            { it, other -> other.powerElectronicsConnection = it },
-            { other -> other.powerElectronicsConnection },
+            PowerElectronicsConnectionPhase::powerElectronicsConnection,
             PowerElectronicsConnection::numPhases,
             PowerElectronicsConnection::addPhase,
         )

--- a/src/test/kotlin/com/zepben/ewb/cim/iec61970/base/wires/PowerTransformerTest.kt
+++ b/src/test/kotlin/com/zepben/ewb/cim/iec61970/base/wires/PowerTransformerTest.kt
@@ -63,26 +63,6 @@ internal class PowerTransformerTest {
     }
 
     @Test
-    internal fun assignsTransformerToEndIfMissing() {
-        val transformer = PowerTransformer(generateId())
-        val end = PowerTransformerEnd(generateId())
-
-        transformer.addEnd(end)
-        assertThat(end.powerTransformer, equalTo(transformer))
-    }
-
-    @Test
-    internal fun rejectsEndWithWrongTransformer() {
-        val tx1 = PowerTransformer(generateId())
-        val tx2 = PowerTransformer(generateId())
-        val end = PowerTransformerEnd(generateId()).apply { powerTransformer = tx2 }
-
-        expect { tx1.addEnd(end) }
-            .toThrow<IllegalArgumentException>()
-            .withMessage("${end.typeNameAndMRID()} `powerTransformer` property references ${tx2.typeNameAndMRID()}, expected ${tx1.typeNameAndMRID()}.")
-    }
-
-    @Test
     internal fun powerTransformerEnds() {
         PrivateCollectionValidator.validateOrdered(
             ::PowerTransformer,
@@ -95,6 +75,19 @@ internal class PowerTransformerTest {
             PowerTransformer::removeEnd,
             PowerTransformer::clearEnds,
             PowerTransformerEnd::endNumber
+        )
+    }
+
+    @Test
+    internal fun powerTransformerEndsBackfill() {
+        PrivateCollectionValidator.validateBackfill(
+            ::PowerTransformer,
+            ::PowerTransformerEnd,
+            "powerTransformer",
+            { it, other -> other.powerTransformer = it },
+            { other -> other.powerTransformer },
+            PowerTransformer::numEnds,
+            PowerTransformer::addEnd,
         )
     }
 

--- a/src/test/kotlin/com/zepben/ewb/cim/iec61970/base/wires/PowerTransformerTest.kt
+++ b/src/test/kotlin/com/zepben/ewb/cim/iec61970/base/wires/PowerTransformerTest.kt
@@ -83,9 +83,7 @@ internal class PowerTransformerTest {
         PrivateCollectionValidator.validateBackfill(
             ::PowerTransformer,
             ::PowerTransformerEnd,
-            "powerTransformer",
-            { it, other -> other.powerTransformer = it },
-            { other -> other.powerTransformer },
+            PowerTransformerEnd::powerTransformer,
             PowerTransformer::numEnds,
             PowerTransformer::addEnd,
         )

--- a/src/test/kotlin/com/zepben/ewb/utils/PrivateCollectionValidator.kt
+++ b/src/test/kotlin/com/zepben/ewb/utils/PrivateCollectionValidator.kt
@@ -13,6 +13,7 @@ import com.zepben.testutils.exception.ExpectException.Companion.expect
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.*
 import java.util.regex.Pattern
+import kotlin.reflect.KMutableProperty1
 
 
 internal class PrivateCollectionValidator {
@@ -274,18 +275,14 @@ internal class PrivateCollectionValidator {
          * Check that list-related auto-linked relationships function as expected
          * @param createIt lambda creating containing object by mRID
          * @param createOther lambda creating object that's added to the list (also by mRID)
-         * @param fieldName the name of the backref field for the exception string check
-         * @param assignItToOther setting the backref - eg `feeder.substation` - that is set in the list add method
-         * @param getBackrefFromOther retrieve the backref from the contained object (for verification)
+         * @param backfillProp The property on the contained object referencing the containing object
          * @param num retrieve size of collection
          * @param add attempt to add to the collection
          */
         internal fun <T: Identifiable, U : Identifiable> validateBackfill(
             createIt: (String) -> T,
             createOther: (String) -> U,
-            fieldName: String,
-            assignItToOther: (T, U) -> Unit,
-            getBackrefFromOther: (U) -> T?,
+            backfillProp: KMutableProperty1<U, T?>,
             num: (T) -> Int,
             add: (T, U) -> T,
         ) {
@@ -298,24 +295,24 @@ internal class PrivateCollectionValidator {
             // Check that container is assigned to an object with no backref gets
             add(it, other1)
             assertThat(num(it), equalTo(1))
-            assertThat(getBackrefFromOther(other1), equalTo(it))
+            assertThat(backfillProp.get(other1), equalTo(it))
 
             // Check that an object already backref'd to container is accepted cleanly
-            assignItToOther(it, other2)
-            assertThat(getBackrefFromOther(other2), equalTo(it))
+            backfillProp.set(other2, it)
+            assertThat(backfillProp.get(other2), equalTo(it))
             add(it, other2)
             assertThat(num(it), equalTo(2))
-            assertThat(getBackrefFromOther(other2), equalTo(it))
+            assertThat(backfillProp.get(other2), equalTo(it))
 
             // Check that an object already backref'd to another container is rejected correctly
-            assignItToOther(wrongIt, otherWrong)
-            assertThat(getBackrefFromOther(otherWrong), equalTo(wrongIt))
+            backfillProp.set(otherWrong, wrongIt)
+            assertThat(backfillProp.get(otherWrong), equalTo(wrongIt))
             expect { add(it, otherWrong) }
                 .toThrow<IllegalArgumentException>()
                 .withMessage(Pattern.compile(
-                    "${otherWrong.typeNameAndMRID()} `$fieldName` property references ${wrongIt.typeNameAndMRID()}, expected ${it.typeNameAndMRID()}."
+                    "${otherWrong.typeNameAndMRID()} `${backfillProp.name}` property references ${wrongIt.typeNameAndMRID()}, expected ${it.typeNameAndMRID()}."
                 ))
-            assertThat(getBackrefFromOther(otherWrong), equalTo(wrongIt))
+            assertThat(backfillProp.get(otherWrong), equalTo(wrongIt))
             assertThat(num(it), equalTo(2))
         }
 

--- a/src/test/kotlin/com/zepben/ewb/utils/PrivateCollectionValidator.kt
+++ b/src/test/kotlin/com/zepben/ewb/utils/PrivateCollectionValidator.kt
@@ -270,6 +270,55 @@ internal class PrivateCollectionValidator {
             )
         }
 
+        /**
+         * Check that list-related auto-linked relationships function as expected
+         * @param createIt lambda creating containing object by mRID
+         * @param createOther lambda creating object that's added to the list (also by mRID)
+         * @param fieldName the name of the backref field for the exception string check
+         * @param assignItToOther setting the backref - eg `feeder.substation` - that is set in the list add method
+         * @param getBackrefFromOther retrieve the backref from the contained object (for verification)
+         * @param num retrieve size of collection
+         * @param add attempt to add to the collection
+         */
+        internal fun <T: Identifiable, U : Identifiable> validateBackfill(
+            createIt: (String) -> T,
+            createOther: (String) -> U,
+            fieldName: String,
+            assignItToOther: (T, U) -> Unit,
+            getBackrefFromOther: (U) -> T?,
+            num: (T) -> Int,
+            add: (T, U) -> T,
+        ) {
+            val it = createIt("it")
+            val wrongIt = createIt("wrongIt")
+            val other1 = createOther("1")
+            val other2 = createOther("2")
+            val otherWrong = createOther("3")
+
+            // Check that container is assigned to an object with no backref gets
+            add(it, other1)
+            assertThat(num(it), equalTo(1))
+            assertThat(getBackrefFromOther(other1), equalTo(it))
+
+            // Check that an object already backref'd to container is accepted cleanly
+            assignItToOther(it, other2)
+            assertThat(getBackrefFromOther(other2), equalTo(it))
+            add(it, other2)
+            assertThat(num(it), equalTo(2))
+            assertThat(getBackrefFromOther(other2), equalTo(it))
+
+            // Check that an object already backref'd to another container is rejected correctly
+            assignItToOther(wrongIt, otherWrong)
+            assertThat(getBackrefFromOther(otherWrong), equalTo(wrongIt))
+            expect { add(it, otherWrong) }
+                .toThrow<IllegalArgumentException>()
+                .withMessage(Pattern.compile(
+                    "${otherWrong.typeNameAndMRID()} `$fieldName` property references ${wrongIt.typeNameAndMRID()}, expected ${it.typeNameAndMRID()}."
+                ))
+            assertThat(getBackrefFromOther(otherWrong), equalTo(wrongIt))
+            assertThat(num(it), equalTo(2))
+        }
+
         private fun <T, U> validate(
             it: T,
             others: List<U>,


### PR DESCRIPTION
# Description

This PR adds the function `validateBackfill` that verifies that a collection that is supposed to backfill a field (for example, adding a feeder to a substation sets `feeder.substation = it`) does it correctly - sets the ref to self, and throws the correct exception if the ref is set to something else.

All duplicate tests that used to duplicate check code now reuse this function.

`AcLineSegment.cuts` and `AcLineSegment.clamps` were missing this test, now they are checked as well.

# Associated tasks

None

# Test Steps

Run the test suite; For extra verification, find a backfill adder (containing the line `require(\w+\.\w+ === this)`), remove the line setting the ref, and run the tests to make sure they catch it.

# Checklist

If any of these are not applicable, strikethrough the line `~like this~`. **Do not delete it!**. Let the reviewer decide if you should have done it.

### Code
- [x] I have performed a self review of my own code (including checking issues raised when creating the PR).
- [x] I have added/updated unit tests for these changes, and if not I have explained why they are not necessary.
- [x] I have commented my code in any hard-to-understand or hacky areas.
- [x] I have handled all new warnings generated by the compiler or IDE.
- [x] I have rebased onto the target branch (usually main).

### Security
When developing applications, use following guidelines for information security considerations:
* Access to applications should be protected with security keys/tokens or usernames and passwords;
* All sessions are encrypted if possible;
* All application input is sanitised before being acted on (ie SQL statements, etc);
* Log messages, and especially client-facing ones, must be handled securely and must not leak credentials information (internal URLs, passwords, tokens).

- [x] I have considered if this change impacts information security and made sure those impacts are handled.

### Documentation
- [x] I have updated the changelog.
- [x] I have updated any documentation required for these changes.

# Breaking Changes
- [x] I have considered if this is a breaking change and will communicate it with other team members by posting it on the Slack **breaking-changes** channel.

Please leave a summary of the breaking changes here and then post it on the Slack **breaking-changes** channel to notify the team about it.

