### PR TITLE
Skip python only gRPC changes.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -75,7 +75,7 @@
         <dependency>
             <groupId>com.zepben</groupId>
             <artifactId>protobuf</artifactId>
-            <version>1.7.0</version>
+            <version>1.8.0b3</version>
         </dependency>
         <dependency>
             <groupId>com.zepben</groupId>


### PR DESCRIPTION
# Description

Skip the versions of the gRPC library that have only been released for Python version updates.
